### PR TITLE
fix: user feedback on selection in the feedback dialog and mapping responses in posthog correctly

### DIFF
--- a/apps/nextjs/src/components/Feedback/index.tsx
+++ b/apps/nextjs/src/components/Feedback/index.tsx
@@ -61,6 +61,8 @@ const FeedBack = ({
                 </label>
                 <div className="flex w-full justify-between gap-6">
                   {rating.map((feedback) => {
+                    // first survey key should be $survey_response
+                    // see https://posthog.com/docs/surveys/implementing-custom-surveys under Capturing multiple responses
                     const surveyResponseKey =
                       i === 0 ? `$survey_response` : `$survey_response_${i}`;
 

--- a/apps/nextjs/src/components/Feedback/index.tsx
+++ b/apps/nextjs/src/components/Feedback/index.tsx
@@ -61,6 +61,9 @@ const FeedBack = ({
                 </label>
                 <div className="flex w-full justify-between gap-6">
                   {rating.map((feedback) => {
+                    const surveyResponseKey =
+                      i === 0 ? `$survey_response` : `$survey_response_${i}`;
+
                     return (
                       <button
                         key={feedback.text}
@@ -68,14 +71,13 @@ const FeedBack = ({
                         onClick={() => {
                           setUsersResponse((prevState) => ({
                             ...prevState,
-                            [`$survey_response_${i}`]:
-                              feedback.number.toString(),
+                            [surveyResponseKey]: feedback.number.toString(),
                           }));
                         }}
                       >
                         <span
                           className={`text-lg ${
-                            usersResponse[`$survey_response_${i}`] ===
+                            usersResponse[surveyResponseKey] ===
                             feedback.number.toString()
                               ? `text-[#287C34]`
                               : `text-black`
@@ -85,7 +87,7 @@ const FeedBack = ({
                         </span>
                         <span
                           className={
-                            usersResponse[`$survey_response_${i}`] ===
+                            usersResponse[surveyResponseKey] ===
                             feedback.number.toString()
                               ? "opacity-100"
                               : "opacity-0"

--- a/apps/nextjs/src/components/Feedback/index.tsx
+++ b/apps/nextjs/src/components/Feedback/index.tsx
@@ -68,14 +68,14 @@ const FeedBack = ({
                         onClick={() => {
                           setUsersResponse((prevState) => ({
                             ...prevState,
-                            [`$survey_response_${i}`]:
+                            [`$survey_response_${i + 1}`]:
                               feedback.number.toString(),
                           }));
                         }}
                       >
                         <span
                           className={`text-lg ${
-                            usersResponse[`$survey_response_${i}`] ===
+                            usersResponse[`$survey_response_${i + 1}`] ===
                             feedback.number.toString()
                               ? `text-[#287C34]`
                               : `text-black`
@@ -85,7 +85,7 @@ const FeedBack = ({
                         </span>
                         <span
                           className={
-                            usersResponse[`$survey_response_${i}`] ===
+                            usersResponse[`$survey_response_${i + 1}`] ===
                             feedback.number.toString()
                               ? "opacity-100"
                               : "opacity-0"
@@ -97,6 +97,31 @@ const FeedBack = ({
                     );
                   })}
                 </div>
+              </div>
+            );
+          }
+          if (question.type === "open") {
+            return (
+              <div
+                key={question.question}
+                className="flex flex-col items-start justify-start"
+              >
+                <label
+                  htmlFor={question.question}
+                  className="mb-16 text-center text-xl "
+                >
+                  {question.question}
+                </label>
+                <textarea
+                  className="h-32 w-full min-w-[300px] rounded border-2 border-black p-10"
+                  onChange={(e) => {
+                    setUsersResponse({
+                      ...usersResponse,
+                      $survey_response_3: e.target.value,
+                    });
+                  }}
+                  id={question.question}
+                />
               </div>
             );
           }

--- a/apps/nextjs/src/components/Feedback/index.tsx
+++ b/apps/nextjs/src/components/Feedback/index.tsx
@@ -30,7 +30,7 @@ const FeedBack = ({
   );
   console.log("usersResponse", usersResponse);
   if (!survey?.id) return null;
-
+  console.log("rebuild");
   return (
     <Flex
       className="h-full w-full"

--- a/apps/nextjs/src/components/Feedback/index.tsx
+++ b/apps/nextjs/src/components/Feedback/index.tsx
@@ -108,7 +108,7 @@ const FeedBack = ({
               >
                 <label
                   htmlFor={question.question}
-                  className="mb-16 text-center text-xl "
+                  className="mb-16 text-left text-2xl font-bold"
                 >
                   {question.question}
                 </label>

--- a/apps/nextjs/src/components/Feedback/index.tsx
+++ b/apps/nextjs/src/components/Feedback/index.tsx
@@ -47,6 +47,10 @@ const FeedBack = ({
         className="flex w-full flex-col gap-14"
       >
         {survey?.questions.map((question, i) => {
+          // first survey key should be $survey_response
+          // see https://posthog.com/docs/surveys/implementing-custom-surveys under Capturing multiple responses
+          const surveyResponseKey =
+            i === 0 ? `$survey_response` : `$survey_response_${i}`;
           if (question.type === "rating") {
             return (
               <div
@@ -61,11 +65,6 @@ const FeedBack = ({
                 </label>
                 <div className="flex w-full justify-between gap-6">
                   {rating.map((feedback) => {
-                    // first survey key should be $survey_response
-                    // see https://posthog.com/docs/surveys/implementing-custom-surveys under Capturing multiple responses
-                    const surveyResponseKey =
-                      i === 0 ? `$survey_response` : `$survey_response_${i}`;
-
                     return (
                       <button
                         key={feedback.text}
@@ -121,7 +120,7 @@ const FeedBack = ({
                   onChange={(e) => {
                     setUsersResponse({
                       ...usersResponse,
-                      $survey_response_2: e.target.value,
+                      [surveyResponseKey]: e.target.value,
                     });
                   }}
                   id={question.question}

--- a/apps/nextjs/src/components/Feedback/index.tsx
+++ b/apps/nextjs/src/components/Feedback/index.tsx
@@ -68,14 +68,14 @@ const FeedBack = ({
                         onClick={() => {
                           setUsersResponse((prevState) => ({
                             ...prevState,
-                            [`$survey_response_${i + 1}`]:
+                            [`$survey_response_${i}`]:
                               feedback.number.toString(),
                           }));
                         }}
                       >
                         <span
                           className={`text-lg ${
-                            usersResponse[`$survey_response_${i + 1}`] ===
+                            usersResponse[`$survey_response_${i}`] ===
                             feedback.number.toString()
                               ? `text-[#287C34]`
                               : `text-black`
@@ -85,7 +85,7 @@ const FeedBack = ({
                         </span>
                         <span
                           className={
-                            usersResponse[`$survey_response_${i + 1}`] ===
+                            usersResponse[`$survey_response_${i}`] ===
                             feedback.number.toString()
                               ? "opacity-100"
                               : "opacity-0"
@@ -117,7 +117,7 @@ const FeedBack = ({
                   onChange={(e) => {
                     setUsersResponse({
                       ...usersResponse,
-                      $survey_response_3: e.target.value,
+                      $survey_response_2: e.target.value,
                     });
                   }}
                   id={question.question}

--- a/apps/nextjs/src/components/Feedback/index.tsx
+++ b/apps/nextjs/src/components/Feedback/index.tsx
@@ -28,7 +28,7 @@ const FeedBack = ({
   const [usersResponse, setUsersResponse] = useState<{ [key: string]: string }>(
     {},
   );
-  console.log("usersResponse", usersResponse);
+
   if (!survey?.id) return null;
 
   return (
@@ -76,7 +76,7 @@ const FeedBack = ({
                         <span
                           className={`text-lg ${
                             usersResponse[`$survey_response_${i}`] ===
-                            feedback.text.toString()
+                            feedback.number.toString()
                               ? `text-[#287C34]`
                               : `text-black`
                           }`}
@@ -86,7 +86,7 @@ const FeedBack = ({
                         <span
                           className={
                             usersResponse[`$survey_response_${i}`] ===
-                            feedback.text.toString()
+                            feedback.number.toString()
                               ? "opacity-100"
                               : "opacity-0"
                           }

--- a/apps/nextjs/src/components/Feedback/index.tsx
+++ b/apps/nextjs/src/components/Feedback/index.tsx
@@ -76,7 +76,7 @@ const FeedBack = ({
                         <span
                           className={`text-lg ${
                             usersResponse[`$survey_response_${i}`] ===
-                            feedback.toString()
+                            feedback.text.toString()
                               ? `text-[#287C34]`
                               : `text-black`
                           }`}
@@ -86,7 +86,7 @@ const FeedBack = ({
                         <span
                           className={
                             usersResponse[`$survey_response_${i}`] ===
-                            feedback.toString()
+                            feedback.text.toString()
                               ? "opacity-100"
                               : "opacity-0"
                           }

--- a/apps/nextjs/src/components/Feedback/index.tsx
+++ b/apps/nextjs/src/components/Feedback/index.tsx
@@ -30,7 +30,7 @@ const FeedBack = ({
   );
   console.log("usersResponse", usersResponse);
   if (!survey?.id) return null;
-  console.log("rebuild");
+
   return (
     <Flex
       className="h-full w-full"


### PR DESCRIPTION
## Issue(s)

- User could not see what they had selected in the feedback dialog at the end of a chat.
- Responses weren't mapping to correct columns in PostHog.

## How to test

1. Go to a chat with a fresh browser and clear cookies
2. Ensure you have accepted cookies
3. Go to the download page and wait for the dialog to pop up 
4. Select an item
5. It should be obvious what is selected
6. On submitting the form, data should appear correctly in PostHog.

