### PR TITLE
fix: only run PR workflows in PRs

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -62,7 +62,7 @@ jobs:
           retention-days: 30
       - name: Comment PR with playwright report
         uses: thollander/actions-comment-pull-request@v2
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && github.ref != 'refs/heads/production' && github.ref != 'refs/heads/main' }}
         with:
           pr_number: ${{ steps.ref_from_sha.outputs.pr_number }}
           message: |

--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -62,7 +62,7 @@ jobs:
           retention-days: 30
       - name: Comment PR with playwright report
         uses: thollander/actions-comment-pull-request@v2
-        if: ${{ !cancelled() && github.ref != 'refs/heads/production' && github.ref != 'refs/heads/main' }}
+        if: ${{ !cancelled() && github.event_name == 'pull_request' }}
         with:
           pr_number: ${{ steps.ref_from_sha.outputs.pr_number }}
           message: |

--- a/.github/workflows/post_deployment.yml
+++ b/.github/workflows/post_deployment.yml
@@ -1,6 +1,8 @@
 name: Deployment Actions
 
-on: deployment_status
+on:
+  pull_request:
+    branches: ["*"]
 
 jobs:
   dump_github_event:
@@ -10,7 +12,6 @@ jobs:
   update_pr_description:
     # Only want to run on success, otherwise it might be "pending", or "failure".
     # Filter out storybook deployments and temporarily Netlify deployments
-    if: ${{ github.ref != 'refs/heads/production' && github.ref != 'refs/heads/main' && (github.event.deployment_status.state == 'success') && !startsWith(github.event.deployment_status.environment, 'storybook')}}
     name: Add deploy URL to PR description
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/post_deployment.yml
+++ b/.github/workflows/post_deployment.yml
@@ -10,7 +10,7 @@ jobs:
   update_pr_description:
     # Only want to run on success, otherwise it might be "pending", or "failure".
     # Filter out storybook deployments and temporarily Netlify deployments
-    if: ${{ (github.event.deployment.ref != 'main') && (github.event.deployment_status.state == 'success') && !startsWith(github.event.deployment_status.environment, 'storybook')}}
+    if: ${{ github.ref != 'refs/heads/production' && github.ref != 'refs/heads/main' && (github.event.deployment_status.state == 'success') && !startsWith(github.event.deployment_status.environment, 'storybook')}}
     name: Add deploy URL to PR description
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
## Description

- Only runs the playwright job to update the pull request if the workflow is run from a pull request.
- Only runs the workflow to set the deployment URL in PRs.

## How to test

1. In this PR, the workflows should run and update the PR description and leave a comment (playwright).
2. When merged, they shouldn't run on main, production or any branches.
