### PR TITLE
fix: prompt version hash

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo lint",
     "prompts": "turbo prompts --filter=core",
+    "prompts:dev": "turbo prompts:dev --filter=core",
     "sort-package-json": "sort-package-json \"package.json\" \"packages/*/package.json\" \"apps/*/package.json\"",
     "type-check": "turbo type-check",
     "node-version": "node -v",

--- a/packages/aila/src/features/generation/AilaGeneration.ts
+++ b/packages/aila/src/features/generation/AilaGeneration.ts
@@ -189,20 +189,25 @@ export class AilaGeneration {
         }
       }
     } else {
-      prompt = await prisma.prompt.findFirst({
+      const promptQuery = {
         where: {
           variant: variantSlug,
           appId: appSlug,
           slug: promptSlug,
           current: true,
         },
-      });
+      };
+      prompt = await prisma.prompt.findFirst(promptQuery);
     }
     if (!prompt) {
-      // If the prompt does not exist for this variant, we need to generate it
-      const prompts = new PromptVariants(prisma, ailaGenerate, promptSlug);
-      const created = await prompts.setCurrent(variantSlug, true);
-      promptId = created?.id;
+      throw new Error(
+        "Prompt not found - please run pnpm prompts:dev in development or pnpm prompts in production/staging",
+      );
+
+      // // If the prompt does not exist for this variant, we need to generate it
+      // const prompts = new PromptVariants(prisma, ailaGenerate, promptSlug);
+      // const created = await prompts.setCurrent(variantSlug, true);
+      // promptId = created?.id;
     }
 
     promptId = promptId ?? prompt?.id;

--- a/packages/aila/src/features/generation/AilaGeneration.ts
+++ b/packages/aila/src/features/generation/AilaGeneration.ts
@@ -200,14 +200,14 @@ export class AilaGeneration {
       prompt = await prisma.prompt.findFirst(promptQuery);
     }
     if (!prompt) {
-      throw new Error(
-        "Prompt not found - please run pnpm prompts:dev in development or pnpm prompts in production/staging",
-      );
-
-      // // If the prompt does not exist for this variant, we need to generate it
-      // const prompts = new PromptVariants(prisma, ailaGenerate, promptSlug);
-      // const created = await prompts.setCurrent(variantSlug, true);
-      // promptId = created?.id;
+      // // If the prompt does not exist for this variant, we can try to generate it
+      try {
+        const prompts = new PromptVariants(prisma, ailaGenerate, promptSlug);
+        const created = await prompts.setCurrent(variantSlug, true);
+        promptId = created?.id;
+      } catch (e) {
+        console.error("Error creating prompt", e);
+      }
     }
 
     promptId = promptId ?? prompt?.id;

--- a/packages/core/src/models/promptVariants.ts
+++ b/packages/core/src/models/promptVariants.ts
@@ -83,6 +83,9 @@ export class PromptVariants {
         slug: {
           equals: slug,
         },
+        variant: {
+          equals: variant,
+        },
         id: {
           not: {
             equals: created.id,

--- a/packages/core/src/prompts/lesson-assistant/parts/body.ts
+++ b/packages/core/src/prompts/lesson-assistant/parts/body.ts
@@ -11,7 +11,6 @@ A well-thought-out lesson plan should:
 * Include some engaging activities to help reinforce the learning points.
 
 Ensure that the keywords relevant to the topic are repeated throughout the different sections of the lesson plan.
-
 Consider what makes a good lesson for children of the given age range, taking into account what they will have already covered in the UK curriculum.
 Put thought into how the different sections of the lessons link together to keep pupils informed and engaged.
 


### PR DESCRIPTION
## Description

- Fixes an issue where there could be only one current prompt for each slug, irrespective of the variant
- Ensures there is one current prompt for each variant
- Ideally, developers should use pnpm prompts:dev to set up their prompts initially, but it tries to create the prompt variant if it is not found
