### PR TITLE
chore: skip Github workflows that depend on PR ID when PR doesn't exist

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -62,7 +62,7 @@ jobs:
           retention-days: 30
       - name: Comment PR with playwright report
         uses: thollander/actions-comment-pull-request@v2
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && steps.ref_from_sha.outputs.pr_number }}
         with:
           pr_number: ${{ steps.ref_from_sha.outputs.pr_number }}
           message: |

--- a/.github/workflows/post_deployment.yml
+++ b/.github/workflows/post_deployment.yml
@@ -37,6 +37,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: mcky/find-and-replace-pull-request-body@v1.1.6-mcky
+        if: ${{ steps.ref_from_sha.outputs.pr_number }}
         with:
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           prNumber: ${{ steps.ref_from_sha.outputs.pr_number }}


### PR DESCRIPTION
## Description

Two of our Github workflows are triggered by successful deployments, and then search for a PR with that SHA. They both fail if a branch is pushed before the PR is created

- Skip GH actions that rely on the PR number if it's missing
