### PR TITLE
fix: include patch schema in llm response schema

### DIFF
--- a/packages/aila/src/protocol/jsonPatchProtocol.ts
+++ b/packages/aila/src/protocol/jsonPatchProtocol.ts
@@ -269,6 +269,7 @@ export const JsonPatchDocumentJsonSchema = zodToJsonSchema(
 );
 
 const LLMResponseSchema = z.discriminatedUnion("type", [
+  PatchDocumentSchema,
   PromptDocumentSchema,
   StateDocumentSchema,
   CommentDocumentSchema,


### PR DESCRIPTION
## Description

- Adds 'patch json schema' to 'llm response json schema'
- This should make it likely to follow the format a little close, as it's a more formal explanation of the patch protocol than is written later in the prompt
