### PR TITLE
fix: re-enable onboarding redirect after clerk claim update

### DIFF
--- a/apps/nextjs/src/middlewares/auth.middleware.ts
+++ b/apps/nextjs/src/middlewares/auth.middleware.ts
@@ -106,9 +106,8 @@ function conditionallyProtectRoute(
 
   if (userId && needsToCompleteOnboarding(sessionClaims)) {
     if (shouldInterceptRouteForOnboarding(req)) {
-      // TODO: Fix redirect loop
-      // log("Incomplete onboarding: REDIRECT");
-      // return NextResponse.redirect(new URL("/onboarding", req.url));
+      log("Incomplete onboarding: REDIRECT");
+      return NextResponse.redirect(new URL("/onboarding", req.url));
     }
   }
 


### PR DESCRIPTION
## Description

We had an error where the users got into an onboarding redirect loop in the production environment only. This was because the production session claims in clerk weren't up to date with the template in staging

We previously made a hotfix to disable this behaviour. We can now enable it again

## How to test

1. Deploy this PR to production (don't alias until known to be working)
2. Log in with an account missing `isDemoUser` metadata
3. You shouldn't be in a redirect loop
