### PR TITLE
feat: override styles for gleap button

### DIFF
--- a/apps/nextjs/src/components/ContextProviders/GleapProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/GleapProvider.tsx
@@ -54,5 +54,20 @@ export const GleapProvider = ({ children }: PropsWithChildren) => {
     user.user?.primaryEmailAddress?.emailAddress,
   ]);
 
-  return <>{children}</>;
+  return (
+    <>
+      <style
+        dangerouslySetInnerHTML={{
+          __html: `
+.bb-feedback-button .bb-feedback-button-classic {
+  font-family: Lexend, ui-sans-serif, system-ui, sans-serif;
+  font-weight: 600;
+  color: #222222;
+}
+      `,
+        }}
+      />
+      {children}
+    </>
+  );
 };


### PR DESCRIPTION
## Description

- Gleap only let us change the background colour in their UI. This PR overrides the Gleap styling subtly to make the black *our* black, and the sans serif *our* sans serif

I know it's not a great practice to do this, but if they do change class names the consequences will be very minimal: A different black and different font

## Screenshots

How it used to look
![CleanShot 2024-09-04 at 13 44 09@2x](https://github.com/user-attachments/assets/cbd33988-6f3e-4a25-a39c-d5e66e30451f)

How it should now look:
![CleanShot 2024-09-04 at 13 43 26@2x](https://github.com/user-attachments/assets/75472c59-fb11-4bc6-aae5-d8a5a17fee88)
