### PR TITLE
feat: bring nav in line with mobile design

### DIFF
--- a/apps/nextjs/src/app/home-page.tsx
+++ b/apps/nextjs/src/app/home-page.tsx
@@ -18,7 +18,7 @@ import styled from "styled-components";
 
 import jigsaw from "@/assets/svg/illustration/jigsaw.svg";
 import oakSupporting from "@/assets/svg/illustration/oak_supporting.svg";
-import BetaTag from "@/components/AppComponents/Chat/beta-tag";
+import { BetaTagPage } from "@/components/AppComponents/Chat/beta-tag";
 import HeroContainer from "@/components/HeroContainer";
 import { HomePageCTA } from "@/components/Home/HomePageCTA";
 import Layout from "@/components/Layout";
@@ -52,7 +52,7 @@ export default function HomePage({ featureFlag }) {
             $gap={"all-spacing-5"}
           >
             <OakBox $width="fit-content">
-              <BetaTag />
+              <BetaTagPage />
             </OakBox>
             <OakHeading tag="h1" $font={"heading-2"}>
               Introducing Aila{" "}

--- a/apps/nextjs/src/components/AppComponents/Chat/beta-tag.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/beta-tag.tsx
@@ -1,6 +1,14 @@
-export default function BetaTag() {
+export function BetaTagPage() {
   return (
     <span className="flex h-[32px] items-center justify-center rounded-full bg-teachersPastelBlue px-9 py-1 text-sm font-semibold">
+      Beta
+    </span>
+  );
+}
+
+export function BetaTagHeader() {
+  return (
+    <span className="flex items-center justify-center rounded-full bg-teachersPastelBlue px-8 py-2 text-sm font-semibold text-black">
       Beta
     </span>
   );

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-history.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-history.tsx
@@ -22,7 +22,7 @@ export function ChatHistory() {
           </span>
           <span>New lesson</span>
         </ChatButton>
-        <ChatButton href="/aila" variant="text-link">
+        <ChatButton href="/" variant="text-link">
           <OakIcon
             iconName="home"
             $width="all-spacing-6"
@@ -30,7 +30,7 @@ export function ChatHistory() {
           />
           AI Experiments
         </ChatButton>
-        <ChatButton href="/aila" variant="text-link">
+        <ChatButton href="/aila/help" variant="text-link">
           <OakIcon
             iconName="question-mark"
             $width="all-spacing-6"

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-history.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-history.tsx
@@ -10,24 +10,32 @@ import ChatButton from "./ui/chat-button";
 
 export function ChatHistory() {
   return (
-    <div className="mt-20 flex h-full flex-col">
+    <div className="mt-16 flex h-full flex-col">
       <div className="my-10 flex flex-col px-7">
         <ChatButton href="/aila" variant="text-link">
-          <span className="rotate-45 scale-90">
-            <OakIcon iconName="cross" />
+          <span className="rotate-45">
+            <OakIcon
+              iconName="cross"
+              $width="all-spacing-6"
+              $height="all-spacing-6"
+            />
           </span>
-          <span>New Lesson</span>
+          <span>New lesson</span>
         </ChatButton>
         <ChatButton href="/aila" variant="text-link">
-          <span className="scale-90">
-            <OakIcon iconName="home" />
-          </span>
-          Ai experiments page
+          <OakIcon
+            iconName="home"
+            $width="all-spacing-6"
+            $height="all-spacing-6"
+          />
+          AI Experiments
         </ChatButton>
         <ChatButton href="/aila" variant="text-link">
-          <span className="scale-90">
-            <OakIcon iconName="question-mark" />
-          </span>
+          <OakIcon
+            iconName="question-mark"
+            $width="all-spacing-6"
+            $height="all-spacing-6"
+          />
           Help
         </ChatButton>
       </div>

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-start.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-start.tsx
@@ -14,7 +14,7 @@ import useAnalytics from "@/lib/analytics/useAnalytics";
 import { trpc } from "@/utils/trpc";
 
 import { useDialog } from "../DialogContext";
-import BetaTag from "./beta-tag";
+import { BetaTagPage } from "./beta-tag";
 import ChatPanelDisclaimer from "./chat-panel-disclaimer";
 import { ChatStartForm } from "./chat-start-form";
 import EmptyScreenAccordion from "./empty-screen-accordian";
@@ -103,7 +103,7 @@ export function ChatStart() {
               <div className="flex h-full flex-col justify-center gap-18">
                 <div>
                   <div className="mb-13   block w-fit sm:hidden">
-                    <BetaTag />
+                    <BetaTagPage />
                   </div>
                   <h1
                     data-testid="chat-h1"

--- a/apps/nextjs/src/components/AppComponents/Chat/header.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/header.tsx
@@ -9,7 +9,7 @@ import { useDemoUser } from "@/components/ContextProviders/Demo";
 import { Icon } from "@/components/Icon";
 import OakIconLogo from "@/components/OakIconLogo";
 
-import BetaTag from "./beta-tag";
+import { BetaTagHeader } from "./beta-tag";
 import { ChatHistory } from "./chat-history";
 import { SidebarMobile } from "./sidebar-mobile";
 import { UserOrLogin } from "./user-or-login";
@@ -18,7 +18,7 @@ export function Header() {
   const demo = useDemoUser();
 
   return (
-    <header className="fixed inset-x-0 top-0 z-50 ">
+    <header className="fixed inset-x-0 top-0 z-50">
       {demo.isDemoUser && (
         <div className="flex h-28 items-center border-b-2 border-black bg-lemon px-15 py-6 sm:h-26 md:h-22">
           <div>
@@ -44,38 +44,32 @@ export function Header() {
         </div>
       )}
 
-      <div className="flex h-26  shrink-0 items-center justify-between border-b-2 border-black  bg-white  px-10  ">
-        <div className="flex items-center gap-10">
-          <div className="hidden sm:flex">
-            <SidebarMobile>
-              <ChatHistory />
-            </SidebarMobile>
-          </div>
-          <div className="flex items-center gap-10">
-            <span className="hidden font-bold sm:block">
-              AI lesson assistant
-            </span>
-            <span className="flex items-center justify-center gap-9  sm:hidden">
-              <Link href="/" aria-label="go to home page">
-                <OakIconLogo />
-              </Link>
-              <span className="text-xl font-bold">Aila</span>
-            </span>
-            <div className="hidden sm:flex">
-              <BetaTag />
-            </div>
+      <div className="flex h-26 shrink-0 items-center justify-between border-b-2 border-black bg-white px-10">
+        <div className="flex items-center gap-9">
+          <span className="flex items-center justify-center gap-9">
+            <Link href="/" aria-label="go to home page">
+              <OakIconLogo />
+            </Link>
+            <span className="text-xl font-bold text-black">Aila</span>
+          </span>
+          <div className="flex">
+            <BetaTagHeader />
           </div>
         </div>
+
         <div className="flex items-center justify-end space-x-12">
-          <div className="flex sm:hidden">
-            <Link href="/aila/help">
-              <OakIcon iconName="question-mark" />
-            </Link>
-          </div>
+          <Link
+            className="hidden items-center sm:flex"
+            href={"/aila/help"}
+            target="_blank"
+          >
+            <OakIcon iconName="question-mark" $width="all-spacing-6" />
+            <div className="ml-6 text-sm font-semibold text-black">Help</div>
+          </Link>
           <div className="= flex items-center">
             <UserOrLogin />
           </div>
-          <div className="flex sm:hidden">
+          <div className="flex">
             <SidebarMobile>
               <ChatHistory />
             </SidebarMobile>

--- a/apps/nextjs/src/components/AppComponents/Chat/sidebar-mobile.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/sidebar-mobile.tsx
@@ -21,16 +21,22 @@ export function SidebarMobile({ children }: Readonly<SidebarMobileProps>) {
       <SheetTrigger asChild>
         <Button
           variant="ghost"
-          className="-ml-7 flex h-19 w-19 p-0 "
+          className="flex items-center px-5"
           onClick={() => {
             trackEvent("chat:toggle_sidebar");
           }}
         >
           <Icon icon="sidebar" size="md" />
-          <span className="sr-only">Toggle Sidebar</span>
+          <div className="ml-4 hidden pr-5 font-semibold text-black sm:block">
+            Menu
+          </div>
+          <span className="sr-only block sm:hidden">Toggle Sidebar</span>
         </Button>
       </SheetTrigger>
-      <SheetContent className="inset-y-0 flex h-auto w-full flex-col p-0 sm:w-[300px]">
+      <SheetContent
+        side="right"
+        className="inset-y-0 flex h-auto w-full flex-col p-0 sm:w-[300px]"
+      >
         <Sidebar className="flex">{children}</Sidebar>
       </SheetContent>
     </Sheet>

--- a/apps/nextjs/src/components/AppComponents/Chat/ui/icons.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/ui/icons.tsx
@@ -4,90 +4,6 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-function IconNextChat({
-  className,
-  inverted,
-  ...props
-}: React.ComponentProps<"svg"> & { inverted?: boolean }) {
-  const id = React.useId();
-
-  return (
-    <svg
-      viewBox="0 0 17 17"
-      fill="none"
-      xmlns="http://www.w3.org/2000/svg"
-      className={cn("h-10 w-10", className)}
-      {...props}
-    >
-      <defs>
-        <linearGradient
-          id={`gradient-${id}-1`}
-          x1="10.6889"
-          y1="10.3556"
-          x2="13.8445"
-          y2="14.2667"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopColor={inverted ? "white" : "black"} />
-          <stop
-            offset={1}
-            stopColor={inverted ? "white" : "black"}
-            stopOpacity={0}
-          />
-        </linearGradient>
-        <linearGradient
-          id={`gradient-${id}-2`}
-          x1="11.7555"
-          y1="4.8"
-          x2="11.7376"
-          y2="9.50002"
-          gradientUnits="userSpaceOnUse"
-        >
-          <stop stopColor={inverted ? "white" : "black"} />
-          <stop
-            offset={1}
-            stopColor={inverted ? "white" : "black"}
-            stopOpacity={0}
-          />
-        </linearGradient>
-      </defs>
-      <path
-        d="M1 16L2.58314 11.2506C1.83084 9.74642 1.63835 8.02363 2.04013 6.39052C2.4419 4.75741 3.41171 3.32057 4.776 2.33712C6.1403 1.35367 7.81003 0.887808 9.4864 1.02289C11.1628 1.15798 12.7364 1.8852 13.9256 3.07442C15.1148 4.26363 15.842 5.83723 15.9771 7.5136C16.1122 9.18997 15.6463 10.8597 14.6629 12.224C13.6794 13.5883 12.2426 14.5581 10.6095 14.9599C8.97637 15.3616 7.25358 15.1692 5.74942 14.4169L1 16Z"
-        fill={inverted ? "black" : "white"}
-        stroke={inverted ? "black" : "white"}
-        strokeWidth={2}
-        strokeLinecap="round"
-        strokeLinejoin="round"
-      />
-      <mask
-        id="mask0_91_2047"
-        style={{ maskType: "alpha" }}
-        maskUnits="userSpaceOnUse"
-        x={1}
-        y={0}
-        width={16}
-        height={16}
-      >
-        <circle cx={9} cy={8} r={8} fill={inverted ? "black" : "white"} />
-      </mask>
-      <g mask="url(#mask0_91_2047)">
-        <circle cx={9} cy={8} r={8} fill={inverted ? "black" : "white"} />
-        <path
-          d="M14.2896 14.0018L7.146 4.8H5.80005V11.1973H6.87681V6.16743L13.4444 14.6529C13.7407 14.4545 14.0231 14.2369 14.2896 14.0018Z"
-          fill={`url(#gradient-${id}-1)`}
-        />
-        <rect
-          x="11.2222"
-          y="4.8"
-          width="1.06667"
-          height="6.4"
-          fill={`url(#gradient-${id}-2)`}
-        />
-      </g>
-    </svg>
-  );
-}
-
 function IconOpenAI({ className, ...props }: React.ComponentProps<"svg">) {
   return (
     <svg
@@ -478,7 +394,6 @@ function IconChevronUpDown({
 
 export {
   IconEdit,
-  IconNextChat,
   IconOpenAI,
   IconVercel,
   IconGitHub,

--- a/apps/nextjs/src/components/AppComponents/Chat/ui/sheet.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/ui/sheet.tsx
@@ -49,8 +49,10 @@ const SheetContent = React.forwardRef<
     >
       {children}
       <SheetPrimitive.Close className="absolute left-16 top-16 rounded-sm  ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-secondary">
-        <div className="rounded-full bg-black p-6">
-          <Icon icon="cross-white" size="sm" />
+        <div className="-m-6 p-6">
+          <div className="rounded-full bg-black p-5">
+            <Icon icon="cross-white" size="sm" />
+          </div>
         </div>
         <span className="sr-only">Close</span>
       </SheetPrimitive.Close>

--- a/apps/nextjs/src/components/AppComponents/Chat/user-or-login.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/user-or-login.tsx
@@ -4,7 +4,6 @@ import { SignedIn, SignedOut, UserButton } from "@clerk/nextjs";
 import Link from "next/link";
 
 import { Button } from "@/components/AppComponents/Chat/ui/button";
-import { IconNextChat } from "@/components/AppComponents/Chat/ui/icons";
 
 export function UserOrLogin() {
   if (typeof window === "undefined") {
@@ -12,24 +11,7 @@ export function UserOrLogin() {
   }
   return (
     <>
-      <SignedIn>
-        <div className="hidden  items-center justify-end space-x-15 sm:flex">
-          <Link className="text-base" href={"/aila/help"} target="_blank">
-            Help
-          </Link>
-
-          <Link className="text-base" href={"/"}>
-            AI experiments
-          </Link>
-        </div>
-      </SignedIn>
-      <SignedOut>
-        <Link href="/" target="_blank" rel="nofollow">
-          <IconNextChat className="mr-7 h-14 w-14 dark:hidden" inverted />
-          <IconNextChat className="mr-7 hidden h-14 w-14 dark:block" />
-        </Link>
-      </SignedOut>
-      <div className="flex items-center sm:ml-15">
+      <div className="flex items-center sm:ml-8">
         <SignedIn>
           <UserButton />
         </SignedIn>


### PR DESCRIPTION
## Description

- Use "Aila" in headers
- Use acorn logo
- Tighten spacing of Beta label
- Hide help on mobile header
- Move menu to right and add text label on desktop
- Adjust icon sizes in header
- Make sidebar slide out from right
- Shrink icon sizes in sidebar
- Shrink sidebar X button and bring content below a bit closer

https://www.figma.com/design/8yhBj0ewAVelXOPEKEvCNu/Mobile-view-tests?node-id=2427-5649&node-type=SECTION&t=uMfCMo3HRoQh0CQT-0


## How to test

1. Go to https://oak-ai-lesson-assistant-3ie0o7hoz.vercel-preview.thenational.academy/aila
2. Look at the nav and the menu
3. Look again at a mobile width

## Screenshots


How it should now look:
![CleanShot 2024-09-04 at 13 49 37@2x](https://github.com/user-attachments/assets/86731cc0-ad52-4f74-991a-7c28e29c74a6)
![CleanShot 2024-09-04 at 13 49 40@2x](https://github.com/user-attachments/assets/f7b33740-3046-4b65-80c7-ddb1a5b690ae)
![CleanShot 2024-09-04 at 13 49 48@2x](https://github.com/user-attachments/assets/00ce3be7-3116-419c-9cd1-b98181168432)

