### PR TITLE
fix: ensure prompt variants are initialised correctly

### DIFF
--- a/packages/core/src/prompts/lesson-assistant/variants.ts
+++ b/packages/core/src/prompts/lesson-assistant/variants.ts
@@ -11,6 +11,7 @@ const generatePromptParts = (
   props: TemplateProps,
   slug: string,
 ): OakPromptVariant => {
+  console.log("Calling generatePromptParts in variants");
   const parts = getPromptParts(props);
   return {
     slug,
@@ -31,7 +32,7 @@ export const generateAilaPromptVersionVariantSlug = (
   return `${responseMode}-${basedOn ? "basedOn" : "notBasedOn"}-${useRag ? "rag" : "noRag"}`;
 };
 
-const variants = [
+const variantConfigs = [
   { responseMode: "interactive", basedOn: true, useRag: true },
   { responseMode: "interactive", basedOn: true, useRag: false },
   { responseMode: "interactive", basedOn: false, useRag: true },
@@ -40,29 +41,36 @@ const variants = [
   { responseMode: "generate", basedOn: true, useRag: false },
   { responseMode: "generate", basedOn: false, useRag: true },
   { responseMode: "generate", basedOn: false, useRag: false },
-].map(({ responseMode, basedOn, useRag }) => {
-  const slug = generateAilaPromptVersionVariantSlug(
-    responseMode,
-    basedOn,
-    useRag,
-  );
-  return generatePromptParts(
-    {
-      responseMode: responseMode as "interactive" | "generate",
-      baseLessonPlan: basedOn ? "dummy" : undefined,
+];
+
+export const generateVariants = (): OakPromptVariant[] => {
+  return variantConfigs.map(({ responseMode, basedOn, useRag }) => {
+    const slug = generateAilaPromptVersionVariantSlug(
+      responseMode,
+      basedOn,
       useRag,
-      lessonPlanJsonSchema: "<lessonPlanJsonSchema>",
-      llmResponseJsonSchema: "<llmResponseJsonSchema>",
-    },
-    slug,
-  );
-});
+    );
+    return generatePromptParts(
+      {
+        responseMode: responseMode as "interactive" | "generate",
+        baseLessonPlan: basedOn ? "dummy" : undefined,
+        useRag,
+        lessonPlanJsonSchema: "<lessonPlanJsonSchema>",
+        llmResponseJsonSchema: "<llmResponseJsonSchema>",
+        currentLessonPlan: "dummy",
+      },
+      slug,
+    );
+  });
+};
 
 const ailaGenerate: OakPromptDefinition = {
   appId: "lesson-planner",
   name: "Generate lesson plan",
   slug: "generate-lesson-plan",
-  variants,
+  get variants() {
+    return generateVariants();
+  },
   inputSchema,
   outputSchema,
 };

--- a/packages/core/src/prompts/lesson-assistant/variants.ts
+++ b/packages/core/src/prompts/lesson-assistant/variants.ts
@@ -11,7 +11,6 @@ const generatePromptParts = (
   props: TemplateProps,
   slug: string,
 ): OakPromptVariant => {
-  console.log("Calling generatePromptParts in variants");
   const parts = getPromptParts(props);
   return {
     slug,


### PR DESCRIPTION

## Description

- Currently the variants for the Aila prompt are created inline whenever the variants.ts file is imported
- This shifts it into a method that is called in the prompt initialisation script instead
