### PR TITLE
feat: add homepage link to AI blogs

### DIFF
--- a/apps/nextjs/src/components/MainNavigation/MainNavigationMenu.tsx
+++ b/apps/nextjs/src/components/MainNavigation/MainNavigationMenu.tsx
@@ -55,6 +55,18 @@ const MainNavigationWithRef = (
               menuOpen={menuOpen}
             />
           ))}
+          <MobileListItem
+            featureFlag={featureFlag}
+            key="ai-blogs"
+            item={{
+              title: "AI blogs",
+              href: "https://www.thenational.academy/blog/categories/ai-in-education",
+              id: "ai-blogs",
+              external: true,
+            }}
+            setMenuOpen={setMenuOpen}
+            menuOpen={menuOpen}
+          />
 
           {!isSignedIn && (
             <>
@@ -93,7 +105,7 @@ const MainNavigationWithRef = (
             href="https://thenational.academy"
             icon="external"
           >
-            Back to Oak
+            Back to Oak&nbsp;
           </Button>
           <div className="flex gap-5">
             {socialMenuItems.map((item) => {

--- a/apps/nextjs/src/components/MainNavigation/MobileListItem.tsx
+++ b/apps/nextjs/src/components/MainNavigation/MobileListItem.tsx
@@ -1,7 +1,7 @@
 import { useState } from "react";
 
-import { MenuItem } from "data/menus";
 import { usePathname } from "#next/navigation";
+import { MenuItem } from "data/menus";
 
 import Button from "../Button";
 
@@ -41,8 +41,10 @@ export const MobileListItem = ({
         }}
         active={pathname === item.href}
         disabled={item.behindFeatureFlag && !handleFeatureFlagType(featureFlag)}
+        icon={item.external ? "external" : undefined}
+        target={item.external ? "_blank" : undefined}
       >
-        <span className="flex flex-col items-center gap-8 sm:flex-row">
+        <span className="mr-8 flex flex-col items-center gap-8 sm:flex-row">
           {item.title}
           {item.behindFeatureFlag && !handleFeatureFlagType(featureFlag) && (
             <span

--- a/apps/nextjs/src/data/menus.tsx
+++ b/apps/nextjs/src/data/menus.tsx
@@ -12,6 +12,7 @@ export interface MenuItem {
   id: string;
   target?: string;
   behindFeatureFlag?: boolean;
+  external?: boolean;
 }
 
 export const menuItems: MenuItem[] = [];


### PR DESCRIPTION
## Description

- Adds a link to the Oak blogs for AI
- Adds spacing to "Back to Oak" icon

## How to test

1. Go to https://oak-ai-lesson-assistant-8b2s70h2x.vercel-preview.thenational.academy
2. Click on the menu
3. You should see the link
4. Click on the link
5. You should in on the oak blog, with the AI category (currently there aren't any published posts)

## Screenshots

![CleanShot 2024-09-04 at 16 07 19@2x](https://github.com/user-attachments/assets/87a7e77d-415e-411c-af7f-2c969d070d34)

