### PR TITLE
feat: help text when downloading an unfinished lesson

### DIFF
--- a/apps/nextjs/src/app/aila/[id]/download/DownloadView.tsx
+++ b/apps/nextjs/src/app/aila/[id]/download/DownloadView.tsx
@@ -34,6 +34,8 @@ export function DownloadView({
     totalSectionsComplete,
   } = useDownloadView(chat);
 
+  const isLessonComplete = totalSectionsComplete >= totalSections;
+
   return (
     <Layout featureFlag={featureFlag}>
       <DialogRoot>
@@ -61,7 +63,18 @@ export function DownloadView({
               <div>
                 <h1 className="my-24 text-4xl font-bold">Download resources</h1>
                 <p className="mb-24 max-w-[600px]">
-                  Choose the resources you would like to generate and download.
+                  {isLessonComplete ? (
+                    <>
+                      Choose the resources you would like to generate and
+                      download.
+                    </>
+                  ) : (
+                    <>
+                      Complete all {totalSections} sections of your lesson to
+                      unlock resources below. If a section is missing, just ask
+                      Aila to help you complete your lesson.
+                    </>
+                  )}
                 </p>
               </div>
               <Grid
@@ -74,7 +87,7 @@ export function DownloadView({
                 <Flex direction="column" className="gap-14">
                   <DownloadButton
                     onClick={() => lessonPlanExport.start()}
-                    title="Lesson"
+                    title="Lesson plan"
                     subTitle="Overview of the complete lesson"
                     downloadAvailable={!!lessonPlanExport.readyToExport}
                     downloadLoading={lessonPlanExport.status === "loading"}


### PR DESCRIPTION
## Description

- Add text to explain why you can't download if you don't have 10/10 sections complete
- Update "Lesson" section to "Lesson plan"

## How to test

1. Go to https://oak-ai-lesson-assistant-pwh6d95ed.vercel-preview.thenational.academy
2. Create a new lesson
3. Click on "download"
4. You should see the friendly explanation

## Screenshots

![CleanShot 2024-09-04 at 16 24 19@2x](https://github.com/user-attachments/assets/acae6d20-6968-48ec-bb31-65741b7e74fd)


## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
