### PR TITLE
fix: remove duplicate beta tag on mobile

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-start.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-start.tsx
@@ -14,7 +14,6 @@ import useAnalytics from "@/lib/analytics/useAnalytics";
 import { trpc } from "@/utils/trpc";
 
 import { useDialog } from "../DialogContext";
-import { BetaTagPage } from "./beta-tag";
 import ChatPanelDisclaimer from "./chat-panel-disclaimer";
 import { ChatStartForm } from "./chat-start-form";
 import EmptyScreenAccordion from "./empty-screen-accordian";
@@ -102,9 +101,6 @@ export function ChatStart() {
             <div className="mx-auto flex h-full max-w-[580px] flex-col justify-between">
               <div className="flex h-full flex-col justify-center gap-18">
                 <div>
-                  <div className="mb-13   block w-fit sm:hidden">
-                    <BetaTagPage />
-                  </div>
                   <h1
                     data-testid="chat-h1"
                     className="mb-11 text-3xl font-semibold capitalize"


### PR DESCRIPTION

## Screenshots

How it used to look (delete if n/a):
![Screenshot 2024-09-04 at 16 59 33](https://github.com/user-attachments/assets/6a8577b0-0b1b-4625-892a-e40b2696e201)


How it should now look:
![CleanShot 2024-09-04 at 18 50 36@2x](https://github.com/user-attachments/assets/e773037f-875e-44c4-bb57-e0e52e0a6726)
