### PR TITLE
chore: add lesson plan content to rag error logs

### DIFF
--- a/packages/aila/src/utils/lessonPlan/fetchLessonPlanContentById.ts
+++ b/packages/aila/src/utils/lessonPlan/fetchLessonPlanContentById.ts
@@ -23,6 +23,11 @@ export async function fetchLessonPlanContentById(
   const parsedPlan = tryWithErrorReporting(
     () => LessonPlanSchemaWhilstStreaming.parse(lessonPlanRecord.content),
     "Failed to parse lesson plan content",
+    undefined,
+    undefined,
+    {
+      lessonPlanContent: lessonPlanRecord.content,
+    },
   );
 
   return parsedPlan;


### PR DESCRIPTION
## Description

- adds lesson plan content to the error so we see what the content was that failed to parse

