### PR TITLE
fix: mobile download buttons were blocked by demo account banner

### DIFF
--- a/apps/nextjs/src/components/ContextProviders/Demo.tsx
+++ b/apps/nextjs/src/components/ContextProviders/Demo.tsx
@@ -51,14 +51,14 @@ export function DemoProvider({ children }: Readonly<DemoProviderProps>) {
     () =>
       isDemoUser
         ? {
-            isDemoUser,
+            isDemoUser: true,
             appSessionsRemaining,
             appSessionsPerMonth: DEMO_APP_SESSIONS_PER_30D,
             contactHref: "mailto:help@thenational.academy",
             isSharingEnabled,
           }
         : {
-            isDemoUser,
+            isDemoUser: true,
             isSharingEnabled,
           },
     [isDemoUser, appSessionsRemaining, isSharingEnabled],


### PR DESCRIPTION
## Issue(s)

The download and share bar were dropped by the demo account banner for users on demo accounts.

Fixes #

## How to test

1. Go to a chat in development on mobile
2. You should be able to access the share and download buttons
