### PR TITLE
fix: downgrade moderation if all categories triggered at same time

### DIFF
--- a/packages/core/src/utils/ailaModeration/helpers.ts
+++ b/packages/core/src/utils/ailaModeration/helpers.ts
@@ -2,6 +2,15 @@ import moderationCategories from "./moderationCategories.json";
 import { ModerationBase, ModerationResult } from "./moderationSchema";
 
 export function isToxic(result: ModerationBase): boolean {
+  // FIX: Sometimes the LLM returns all available categories. Until we fix this edge case, we can assume it's not toxic'
+  const allCategoryCount = moderationCategories.reduce(
+    (acc, category) => acc + category.categories.length,
+    0,
+  );
+  if (result.categories.length === allCategoryCount) {
+    return false;
+  }
+
   return result.categories.some((category) =>
     typeof category === "string" ? category.startsWith("t/") : false,
   );


### PR DESCRIPTION
Sometimes the moderation prompt returns all categories for a benign "sensitive" input. Until we can address the root cause, detect this case

![CleanShot 2024-09-05 at 12 53 44@2x](https://github.com/user-attachments/assets/f09bf99c-90e1-487d-8a3f-1e1282ca1b15)
