### PR TITLE
chore: add fonts.static.com to font csp

### DIFF
--- a/apps/nextjs/src/middlewares/csp.ts
+++ b/apps/nextjs/src/middlewares/csp.ts
@@ -99,7 +99,13 @@ const buildCspHeaders = (nonce: string) => {
       "https://*.hubspot.com",
       "https://*.hsforms.com",
     ],
-    "font-src": ["'self'", "gstatic-fonts.thenational.academy"],
+    "font-src": [
+      "'self'",
+      // Oak font subdomain
+      "gstatic-fonts.thenational.academy",
+      // Google fonts used by third party tools
+      "fonts.gstatic.com",
+    ],
     "object-src": ["'none'"],
     "base-uri": ["'self'"],
     "frame-src": [


### PR DESCRIPTION
## Description

We shouldn't be using this domain ourselves, but something in our project is trying to load IBM Plex. It could be a third party for example. We can trust Google Fonts, so I think we should just enable it

This has triggered 1.8k times
https://oak-national-academy.sentry.io/issues/425476