### PR TITLE
fix: mobile downloads blocked on demo

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.tsx
@@ -72,7 +72,7 @@ const ChatRightHandSideLesson = ({
   const endOfDocRef = useRef<HTMLDivElement>(null);
   return (
     <div
-      className={`fixed bottom-0 ${showLessonMobile ? `right-0` : `right-[-100%] sm:right-0`} right-0 top-0 z-30 w-[95%] bg-white shadow-md duration-300 sm:relative  sm:z-0  sm:w-[50%] sm:shadow-none lg:w-full`}
+      className={`fixed bottom-0 ${showLessonMobile ? `right-0` : `right-[-100%] sm:right-0`} right-0 ${demo.isDemoUser ? `top-19` : `top-0`}  z-30 w-[95%] bg-white shadow-md duration-300 sm:relative  sm:z-0  sm:w-[50%] sm:shadow-none lg:w-full`}
       ref={documentContainerRef}
       onScroll={handleScroll}
       style={{ overflowY: "auto" }}

--- a/apps/nextjs/src/components/ContextProviders/Demo.tsx
+++ b/apps/nextjs/src/components/ContextProviders/Demo.tsx
@@ -51,14 +51,14 @@ export function DemoProvider({ children }: Readonly<DemoProviderProps>) {
     () =>
       isDemoUser
         ? {
-            isDemoUser,
+            isDemoUser: true,
             appSessionsRemaining,
             appSessionsPerMonth: DEMO_APP_SESSIONS_PER_30D,
             contactHref: "mailto:help@thenational.academy",
             isSharingEnabled,
           }
         : {
-            isDemoUser,
+            isDemoUser: true,
             isSharingEnabled,
           },
     [isDemoUser, appSessionsRemaining, isSharingEnabled],

--- a/apps/nextjs/src/components/ContextProviders/Demo.tsx
+++ b/apps/nextjs/src/components/ContextProviders/Demo.tsx
@@ -51,14 +51,14 @@ export function DemoProvider({ children }: Readonly<DemoProviderProps>) {
     () =>
       isDemoUser
         ? {
-            isDemoUser: true,
+            isDemoUser,
             appSessionsRemaining,
             appSessionsPerMonth: DEMO_APP_SESSIONS_PER_30D,
             contactHref: "mailto:help@thenational.academy",
             isSharingEnabled,
           }
         : {
-            isDemoUser: true,
+            isDemoUser,
             isSharingEnabled,
           },
     [isDemoUser, appSessionsRemaining, isSharingEnabled],


### PR DESCRIPTION
## Issue(s)

The download and share bar were dropped by the demo account banner for users on demo accounts.

Fixes #

## How to test

1. Go to a chat in development on mobile
2. You should be able to access the share and download buttons
