### PR TITLE
chore: ensure whole moderation result is logged

### DIFF
--- a/packages/aila/src/features/moderation/moderators/OpenAiModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/OpenAiModerator.ts
@@ -71,7 +71,6 @@ export class OpenAiModerator extends AilaModerator {
 
     console.log(
       "Moderation response: ",
-      input,
       JSON.stringify(moderationResponse, null, 2),
     );
 


### PR DESCRIPTION
## Description

- removes 'input' from logs, which often was meaning that there wasn't space in the log for the moderationResult (it was cut off)
- we can look up input in the moderations table if we want, but we don't store the full moderation response, so the log is useful in itself