### PR TITLE
fix: add dummy moderation category to detect over-eager moderation

### DIFF
--- a/apps/nextjs/src/components/ContextProviders/AnalyticsProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/AnalyticsProvider.tsx
@@ -195,7 +195,8 @@ export const AnalyticsProvider: React.FC<AnalyticsProviderProps> = ({
       const allServices = !services;
       if (allServices || services?.includes("posthog")) {
         posthogAiBeta.identify(userId, properties);
-        const { email, ...nonPiiProperties } = properties;
+        const { ...nonPiiProperties } = properties;
+        delete nonPiiProperties.email;
         posthogOak.identify(userId, nonPiiProperties);
       }
       if (allServices || services?.includes("hubspot")) {

--- a/packages/aila/src/features/moderation/moderators/OpenAiModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/OpenAiModerator.ts
@@ -94,6 +94,13 @@ export class OpenAiModerator extends AilaModerator {
       });
       throw new AilaModerationError(`No moderation response`);
     }
+
+    // FIX: Sometimes the LLM incorrectly flags all available categories.
+    // The dummy smoke test shouldn't be triggered in normal use, and indicates this bug
+    if (response.data.categories.includes("t/dummy-smoke-test")) {
+      return await this.moderate(input);
+    }
+
     return response.data;
   }
 }

--- a/packages/core/src/utils/ailaModeration/helpers.ts
+++ b/packages/core/src/utils/ailaModeration/helpers.ts
@@ -2,15 +2,6 @@ import moderationCategories from "./moderationCategories.json";
 import { ModerationBase, ModerationResult } from "./moderationSchema";
 
 export function isToxic(result: ModerationBase): boolean {
-  // FIX: Sometimes the LLM returns all available categories. Until we fix this edge case, we can assume it's not toxic'
-  const allCategoryCount = moderationCategories.reduce(
-    (acc, category) => acc + category.categories.length,
-    0,
-  );
-  if (result.categories.length === allCategoryCount) {
-    return false;
-  }
-
   return result.categories.some((category) =>
     typeof category === "string" ? category.startsWith("t/") : false,
   );

--- a/packages/core/src/utils/ailaModeration/moderationCategories.json
+++ b/packages/core/src/utils/ailaModeration/moderationCategories.json
@@ -200,6 +200,12 @@
         "title": "Encouragement of Violence",
         "userDescription": "encouragement of violence",
         "llmDescription": "Encouragement of violence"
+      },
+      {
+        "code": "t/dummy-smoke-test",
+        "title": "",
+        "userDescription": "",
+        "llmDescription": "no content matches this category"
       }
     ]
   }

--- a/packages/core/src/utils/ailaModeration/moderationSchema.ts
+++ b/packages/core/src/utils/ailaModeration/moderationSchema.ts
@@ -35,6 +35,8 @@ export const moderationCategoriesSchema = z.array(
       z.literal("t/encouragement-harmful-behaviour"),
       z.literal("t/encouragement-illegal-activity"),
       z.literal("t/encouragement-violence"),
+      z.literal("t/encouragement-violence"),
+      z.literal("t/dummy-smoke-test"),
     ])
     .describe(
       `If the content scores less then 5 for any group, specify the categories on which it failed.`,


### PR DESCRIPTION
As per #79, sometimes the moderation LLM call returns all possible moderation categories for an input. This incorrectly flags a toxic status which locks the lesson, etc

This is an approach to detect this case using a `t/dummy-smoke-test` category