### PR TITLE
fix: remove demo header margin on mobile

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.tsx
@@ -72,7 +72,7 @@ const ChatRightHandSideLesson = ({
   const endOfDocRef = useRef<HTMLDivElement>(null);
   return (
     <div
-      className={`fixed bottom-0 ${showLessonMobile ? `right-0` : `right-[-100%] sm:right-0`} right-0 ${demo.isDemoUser ? `top-19` : `top-0`}  z-30 w-[95%] bg-white shadow-md duration-300 sm:relative  sm:z-0  sm:w-[50%] sm:shadow-none lg:w-full`}
+      className={`fixed bottom-0 ${showLessonMobile ? `right-0` : `right-[-100%] sm:right-0`} right-0  ${demo.isDemoUser ? `top-19` : ``} z-30 w-[95%] bg-white shadow-md duration-300 sm:relative sm:top-0  sm:z-0  sm:w-[50%] sm:shadow-none lg:w-full`}
       ref={documentContainerRef}
       onScroll={handleScroll}
       style={{ overflowY: "auto" }}


### PR DESCRIPTION
## Description

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to https://oak-ai-lesson-assistant-huczl8uwl.vercel-preview.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
