### PR TITLE
chore: add workflow to merge approved RCs

### DIFF
--- a/.github/workflows/accept_release_candidate.yml
+++ b/.github/workflows/accept_release_candidate.yml
@@ -1,0 +1,27 @@
+name: Accept Release Candidate
+
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  merge:
+    name: Merge Release Candidate
+    if: |
+      github.event.review.state == 'approved' &&
+      startsWith(github.event.pull_request.base.ref, "rc")
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Merge pull request"
+        uses: "actions/github-script@v7"
+        with:
+          script: |
+            const pullRequest = context.payload.workflow_run.pull_requests[0]
+            const repository = context.repo
+
+            await github.rest.pulls.merge({
+              merge_method: "merge",
+              owner: repository.owner,
+              pull_number: pullRequest.number,
+              repo: repository.repo,
+            })


### PR DESCRIPTION
## Description

We release by creating a release candidate PR and then merging it. We need to merge it with the "merge" strategy. For our own PRs, we should use the "squash" strategy. Github remembers your last-used strategy so it's easy to get this wrong

This automation will automatically merge the RC to production when someone approves it
