### PR TITLE
feat: add pwa manifest

### DIFF
--- a/apps/nextjs/src/app/manifest.ts
+++ b/apps/nextjs/src/app/manifest.ts
@@ -4,7 +4,7 @@ export default function manifest(): MetadataRoute.Manifest {
   return {
     name: "Aila: Oak's AI Lesson Assistant",
     short_name: 'Aila',
-    description: 'Oak AI experiments offers some experimental generative AI tools designed for and freely available to teachers. We are actively looking for your feedback to refine and optimise these tools, making them more effective and time-saving.',
+    description: 'An AI lesson assistant chatbot for UK teachers to create lessons personalised for their classes, with the aim of reducing teacher workload.',
     start_url: '/',
     display: 'minimal-ui',
     background_color: '#BEF2BD',

--- a/apps/nextjs/src/app/manifest.ts
+++ b/apps/nextjs/src/app/manifest.ts
@@ -2,9 +2,9 @@ import type { MetadataRoute } from 'next'
  
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "AI Lesson Assistant (Aila)",
+    name: "Oak AI Experiments",
     short_name: 'Aila',
-    description: 'AI lesson assistant chatbot for UK teachers to create lessons personalised for their classes, with the aim of reducing teacher workload.',
+    description: 'Oak AI experiments offers some experimental generative AI tools designed for and freely available to teachers. We are actively looking for your feedback to refine and optimise these tools, making them more effective and time-saving.',
     start_url: '/',
     display: 'minimal-ui',
     background_color: '#BEF2BD',

--- a/apps/nextjs/src/app/manifest.ts
+++ b/apps/nextjs/src/app/manifest.ts
@@ -1,0 +1,45 @@
+import type { MetadataRoute } from 'next'
+ 
+export default function manifest(): MetadataRoute.Manifest {
+  return {
+    name: "Oak's AI Lesson Assistant",
+    short_name: 'Aila',
+    description: 'AI lesson assistant chatbot for UK teachers to create lessons personalised for their classes, with the aim of reducing teacher workload.',
+    start_url: '/aila',
+    display: 'minimal-ui',
+    background_color: '#BEF2BD',
+    theme_color: '#BEF2BD',
+    icons: [
+      {
+        "src": "/favicon/android-chrome-192x192.png",
+        "sizes": "192x192",
+        "type": "image/png"
+      },
+      {
+        "src": "/favicon/android-chrome-512x512.png",
+        "sizes": "512x512",
+        "type": "image/png"
+      },
+      {
+        "src": "/favicon/apple-touch-icon.png",
+        "sizes": "180x180",
+        "type": "image/png"
+      },
+      {
+        "src": "/favicon/favicon-16x16.png",
+        "sizes": "16x16",
+        "type": "image/png"
+      },
+      {
+        "src": "/favicon/favicon-32x32.png",
+        "sizes": "32x32",
+        "type": "image/png"
+      },
+      {
+        "src": "/favicon/favicon.ico",
+        "sizes": "48x48 16x16 32x32",
+        "type": "image/x-icon"
+      }
+    ]
+  }
+}

--- a/apps/nextjs/src/app/manifest.ts
+++ b/apps/nextjs/src/app/manifest.ts
@@ -2,7 +2,7 @@ import type { MetadataRoute } from 'next'
  
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "Oak AI Experiments",
+    name: "Aila: Oak's AI Lesson Assistant",
     short_name: 'Aila',
     description: 'Oak AI experiments offers some experimental generative AI tools designed for and freely available to teachers. We are actively looking for your feedback to refine and optimise these tools, making them more effective and time-saving.',
     start_url: '/',

--- a/apps/nextjs/src/app/manifest.ts
+++ b/apps/nextjs/src/app/manifest.ts
@@ -2,10 +2,10 @@ import type { MetadataRoute } from 'next'
  
 export default function manifest(): MetadataRoute.Manifest {
   return {
-    name: "Oak's AI Lesson Assistant",
+    name: "AI Lesson Assistant (Aila)",
     short_name: 'Aila',
     description: 'AI lesson assistant chatbot for UK teachers to create lessons personalised for their classes, with the aim of reducing teacher workload.',
-    start_url: '/aila',
+    start_url: '/',
     display: 'minimal-ui',
     background_color: '#BEF2BD',
     theme_color: '#BEF2BD',

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "oak-ai-web-app",
+  "name": "oak-ai-lesson-assistant",
   "private": true,
   "scripts": {
     "FIXME:lint": "turbo lint && manypkg check",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "oak-ai-lesson-assistant",
+  "name": "oak-ai-web-app",
   "private": true,
   "scripts": {
     "FIXME:lint": "turbo lint && manypkg check",


### PR DESCRIPTION
## Description

- Adds web app manifest for [next app](https://nextjs.org/docs/app/building-your-application/configuring/progressive-web-apps#1-creating-the-web-app-manifest).
  - Might need to tweak the config, but it currently displays as below.

## Issue(s)

Fixes [#AI-510](https://www.notion.so/oaknationalacademy/Add-PWA-manifest-fafdd33db57541fb879df03a4d133cba?pvs=4).

## How to test

1. Go to https://oak-ai-lesson-assistant-np4cw1eeb.vercel-preview.thenational.academy on Chrome.
2. Install web app.
3. You should see the installed web app in Chrome Applications.

## Screenshots

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
