### PR TITLE
chore: add space before email link

### DIFF
--- a/apps/nextjs/src/app/faqs/index.tsx
+++ b/apps/nextjs/src/app/faqs/index.tsx
@@ -123,7 +123,7 @@ const FAQPage = () => {
                 How do I sign up for Aila?
               </OakHeading>
               <OakP>
-                You can sign up to access Aila and our other AI experiments
+                You can sign up to access Aila and our other AI experiments{" "}
                 <OakLink href="/aila">here</OakLink>.
               </OakP>
               <OakHeading


### PR DESCRIPTION
## Description

- Adds a space between via and email

## Issue(s) - AI-526
https://www.notion.so/oaknationalacademy/b592fa16f54d45328042f36b307e04e4?v=d7b84ac333f74092925c92f83bc6a787&p=af2d03fa38c749048cb05b7064b1305e&pm=s

Fixes #

## How to test

1. Go to https://oak-ai-lesson-assistant-dpwjkadl2.vercel-preview.thenational.academy
/faqs 

## Screenshots

How it used to look (delete if n/a):
[{screenshots}](https://www.notion.so/oaknationalacademy/Space-missing-in-FAQ-af2d03fa38c749048cb05b7064b1305e?pvs=4#77a9b260530e40dc958cf7f503cf8331)

How it should now look:
  
<img width="825" alt="image" src="https://github.com/user-attachments/assets/00a28d18-a5a2-407b-adf7-00ccc6f80be8">


## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
