### PR TITLE
fix: return protocol error messages for user restrictions

### DIFF
--- a/apps/nextjs/src/app/api/chat/chatHandler.ts
+++ b/apps/nextjs/src/app/api/chat/chatHandler.ts
@@ -1,11 +1,6 @@
-import {
-  Aila,
-  AilaAuthenticationError,
-  AilaThreatDetectionError,
-} from "@oakai/aila";
+import { Aila } from "@oakai/aila";
 import type { AilaOptions, AilaPublicChatOptions, Message } from "@oakai/aila";
 import { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
-import { handleHeliconeError } from "@oakai/aila/src/utils/moderation/moderationErrorHandling";
 import {
   TracingSpan,
   withTelemetry,
@@ -16,7 +11,8 @@ import { NextRequest } from "next/server";
 import invariant from "tiny-invariant";
 
 import { Config } from "./config";
-import { streamingJSON } from "./protocol";
+import { handleChatException } from "./errorHandling";
+import { fetchAndCheckUser } from "./user";
 
 export const maxDuration = 300;
 
@@ -61,25 +57,6 @@ async function setupChatHandler(req: NextRequest) {
   );
 }
 
-function reportErrorTelemetry(
-  span: TracingSpan,
-  error: Error,
-  errorType: string,
-  statusMessage: string,
-  additionalAttributes: Record<
-    string,
-    string | number | boolean | undefined
-  > = {},
-) {
-  span.setTag("error", true);
-  span.setTag("error.type", errorType);
-  span.setTag("error.message", statusMessage);
-  span.setTag("error.stack", error.stack);
-  Object.entries(additionalAttributes).forEach(([key, value]) => {
-    span.setTag(key, value);
-  });
-}
-
 function setTelemetryMetadata(
   span: TracingSpan,
   id: string,
@@ -110,35 +87,6 @@ function handleConnectionAborted(req: NextRequest) {
   return abortController;
 }
 
-async function handleThreatDetectionError(
-  span: TracingSpan,
-  e: AilaThreatDetectionError,
-  userId: string,
-  id: string,
-  prisma: PrismaClientWithAccelerate,
-) {
-  const heliconeErrorMessage = await handleHeliconeError(userId, id, e, prisma);
-  reportErrorTelemetry(span, e, "AilaThreatDetectionError", "Threat detected");
-  return streamingJSON(heliconeErrorMessage);
-}
-
-async function handleAilaAuthenticationError(
-  span: TracingSpan,
-  e: AilaAuthenticationError,
-) {
-  reportErrorTelemetry(span, e, "AilaAuthenticationError", "Unauthorized");
-  return new Response("Unauthorized", { status: 401 });
-}
-
-async function handleGenericError(span: TracingSpan, e: Error) {
-  reportErrorTelemetry(span, e, e.name, e.message);
-  return streamingJSON({
-    type: "error",
-    message: e.message,
-    value: `Sorry, an error occurred: ${e.message}`,
-  });
-}
-
 async function generateChatStream(
   aila: Aila,
   abortController: AbortController,
@@ -152,28 +100,6 @@ async function generateChatStream(
       return result;
     },
   );
-}
-
-async function handleChatException(
-  span: TracingSpan,
-  e: unknown,
-  userId: string | undefined,
-  chatId: string,
-  prisma: PrismaClientWithAccelerate,
-): Promise<Response> {
-  if (e instanceof AilaAuthenticationError) {
-    return handleAilaAuthenticationError(span, e);
-  }
-
-  if (e instanceof AilaThreatDetectionError && userId) {
-    return handleThreatDetectionError(span, e, userId, chatId, prisma);
-  }
-
-  if (e instanceof Error) {
-    return handleGenericError(span, e);
-  }
-
-  throw e;
 }
 
 export async function handleChatPostRequest(
@@ -190,11 +116,7 @@ export async function handleChatPostRequest(
     let aila: Aila | undefined;
 
     try {
-      const userLookup = await config.handleUserLookup(chatId);
-      // The user lookup can either return a userId or a response like a streaming protocol message
-      if ("failureResponse" in userLookup) {
-        return userLookup.failureResponse;
-      }
+      userId = await fetchAndCheckUser(chatId);
 
       span.setTag("user_id", userId);
       aila = await withTelemetry(

--- a/apps/nextjs/src/app/api/chat/chatHandler.ts
+++ b/apps/nextjs/src/app/api/chat/chatHandler.ts
@@ -141,7 +141,7 @@ export async function handleChatPostRequest(
       const stream = await generateChatStream(aila, abortController);
       return new StreamingTextResponse(stream);
     } catch (e) {
-      return handleChatException(span, e, userId, chatId, prisma);
+      return handleChatException(span, e, chatId, prisma);
     } finally {
       if (aila) {
         await aila.ensureShutdown();

--- a/apps/nextjs/src/app/api/chat/config.ts
+++ b/apps/nextjs/src/app/api/chat/config.ts
@@ -5,27 +5,14 @@ import {
 } from "@oakai/db";
 import { nanoid } from "ai";
 
-import { handleUserLookup as defaultHandleUserLookup } from "./user";
 import { createWebActionsPlugin } from "./webActionsPlugin";
 
 export interface Config {
-  shouldPerformUserLookup: boolean;
-  mockUserId?: string;
-  handleUserLookup: (chatId: string) => Promise<
-    | {
-        userId: string;
-      }
-    | {
-        failureResponse: Response;
-      }
-  >;
   prisma: PrismaClientWithAccelerate;
   createAila: (options: Partial<AilaInitializationOptions>) => Promise<Aila>;
 }
 
 export const defaultConfig: Config = {
-  shouldPerformUserLookup: true,
-  handleUserLookup: defaultHandleUserLookup,
   prisma: globalPrisma,
   createAila: async (options) => {
     const webActionsPlugin = createWebActionsPlugin(globalPrisma);

--- a/apps/nextjs/src/app/api/chat/errorHandling.test.ts
+++ b/apps/nextjs/src/app/api/chat/errorHandling.test.ts
@@ -21,13 +21,12 @@ describe("handleChatException", () => {
         });
 
       const span = { setTag: jest.fn() } as unknown as TracingSpan;
-      const error = new AilaThreatDetectionError("test error");
+      const error = new AilaThreatDetectionError("user_abc", "test error");
       const prisma = {} as unknown as PrismaClientWithAccelerate;
 
       const response = await handleChatException(
         span,
         error,
-        "test-user-id",
         "test-chat-id",
         prisma,
       );
@@ -54,7 +53,6 @@ describe("handleChatException", () => {
       const response = await handleChatException(
         span,
         error,
-        "test-user-id",
         "test-chat-id",
         prisma,
       );
@@ -69,13 +67,16 @@ describe("handleChatException", () => {
   describe("RateLimitExceededError", () => {
     it("should return an error chat message", async () => {
       const span = { setTag: jest.fn() } as unknown as TracingSpan;
-      const error = new RateLimitExceededError(100, Date.now() + 3600 * 1000);
+      const error = new RateLimitExceededError(
+        "user_abc",
+        100,
+        Date.now() + 3600 * 1000,
+      );
       const prisma = {} as unknown as PrismaClientWithAccelerate;
 
       const response = await handleChatException(
         span,
         error,
-        "test-user-id",
         "test-chat-id",
         prisma,
       );
@@ -103,7 +104,6 @@ describe("handleChatException", () => {
       const response = await handleChatException(
         span,
         error,
-        "test-user-id",
         "test-chat-id",
         prisma,
       );

--- a/apps/nextjs/src/app/api/chat/errorHandling.test.ts
+++ b/apps/nextjs/src/app/api/chat/errorHandling.test.ts
@@ -1,0 +1,122 @@
+import { AilaAuthenticationError, AilaThreatDetectionError } from "@oakai/aila";
+import * as moderationErrorHandling from "@oakai/aila/src/utils/moderation/moderationErrorHandling";
+import { UserBannedError } from "@oakai/core/src/models/safetyViolations";
+import { TracingSpan } from "@oakai/core/src/tracing/serverTracing";
+import { RateLimitExceededError } from "@oakai/core/src/utils/rateLimiting/userBasedRateLimiter";
+import { PrismaClientWithAccelerate } from "@oakai/db";
+
+import { consumeStream } from "@/utils/testHelpers/consumeStream";
+
+import { handleChatException } from "./errorHandling";
+
+describe("handleChatException", () => {
+  describe("AilaThreatDetectionError", () => {
+    it("should forward the message from handleHeliconeError", async () => {
+      jest
+        .spyOn(moderationErrorHandling, "handleHeliconeError")
+        .mockResolvedValue({
+          type: "error",
+          value: "Threat detected",
+          message: "Threat was detected",
+        });
+
+      const span = { setTag: jest.fn() } as unknown as TracingSpan;
+      const error = new AilaThreatDetectionError("test error");
+      const prisma = {} as unknown as PrismaClientWithAccelerate;
+
+      const response = await handleChatException(
+        span,
+        error,
+        "test-user-id",
+        "test-chat-id",
+        prisma,
+      );
+
+      expect(response.status).toBe(200);
+
+      const message = JSON.parse(
+        await consumeStream(response.body as ReadableStream),
+      );
+      expect(message).toEqual({
+        type: "error",
+        value: "Threat detected",
+        message: "Threat was detected",
+      });
+    });
+  });
+
+  describe("AilaAuthenticationError", () => {
+    it("should return an error chat message", async () => {
+      const span = { setTag: jest.fn() } as unknown as TracingSpan;
+      const error = new AilaAuthenticationError("test error");
+      const prisma = {} as unknown as PrismaClientWithAccelerate;
+
+      const response = await handleChatException(
+        span,
+        error,
+        "test-user-id",
+        "test-chat-id",
+        prisma,
+      );
+
+      expect(response.status).toBe(401);
+
+      const message = await consumeStream(response.body as ReadableStream);
+      expect(message).toEqual("Unauthorized");
+    });
+  });
+
+  describe("RateLimitExceededError", () => {
+    it("should return an error chat message", async () => {
+      const span = { setTag: jest.fn() } as unknown as TracingSpan;
+      const error = new RateLimitExceededError(100, Date.now() + 3600 * 1000);
+      const prisma = {} as unknown as PrismaClientWithAccelerate;
+
+      const response = await handleChatException(
+        span,
+        error,
+        "test-user-id",
+        "test-chat-id",
+        prisma,
+      );
+
+      expect(response.status).toBe(200);
+
+      const message = JSON.parse(
+        await consumeStream(response.body as ReadableStream),
+      );
+      expect(message).toEqual({
+        type: "error",
+        value: "Rate limit exceeded",
+        message:
+          "**Unfortunately you’ve exceeded your fair usage limit for today.** Please come back in 1 hour. If you require a higher limit, please [make a request](https://forms.gle/tHsYMZJR367zydsG8).",
+      });
+    });
+  });
+
+  describe("UserBannedError", () => {
+    it("should return an error chat message", async () => {
+      const span = { setTag: jest.fn() } as unknown as TracingSpan;
+      const error = new UserBannedError("test error");
+      const prisma = {} as unknown as PrismaClientWithAccelerate;
+
+      const response = await handleChatException(
+        span,
+        error,
+        "test-user-id",
+        "test-chat-id",
+        prisma,
+      );
+
+      expect(response.status).toBe(200);
+
+      const message = JSON.parse(
+        await consumeStream(response.body as ReadableStream),
+      );
+      expect(message).toEqual({
+        type: "action",
+        action: "SHOW_ACCOUNT_LOCKED",
+      });
+    });
+  });
+});

--- a/apps/nextjs/src/app/api/chat/errorHandling.ts
+++ b/apps/nextjs/src/app/api/chat/errorHandling.ts
@@ -1,0 +1,115 @@
+import { AilaAuthenticationError, AilaThreatDetectionError } from "@oakai/aila";
+import {
+  ActionDocument,
+  ErrorDocument,
+} from "@oakai/aila/src/protocol/jsonPatchProtocol";
+import { handleHeliconeError } from "@oakai/aila/src/utils/moderation/moderationErrorHandling";
+import { UserBannedError } from "@oakai/core/src/models/safetyViolations";
+import { TracingSpan } from "@oakai/core/src/tracing/serverTracing";
+import { RateLimitExceededError } from "@oakai/core/src/utils/rateLimiting/userBasedRateLimiter";
+import { PrismaClientWithAccelerate } from "@oakai/db";
+
+import { streamingJSON } from "./protocol";
+
+function reportErrorTelemetry(
+  span: TracingSpan,
+  error: Error,
+  errorType: string,
+  statusMessage: string,
+  additionalAttributes: Record<
+    string,
+    string | number | boolean | undefined
+  > = {},
+) {
+  span.setTag("error", true);
+  span.setTag("error.type", errorType);
+  span.setTag("error.message", statusMessage);
+  span.setTag("error.stack", error.stack);
+  Object.entries(additionalAttributes).forEach(([key, value]) => {
+    span.setTag(key, value);
+  });
+}
+
+async function handleThreatDetectionError(
+  span: TracingSpan,
+  e: AilaThreatDetectionError,
+  userId: string,
+  id: string,
+  prisma: PrismaClientWithAccelerate,
+) {
+  const heliconeErrorMessage = await handleHeliconeError(userId, id, e, prisma);
+  reportErrorTelemetry(span, e, "AilaThreatDetectionError", "Threat detected");
+  return streamingJSON(heliconeErrorMessage);
+}
+
+async function handleAilaAuthenticationError(
+  span: TracingSpan,
+  e: AilaAuthenticationError,
+) {
+  reportErrorTelemetry(span, e, "AilaAuthenticationError", "Unauthorized");
+  return new Response("Unauthorized", { status: 401 });
+}
+
+export async function handleRateLimitError(
+  span: TracingSpan,
+  error: RateLimitExceededError,
+) {
+  reportErrorTelemetry(span, error, "RateLimitExceededError", "Rate limited");
+
+  const timeRemainingHours = Math.ceil(
+    (error.reset - Date.now()) / 1000 / 60 / 60,
+  );
+  const hours = timeRemainingHours === 1 ? "hour" : "hours";
+
+  return streamingJSON({
+    type: "error",
+    value: error.message,
+    message: `**Unfortunately you’ve exceeded your fair usage limit for today.** Please come back in ${timeRemainingHours} ${hours}. If you require a higher limit, please [make a request](${process.env.RATELIMIT_FORM_URL}).`,
+  } as ErrorDocument);
+}
+
+async function handleUserBannedError() {
+  return streamingJSON({
+    type: "action",
+    action: "SHOW_ACCOUNT_LOCKED",
+  } as ActionDocument);
+}
+
+async function handleGenericError(span: TracingSpan, e: Error) {
+  reportErrorTelemetry(span, e, e.name, e.message);
+  return streamingJSON({
+    type: "error",
+    message: e.message,
+    value: `Sorry, an error occurred: ${e.message}`,
+  } as ErrorDocument);
+}
+
+export async function handleChatException(
+  span: TracingSpan,
+  e: unknown,
+  userId: string | undefined,
+  chatId: string,
+  prisma: PrismaClientWithAccelerate,
+): Promise<Response> {
+  if (e instanceof AilaAuthenticationError) {
+    return handleAilaAuthenticationError(span, e);
+  }
+
+  if (e instanceof AilaThreatDetectionError && userId) {
+    return handleThreatDetectionError(span, e, userId, chatId, prisma);
+  }
+
+  if (e instanceof RateLimitExceededError && userId) {
+    return handleRateLimitError(span, e);
+  }
+
+  if (e instanceof UserBannedError) {
+    return handleUserBannedError();
+  }
+
+  if (e instanceof Error) {
+    return handleGenericError(span, e);
+  }
+
+  throw e;
+}

--- a/apps/nextjs/src/app/api/chat/route.test.ts
+++ b/apps/nextjs/src/app/api/chat/route.test.ts
@@ -12,6 +12,10 @@ import { Config } from "./config";
 const chatId = "test-chat-id";
 const userId = "test-user-id";
 
+jest.mock("./user", () => ({
+  fetchAndCheckUser: jest.fn().mockResolvedValue("test-user-id"),
+}));
+
 describe("Chat API Route", () => {
   let testConfig: Config;
   let mockLLMService: MockLLMService;
@@ -32,9 +36,6 @@ describe("Chat API Route", () => {
     jest.spyOn(mockLLMService, "createChatCompletionStream");
 
     testConfig = {
-      shouldPerformUserLookup: false,
-      handleUserLookup: jest.fn(),
-      mockUserId: userId,
       createAila: jest.fn().mockImplementation(async (options) => {
         const ailaConfig = {
           options: {
@@ -92,7 +93,5 @@ describe("Chat API Route", () => {
     expectTracingSpan("chat-api").toHaveBeenExecutedWith({
       chat_id: "test-chat-id",
     });
-
-    expect(testConfig.handleUserLookup).not.toHaveBeenCalled();
-  }, 30000);
+  });
 });

--- a/apps/nextjs/src/app/api/chat/user.test.ts
+++ b/apps/nextjs/src/app/api/chat/user.test.ts
@@ -17,9 +17,14 @@ describe("chat route user functions", () => {
       jest.spyOn(posthogAiBetaServerClient, "identify");
       jest.spyOn(posthogAiBetaServerClient, "capture");
       jest.spyOn(posthogAiBetaServerClient, "shutdown");
-      const error = new RateLimitExceededError(100, Date.now() + 3600 * 1000);
-      const chatId = "testChatId";
+
       const userId = "testUserId";
+      const error = new RateLimitExceededError(
+        userId,
+        100,
+        Date.now() + 3600 * 1000,
+      );
+      const chatId = "testChatId";
 
       await reportRateLimitError(error, userId, chatId);
 
@@ -48,9 +53,13 @@ describe("chat route user functions", () => {
         posthogAiBetaServerClient: mockPosthogClient,
       }));
 
-      const error = new RateLimitExceededError(10, Date.now() + 3600 * 1000);
-      const chatId = "testChatId";
       const userId = "testUserId";
+      const error = new RateLimitExceededError(
+        userId,
+        10,
+        Date.now() + 3600 * 1000,
+      );
+      const chatId = "testChatId";
 
       await reportRateLimitError(error, userId, chatId);
 

--- a/apps/nextjs/src/app/api/chat/user.test.ts
+++ b/apps/nextjs/src/app/api/chat/user.test.ts
@@ -2,7 +2,7 @@ import { inngest } from "@oakai/core";
 import { posthogAiBetaServerClient } from "@oakai/core/src/analytics/posthogAiBetaServerClient";
 import { RateLimitExceededError } from "@oakai/core/src/utils/rateLimiting/userBasedRateLimiter";
 
-import { handleRateLimitError } from "./user";
+import { reportRateLimitError } from "./user";
 
 jest.mock("@oakai/core/src/client", () => ({
   inngest: {
@@ -12,7 +12,7 @@ jest.mock("@oakai/core/src/client", () => ({
 }));
 
 describe("chat route user functions", () => {
-  describe("handleRateLimitError", () => {
+  describe("reportRateLimitError", () => {
     it("should report rate limit exceeded to PostHog when userId is provided", async () => {
       jest.spyOn(posthogAiBetaServerClient, "identify");
       jest.spyOn(posthogAiBetaServerClient, "capture");
@@ -21,7 +21,7 @@ describe("chat route user functions", () => {
       const chatId = "testChatId";
       const userId = "testUserId";
 
-      await handleRateLimitError(error, userId, chatId);
+      await reportRateLimitError(error, userId, chatId);
 
       expect(posthogAiBetaServerClient.identify).toHaveBeenCalledWith({
         distinctId: userId,
@@ -52,7 +52,7 @@ describe("chat route user functions", () => {
       const chatId = "testChatId";
       const userId = "testUserId";
 
-      await handleRateLimitError(error, userId, chatId);
+      await reportRateLimitError(error, userId, chatId);
 
       expect(inngest.send).toHaveBeenCalledTimes(1);
       expect(inngest.send).toHaveBeenCalledWith({
@@ -64,29 +64,6 @@ describe("chat route user functions", () => {
           limit: error.limit,
           reset: new Date(error.reset),
         },
-      });
-    });
-
-    it("should return an error chat message", async () => {
-      const mockPosthogClient = {
-        identify: jest.fn(),
-        capture: jest.fn(),
-        shutdown: jest.fn().mockResolvedValue(undefined),
-      };
-      jest.mock("@oakai/core/src/analytics/posthogAiBetaServerClient", () => ({
-        posthogAiBetaServerClient: mockPosthogClient,
-      }));
-      const error = new RateLimitExceededError(100, Date.now() + 3600 * 1000);
-      const chatId = "testChatId";
-      const userId = "testUserId";
-
-      const response = await handleRateLimitError(error, userId, chatId);
-
-      expect(response).toEqual({
-        type: "error",
-        value: "Rate limit exceeded",
-        message:
-          "**Unfortunately you've exceeded your fair usage limit for today.** Please come back in 1 hour. If you require a higher limit, please [make a request](https://forms.gle/tHsYMZJR367zydsG8).",
       });
     });
   });

--- a/apps/nextjs/src/app/api/chat/user.ts
+++ b/apps/nextjs/src/app/api/chat/user.ts
@@ -1,18 +1,17 @@
 import { auth, clerkClient } from "@clerk/nextjs/server";
-import { ErrorDocument } from "@oakai/aila/src/protocol/jsonPatchProtocol";
+import { AilaAuthenticationError } from "@oakai/aila";
 import { demoUsers, inngest } from "@oakai/core";
 import { posthogAiBetaServerClient } from "@oakai/core/src/analytics/posthogAiBetaServerClient";
+import { UserBannedError } from "@oakai/core/src/models/safetyViolations";
 import { withTelemetry } from "@oakai/core/src/tracing/serverTracing";
 import { rateLimits } from "@oakai/core/src/utils/rateLimiting/rateLimit";
 import { RateLimitExceededError } from "@oakai/core/src/utils/rateLimiting/userBasedRateLimiter";
-
-import { streamingJSON } from "./protocol";
 
 async function checkRateLimit(
   userId: string,
   isDemoUser: boolean,
   chatId: string,
-): Promise<ErrorDocument | null> {
+): Promise<void> {
   return withTelemetry("check-rate-limit", { userId, chatId }, async (span) => {
     const rateLimiter = isDemoUser
       ? rateLimits.generations.demo
@@ -20,29 +19,36 @@ async function checkRateLimit(
 
     try {
       await rateLimiter.check(userId);
-      return null;
     } catch (e) {
-      if (e instanceof RateLimitExceededError) {
-        return await handleRateLimitError(e, userId, chatId);
-      }
       span.setTag("error", true);
       if (e instanceof Error) {
         span.setTag("error.message", e.message);
       }
+
+      if (e instanceof RateLimitExceededError) {
+        await reportRateLimitError(e, userId, chatId);
+
+        const timeRemainingHours = Math.ceil(
+          (e.reset - Date.now()) / 1000 / 60 / 60,
+        );
+        span.setTag("error.type", "RateLimitExceeded");
+        span.setTag("rate_limit.reset_hours", timeRemainingHours);
+      }
+
       throw e;
     }
   });
 }
 
-export async function handleRateLimitError(
+export async function reportRateLimitError(
   error: RateLimitExceededError,
   userId: string,
   chatId: string,
-): Promise<ErrorDocument> {
+): Promise<void> {
   return withTelemetry(
     "handle-rate-limit-error",
     { chatId, userId },
-    async (span) => {
+    async () => {
       posthogAiBetaServerClient.identify({
         distinctId: userId,
       });
@@ -67,69 +73,39 @@ export async function handleRateLimitError(
           reset: new Date(error.reset),
         },
       });
-
-      // Build user-friendly error message
-      const timeRemainingHours = Math.ceil(
-        (error.reset - Date.now()) / 1000 / 60 / 60,
-      );
-      const hours = timeRemainingHours === 1 ? "hour" : "hours";
-      const higherLimitMessage = process.env.RATELIMIT_FORM_URL
-        ? ` If you require a higher limit, please [make a request](${process.env.RATELIMIT_FORM_URL}).`
-        : "";
-
-      span.setTag("error", true);
-      span.setTag("error.type", "RateLimitExceeded");
-      span.setTag("error.message", error.message);
-      span.setTag("rate_limit.reset_hours", timeRemainingHours);
-
-      return {
-        type: "error",
-        value: error.message,
-        message: `**Unfortunately you've exceeded your fair usage limit for today.** Please come back in ${timeRemainingHours} ${hours}.${higherLimitMessage}`,
-      };
     },
   );
 }
 
-export async function fetchAndCheckUser(
-  chatId: string,
-): Promise<{ userId: string } | { failureResponse: Response }> {
+export async function fetchAndCheckUser(chatId: string): Promise<string> {
   return withTelemetry("fetch-and-check-user", { chatId }, async (span) => {
     const userId = auth().userId;
     if (!userId) {
       span.setTag("error", true);
       span.setTag("error.message", "Unauthorized");
-      return {
-        failureResponse: new Response("Unauthorized", {
-          status: 401,
-        }),
-      };
+      throw new AilaAuthenticationError("No user id");
     }
 
     const clerkUser = await clerkClient.users.getUser(userId);
     if (clerkUser.banned) {
       span.setTag("error", true);
       span.setTag("error.message", "Account locked");
-      return {
-        failureResponse: streamingJSON({
-          type: "action",
-          action: "SHOW_ACCOUNT_LOCKED",
-        }),
-      };
+      throw new UserBannedError(userId);
     }
 
     const isDemoUser = demoUsers.isDemoUser(clerkUser);
-    const rateLimitedMessage = await checkRateLimit(userId, isDemoUser, chatId);
-    if (rateLimitedMessage) {
-      span.setTag("error", true);
-      span.setTag("error.message", "Rate limited");
-      return {
-        failureResponse: streamingJSON(rateLimitedMessage),
-      };
+    try {
+      await checkRateLimit(userId, isDemoUser, chatId);
+    } catch (e) {
+      if (e instanceof RateLimitExceededError) {
+        span.setTag("error", true);
+        span.setTag("error.message", "Rate limited");
+      }
+      throw e;
     }
 
     span.setTag("user.id", userId);
     span.setTag("user.demo", isDemoUser);
-    return { userId };
+    return userId;
   });
 }

--- a/apps/nextjs/src/app/api/chat/user.ts
+++ b/apps/nextjs/src/app/api/chat/user.ts
@@ -8,22 +8,6 @@ import { RateLimitExceededError } from "@oakai/core/src/utils/rateLimiting/userB
 
 import { streamingJSON } from "./protocol";
 
-export async function handleUserLookup(chatId: string) {
-  return await withTelemetry(
-    "chat-user-lookup",
-    { chat_id: chatId },
-    async (userLookupSpan) => {
-      const result = await fetchAndCheckUser(chatId);
-
-      if ("failureResponse" in result) {
-        userLookupSpan.setTag("error", true);
-        userLookupSpan.setTag("error.message", "user lookup failed");
-      }
-      return result;
-    },
-  );
-}
-
 async function checkRateLimit(
   userId: string,
   isDemoUser: boolean,

--- a/apps/nextjs/src/app/api/chat/webActionsPlugin.test.ts
+++ b/apps/nextjs/src/app/api/chat/webActionsPlugin.test.ts
@@ -149,7 +149,7 @@ describe("onStreamError", () => {
       type: "error",
       value: "Threat detected",
       message:
-        "I wasn't able to process your request because a potentially malicious input was detected.",
+        "I wasn’t able to process your request because a potentially malicious input was detected.",
     });
   });
 

--- a/apps/nextjs/src/app/api/chat/webActionsPlugin.test.ts
+++ b/apps/nextjs/src/app/api/chat/webActionsPlugin.test.ts
@@ -133,7 +133,7 @@ describe("onStreamError", () => {
     const plugin = createWebActionsPlugin(prisma, safetyViolations);
     await expect(async () => {
       await plugin.onStreamError(
-        new AilaThreatDetectionError("test"),
+        new AilaThreatDetectionError("user_abc", "test"),
         pluginContext,
       );
     }).rejects.toThrow("test");
@@ -170,7 +170,7 @@ describe("onStreamError", () => {
     const plugin = createWebActionsPlugin(prisma, safetyViolations);
     await expect(async () => {
       await plugin.onStreamError(
-        new AilaThreatDetectionError("test"),
+        new AilaThreatDetectionError("user_abc", "test"),
         pluginContext,
       );
     }).rejects.toThrow("test");

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -1,4 +1,5 @@
 import { ReadableStreamDefaultController } from "stream/web";
+import invariant from "tiny-invariant";
 
 import { AilaThreatDetectionError } from "../../features/threatDetection/types";
 import { AilaChatError } from "../AilaError";
@@ -98,7 +99,12 @@ export class AilaStreamHandler {
 
     if (error instanceof Error) {
       if (this._chat.aila.threatDetection?.detector.isThreat(error)) {
-        throw new AilaThreatDetectionError("Threat detected", { cause: error });
+        invariant(this._chat.userId, "User ID is required");
+        throw new AilaThreatDetectionError(
+          this._chat.userId,
+          "Threat detected",
+          { cause: error },
+        );
       } else {
         this._chat.aila.errorReporter?.reportError(error);
         throw new AilaChatError(error.message, { cause: error });

--- a/packages/aila/src/features/threatDetection/types.ts
+++ b/packages/aila/src/features/threatDetection/types.ts
@@ -1,8 +1,11 @@
 import { AilaError } from "../../core/AilaError";
 
 export class AilaThreatDetectionError extends AilaError {
-  constructor(message: string, options?: ErrorOptions) {
+  public readonly userId: string;
+
+  constructor(userId: string, message: string, options?: ErrorOptions) {
     super(message, options);
     this.name = "AilaThreatDetectionError";
+    this.userId = userId;
   }
 }

--- a/packages/aila/src/utils/moderation/moderationErrorHandling.ts
+++ b/packages/aila/src/utils/moderation/moderationErrorHandling.ts
@@ -56,6 +56,6 @@ export async function handleHeliconeError(
     type: "error",
     value: "Threat detected",
     message:
-      "I wasn't able to process your request because a potentially malicious input was detected.",
+      "I wasn’t able to process your request because a potentially malicious input was detected.",
   };
 }

--- a/packages/core/src/utils/rateLimiting/userBasedRateLimiter.ts
+++ b/packages/core/src/utils/rateLimiting/userBasedRateLimiter.ts
@@ -22,12 +22,14 @@ export type RateLimiter = {
 };
 
 export class RateLimitExceededError extends Error {
+  public readonly userId: string;
   public readonly limit: number;
   public readonly reset: number;
 
-  constructor(limit: number, reset: number) {
+  constructor(userId: string, limit: number, reset: number) {
     super("Rate limit exceeded");
     this.name = "RateLimitExceededError";
+    this.userId = userId;
     this.limit = limit;
     this.reset = reset;
   }
@@ -62,7 +64,7 @@ export const userBasedRateLimiter = (rateLimit: Ratelimit): RateLimiter => {
 
       if (!success) {
         logger.warn("Rate limit exceeded for user %s", userId);
-        throw new RateLimitExceededError(rest.limit, rest.reset);
+        throw new RateLimitExceededError(userId, rest.limit, rest.reset);
       }
 
       return {


### PR DESCRIPTION
## Description

Our streaming chat protocol allows us to send predefined error and action messages when a user is banned, rate limited, etc. With recent refactors we've lost some of that functionality

Changes:
- Replace `failureMessage` pattern in chat handler, and throw specific error instances instead
  - Extract error handling code to new file
- Catch known error instances in chat handler, and respond with the appropriate protocol message
- Remove redundant wrappers around user lookup function
- Remove  `shouldPerformUserLookup`, `handleUserLookup`, `mockUserId` functionality as it was only used to support tests

## How to test
Rate limiting
1. Set a low `RATELIMIT_GENERATIONS_PER_24H` in doppler
2. Rebuild the deployment
3. Go to https://oak-ai-lesson-assistant-6qy6b39gj.vercel-preview.thenational.academy
4. Sign in with an account in the pattern myname**+rate-limit-me**@thenational.academy
5. Write some messages
6. You should see a rate limit message

Account locking
1. Go to https://oak-ai-lesson-assistant-eh6lpshzj.vercel-preview.thenational.academy
2. Create 3 lessons with `mod:tox` as the text
3. You should see an "account locked page"

## Screenshots
![CleanShot 2024-09-10 at 21 11 03@2x](https://github.com/user-attachments/assets/d4a080d0-8b64-413f-897c-374b970a2753)
![CleanShot 2024-09-10 at 21 01 20@2x](https://github.com/user-attachments/assets/ed1346a0-587a-468c-b0b1-1e08af231026)

