### PR TITLE
fix: error colour precedence in message wrapper

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-message/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-message/index.tsx
@@ -177,10 +177,10 @@ function MessageWrapper({
     <div
       className={cn(
         "relative mt-14 w-full items-start rounded-md",
+        type === "user" && "bg-teachersLilac p-9",
         errorType && ERROR_TYPE_COLOR_MAP[errorType],
         errorType && "p-9",
         className,
-        type === "user" && "bg-teachersLilac p-9",
       )}
     >
       {type === "aila" ||


### PR DESCRIPTION
## Description

Type 'user' was overriding background colour of the chat message box for `generic` and `moderation ` error messages on reload of the page.

- Change order of classes so errorType has precedence.


## Issue(s) - AI-527
https://www.notion.so/oaknationalacademy/Sensitive-warnings-lose-colour-d1b3361edcf7478ea3b04f7be844a7ce


## How to test

1. Go to https://oak-ai-lesson-assistant-p6i18zgf9.vercel-preview.thenational.academy
Create a lesson with sensitive content, refresh the page, sensitive content box remains mint green colour

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
