### PR TITLE
fix: fuzzy key stage from correct table

### DIFF
--- a/packages/core/src/rag/index.ts
+++ b/packages/core/src/rag/index.ts
@@ -616,7 +616,7 @@ Thank you and happy classifying!`;
         this._chatMeta,
       );
       if (categorisation.keyStage) {
-        foundKeyStage = await this.prisma.subject.findFirst({
+        foundKeyStage = await this.prisma.keyStage.findFirst({
           where: {
             slug: categorisation.keyStage,
           },


### PR DESCRIPTION
## Description

- we're looking in the wrong table at one point, would've been causing an issue when LLM returned a KS which wasn't a simple match for one in our db, looks like it affects RAG 
