### PR TITLE
fix: ask for key stage as slug in prompt

### DIFF
--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -348,7 +348,9 @@ export const CompletedLessonPlanSchema = z.object({
     ),
   keyStage: z
     .string()
-    .describe("The lesson's Key Stage as defined by UK educational standards."),
+    .describe(
+      "The lesson's Key Stage as defined by UK educational standards. In slug format (kebab-case).",
+    ),
   subject: z
     .string()
     .describe(


### PR DESCRIPTION
## Description

- we're getting slightly inconsistent key stages in responses, this asks for the key stage as a slug

I've created #127 which adds an enum, so I think that one probably trumps this