### PR TITLE
test: tighten unit test timeouts which should be using mocks

### DIFF
--- a/apps/nextjs/src/app/api/chat/route.test.ts
+++ b/apps/nextjs/src/app/api/chat/route.test.ts
@@ -62,7 +62,7 @@ describe("Chat API Route", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       prisma: {} as any,
     };
-  }, 60000);
+  });
 
   it("should create correct telemetry spans for a successful chat request", async () => {
     const mockRequest = new NextRequest("http://localhost/api/chat", {
@@ -90,5 +90,5 @@ describe("Chat API Route", () => {
     expectTracingSpan("chat-api").toHaveBeenExecutedWith({
       chat_id: "test-chat-id",
     });
-  }, 60000);
+  });
 });

--- a/packages/aila/src/core/Aila.test.ts
+++ b/packages/aila/src/core/Aila.test.ts
@@ -95,7 +95,7 @@ describe("Aila", () => {
       expect(ailaInstance.lesson.plan.title).not.toBeDefined();
       expect(ailaInstance.lesson.plan.subject).not.toBeDefined();
       expect(ailaInstance.lesson.plan.keyStage).not.toBeDefined();
-    }, 10000);
+    });
   });
 
   describe("checkUserIdPresentIfPersisting", () => {
@@ -218,7 +218,7 @@ describe("Aila", () => {
       expect(ailaInstance.lesson.plan.title).toBeDefined();
       expect(ailaInstance.lesson.plan.subject).toBeDefined();
       expect(ailaInstance.lesson.plan.keyStage).toBeDefined();
-    }, 20000);
+    });
   });
 
   describe("shutdown", () => {
@@ -286,7 +286,7 @@ describe("Aila", () => {
       });
 
       expect(ailaInstance.lesson.plan.title).toBe(newTitle);
-    }, 20000);
+    });
   });
 
   describe("categorisation", () => {


### PR DESCRIPTION
Remove all extended timeouts from unit tests. I'm of the opinion that unit tests need to be fast and free to run, and allowing them to take a long amount of time means we won't catch if they start making third party calls

Improving this should help with our build times, and allow improved local dev experience such as proactive test runs. Obviously it's not passing in CI at the moment, so maybe we can use the PR as a benchmark as we add mocks, etc