### PR TITLE
fix: safari blocking share page as it was an async window pop up

### DIFF
--- a/apps/nextjs/src/components/DialogControl/ContentOptions/ShareChatDialog.tsx
+++ b/apps/nextjs/src/components/DialogControl/ContentOptions/ShareChatDialog.tsx
@@ -9,6 +9,7 @@ import ChatButton from "@/components/AppComponents/Chat/ui/chat-button";
 import { getLessonTrackingProps } from "@/lib/analytics/helpers";
 import useAnalytics from "@/lib/analytics/useAnalytics";
 import { trpc } from "@/utils/trpc";
+import LoadingWheel from "@/components/LoadingWheel";
 
 type ShareChatProps = {
   chatId: string;
@@ -69,8 +70,9 @@ const ShareChat = ({
             Create shareable link
           </ChatButton>
         )}
+        {isLoading && <LoadingWheel />}
         {isError && <p>There has been an error, please try again</p>}
-        {(isSuccess || isShared) && (
+        {(isSuccess || isShared) ? (
           <ChatButton
             variant="primary"
             href={`/aila/${chatId}/share`}

--- a/apps/nextjs/src/components/DialogControl/ContentOptions/ShareChatDialog.tsx
+++ b/apps/nextjs/src/components/DialogControl/ContentOptions/ShareChatDialog.tsx
@@ -29,7 +29,7 @@ const ShareChat = ({
   }, [setOpenExportDialog]);
 
   const { track } = useAnalytics();
-  const { mutateAsync, isSuccess, isError, isLoading } =
+  const { mutateAsync, isSuccess, isLoading, isError } =
     trpc.chat.appSessions.shareChat.useMutation();
 
   const attemptToShareChat = async () => {
@@ -89,6 +89,7 @@ const ShareChat = ({
         </ChatButton>
         {handleShareButtonState()}
       </div>
+      {isError && <p>There was an error sharing the chat.</p>}
     </Flex>
   );
 };

--- a/apps/nextjs/src/components/DialogControl/ContentOptions/ShareChatDialog.tsx
+++ b/apps/nextjs/src/components/DialogControl/ContentOptions/ShareChatDialog.tsx
@@ -6,10 +6,10 @@ import * as Sentry from "@sentry/react";
 
 import { DialogTypes } from "@/components/AppComponents/Chat/Chat/types";
 import ChatButton from "@/components/AppComponents/Chat/ui/chat-button";
+import LoadingWheel from "@/components/LoadingWheel";
 import { getLessonTrackingProps } from "@/lib/analytics/helpers";
 import useAnalytics from "@/lib/analytics/useAnalytics";
 import { trpc } from "@/utils/trpc";
-import LoadingWheel from "@/components/LoadingWheel";
 
 type ShareChatProps = {
   chatId: string;
@@ -45,6 +45,32 @@ const ShareChat = ({
     }
   };
 
+  function handleShareButtonState() {
+    if (isLoading) {
+      return <LoadingWheel />;
+    } else if (isSuccess || isShared) {
+      return (
+        <ChatButton
+          variant="primary"
+          href={`/aila/${chatId}/share`}
+          disabled={isLoading}
+          target="_blank"
+        >
+          Go to share page
+        </ChatButton>
+      );
+    }
+    return (
+      <ChatButton
+        variant="primary"
+        onClick={attemptToShareChat}
+        disabled={isLoading}
+      >
+        Create shareable link
+      </ChatButton>
+    );
+  }
+
   return (
     <Flex className="h-full w-full" direction="column" justify="between">
       <div>
@@ -61,27 +87,7 @@ const ShareChat = ({
         <ChatButton variant="secondary" onClick={() => closeDialog()}>
           Cancel
         </ChatButton>
-        {!isShared && !isSuccess && (
-          <ChatButton
-            variant="primary"
-            onClick={attemptToShareChat}
-            disabled={isLoading}
-          >
-            Create shareable link
-          </ChatButton>
-        )}
-        {isLoading && <LoadingWheel />}
-        {isError && <p>There has been an error, please try again</p>}
-        {(isSuccess || isShared) ? (
-          <ChatButton
-            variant="primary"
-            href={`/aila/${chatId}/share`}
-            disabled={isLoading}
-            target="_blank"
-          >
-            Go to share page
-          </ChatButton>
-        )}
+        {handleShareButtonState()}
       </div>
     </Flex>
   );


### PR DESCRIPTION
## Description

The share page was being blocked on safari as it blocks windows from being opened async as pop-ups. 

This separates out the experience so the user creates the page and then has a user action to go to the page, allowing for errors to be fed back to the user.