### PR TITLE
fix: message ids referenced are from the relevant assistant messages

### DIFF
--- a/apps/nextjs/src/app/aila/[id]/download/useDownloadView.ts
+++ b/apps/nextjs/src/app/aila/[id]/download/useDownloadView.ts
@@ -1,6 +1,8 @@
+import { getLastAssistantMessage } from "@oakai/aila/src/helpers/chat/getLastAssistantMessage";
 import { AilaPersistedChat } from "@oakai/aila/src/protocol/schema";
 
 import { useProgressForDownloads } from "@/components/AppComponents/Chat/Chat/hooks/useProgressForDownloads";
+import { ExportsHookProps } from "@/components/ExportsDialogs/exports.types";
 import { useExportAdditionalMaterials } from "@/components/ExportsDialogs/useExportAdditionalMaterials";
 import { useExportLessonPlanDoc } from "@/components/ExportsDialogs/useExportLessonPlanDoc";
 import { useExportLessonSlides } from "@/components/ExportsDialogs/useExportLessonSlides";
@@ -12,11 +14,11 @@ export function useDownloadView({
   lessonPlan,
   messages,
 }: AilaPersistedChat) {
-  const exportProps = {
+  const exportProps: ExportsHookProps = {
     onStart: () => null,
     lesson: lessonPlan,
     chatId: id,
-    messageId: messages.length,
+    messageId: getLastAssistantMessage(messages)?.id,
     active: true,
   };
 

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/flag-button.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/flag-button.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
+import { getLastAssistantMessage } from "@oakai/aila/src/helpers/chat/getLastAssistantMessage";
 import type { AilaUserFlagType } from "@oakai/db";
 import { OakBox, OakP, OakRadioGroup } from "@oaknational/oak-components";
 import styled from "styled-components";
@@ -32,8 +33,7 @@ const FlagButton = ({ section }: { section: string }) => {
   const chat = useLessonChat();
 
   const { id, messages } = chat;
-  const assistantMessages = messages.filter((m) => m.role === "assistant");
-  const lastAssistantMessage = assistantMessages[assistantMessages.length - 1];
+  const lastAssistantMessage = getLastAssistantMessage(messages);
 
   const { mutateAsync } = trpc.chat.appSessions.flagSection.useMutation();
 

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/modify-button.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/modify-button.tsx
@@ -1,5 +1,6 @@
 import { useRef, useState } from "react";
 
+import { getLastAssistantMessage } from "@oakai/aila/src/helpers/chat/getLastAssistantMessage";
 import type { AilaUserModificationAction } from "@oakai/db";
 import { OakBox, OakP, OakRadioGroup } from "@oaknational/oak-components";
 import { TextArea } from "@radix-ui/themes";
@@ -39,8 +40,7 @@ const ModifyButton = ({
 
   const { mutateAsync } = trpc.chat.appSessions.modifySection.useMutation();
 
-  const assistantMessages = messages.filter((m) => m.role === "assistant");
-  const lastAssistantMessage = assistantMessages[assistantMessages.length - 1];
+  const lastAssistantMessage = getLastAssistantMessage(messages);
 
   const recordUserModifySectionContent = async () => {
     if (selectedRadio && lastAssistantMessage) {

--- a/apps/nextjs/src/components/ExportsDialogs/exports.types.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/exports.types.ts
@@ -1,0 +1,12 @@
+import { LessonDeepPartial } from "@oakai/exports";
+
+export type ExportsHookProps<T = unknown> = T & {
+  onStart: () => void;
+  lesson: LessonDeepPartial;
+  chatId: string;
+  /**
+   * Message ID is of the last assistant message. It should never be undefined, but technically it can be.
+   */
+  messageId: string | undefined;
+  active: boolean;
+};

--- a/apps/nextjs/src/lib/analytics/lessonPlanTrackingContext.tsx
+++ b/apps/nextjs/src/lib/analytics/lessonPlanTrackingContext.tsx
@@ -8,6 +8,7 @@ import {
   useState,
 } from "react";
 
+import { getLastAssistantMessage } from "@oakai/aila/src/helpers/chat/getLastAssistantMessage";
 import { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
 import { Message } from "ai";
 
@@ -44,9 +45,7 @@ const LessonPlanTrackingProvider: FC<{
   }, [chatId]);
   const onStreamFinished = useCallback(
     ({ prevLesson, nextLesson, messages }: OnStreamFinishedProps) => {
-      const ailaMessageContent = messages.findLast(
-        (m) => m.role === "assistant",
-      )?.content;
+      const ailaMessageContent = getLastAssistantMessage(messages)?.content;
       if (!ailaMessageContent) {
         return;
       }

--- a/packages/aila/src/features/moderation/AilaModeration.ts
+++ b/packages/aila/src/features/moderation/AilaModeration.ts
@@ -16,6 +16,7 @@ import invariant from "tiny-invariant";
 import { AilaServices } from "../../core";
 import { Message } from "../../core/chat";
 import { AilaPluginContext } from "../../core/plugins/types";
+import { getLastAssistantMessage } from "../../helpers/chat/getLastAssistantMessage";
 import { ModerationDocument } from "../../protocol/jsonPatchProtocol";
 import { LooseLessonPlan } from "../../protocol/schema";
 import { AilaModerationFeature } from "../types";
@@ -57,7 +58,7 @@ export class AilaModeration implements AilaModerationFeature {
 
   public async persistModerationResult(
     moderationResult: ModerationResult,
-    lastUserMessage: Message,
+    lastAssistantMessage: Message,
     lessonPlan: LooseLessonPlan,
   ) {
     const userId = this._aila.userId;
@@ -68,7 +69,7 @@ export class AilaModeration implements AilaModerationFeature {
     const moderation = await this._moderations.create({
       userId,
       appSessionId: chatId,
-      messageId: lastUserMessage.id,
+      messageId: lastAssistantMessage.id,
       categories: moderationResult.categories,
       justification: moderationResult.justification,
       lesson: lessonPlan,
@@ -86,8 +87,8 @@ export class AilaModeration implements AilaModerationFeature {
     messages: Message[];
     pluginContext: AilaPluginContext;
   }) {
-    const lastUserMessage = messages.findLast((m) => m.role === "user");
-    if (!lastUserMessage) {
+    const lastAssistantMessage = getLastAssistantMessage(messages);
+    if (!lastAssistantMessage) {
       const defaultMessage: ModerationDocument = {
         type: "moderation",
         categories: [],
@@ -104,7 +105,7 @@ export class AilaModeration implements AilaModerationFeature {
     if (this._shouldPersist) {
       const moderation = await this.persistModerationResult(
         moderationResult,
-        lastUserMessage,
+        lastAssistantMessage,
         lessonPlan,
       );
       this.reportModerationToAnalytics(moderationResult, moderation);
@@ -149,12 +150,12 @@ export class AilaModeration implements AilaModerationFeature {
   }
 
   public mockedResponse(messages: Message[]) {
-    const lastUserMessage: Message | undefined = messages.findLast(
+    const lastAssistantMessage: Message | undefined = messages.findLast(
       (m) => m.role === "user",
     );
-    if (lastUserMessage) {
+    if (lastAssistantMessage) {
       const mockModerationResult = getMockModerationResult(
-        lastUserMessage?.content,
+        lastAssistantMessage?.content,
       );
       if (mockModerationResult) {
         console.log("Returning mockModerationResult", mockModerationResult);

--- a/packages/aila/src/helpers/chat/getLastAssistantMessage.ts
+++ b/packages/aila/src/helpers/chat/getLastAssistantMessage.ts
@@ -1,0 +1,21 @@
+import type { Message as AiMessage } from "ai";
+
+import type { Message as AilaMessage } from "../../core/chat/types";
+
+interface AssistantMessage extends AilaMessage {
+  role: "assistant";
+}
+
+/**
+ * This function takes an array of messages, and returns the last message from the assistant.
+ * If the last message is not from the assistant, it synthesises an ID and reports an error.
+ */
+export function getLastAssistantMessage(
+  messages: AiMessage[],
+): AssistantMessage | undefined {
+  const lastAssistantMessage = messages.find(
+    (m): m is AssistantMessage => m.role === "assistant",
+  );
+
+  return lastAssistantMessage;
+}


### PR DESCRIPTION
## Description

- fix issue where moderations and lesson snapshots were referencing user messages (which differed to the message ids referenced by in app feedbacks)
- after this work goes in i'll put in a migration to fix the old instances of the issue
