### PR TITLE
fix: next router skipping signed-in check

### DIFF
--- a/apps/nextjs/src/components/HeaderAuth.tsx
+++ b/apps/nextjs/src/components/HeaderAuth.tsx
@@ -1,6 +1,5 @@
 import { UserButton, useAuth } from "@clerk/nextjs";
 import { OakP } from "@oaknational/oak-components";
-import Link from "next/link";
 
 const HeaderAuth = () => {
   const { isSignedIn } = useAuth();
@@ -9,9 +8,9 @@ const HeaderAuth = () => {
     <>
       {isSignedIn && <UserButton />}
       {!isSignedIn && (
-        <Link href="/sign-in">
+        <a href="/sign-in">
           <OakP $font="body-2">Sign in</OakP>
-        </Link>
+        </a>
       )}
     </>
   );


### PR DESCRIPTION
currently when a user signs into OWA and subsequently clicks the "Sign in" link in Aila (I.e they had the page open in another tab) they're presented with the error

"You're currently in single session mode. You can only be signed into one account at a time."

This appears to be caused by navigating to the page through the Next router. Replacing it with a plain anchor appears to trigger the expected signed-in check and redirect the user back to the app where they are signed in.

## How to test

1. When signed out
2. Open labs
3. Open /sign-in in another tab
4. Sign in
5. Return to the first tab and click "Sign in"
6. Try to sign in
7. You should be redirected to the home page

## Screenshots

How it used to look:

https://github.com/user-attachments/assets/a9f11e3d-0ebd-4817-a50d-d7fa5f24a52d

How it should now look:

https://github.com/user-attachments/assets/be04a9ba-6622-423e-92d7-bc1f9924b1c1




## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
