### PR TITLE
feat: allow the user to interact while moderation is in progress

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-list.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-list.tsx
@@ -159,7 +159,7 @@ export const ChatMessagesDisplay = ({
               chatId={id}
               ailaStreamingStatus={ailaStreamingStatus}
               message={
-                ailaStreamingStatus !== "Idle" &&
+                !["Moderating", "Idle"].includes(ailaStreamingStatus) &&
                 message.role === "assistant" &&
                 messages !== undefined &&
                 message.id === (messages?.[messages?.length - 1]?.id ?? "")

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-message/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-message/index.tsx
@@ -5,6 +5,7 @@ import { ReactNode, useState } from "react";
 import {
   ActionDocument,
   BadDocument,
+  CommentDocument,
   ErrorDocument,
   MessagePart,
   ModerationDocument,
@@ -223,6 +224,7 @@ function ChatMessagePart({
   moderationModalHelpers,
 }: Readonly<ChatMessagePartProps>) {
   const PartComponent = {
+    comment: CommentMessagePart,
     prompt: PromptMessagePart,
     error: ErrorMessagePart,
     bad: BadMessagePart,
@@ -256,6 +258,10 @@ function ChatMessagePart({
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 function BadMessagePart({ part }: Readonly<{ part: BadDocument }>) {
+  return null;
+}
+
+function CommentMessagePart({ part }: Readonly<{ part: CommentDocument }>) {
   return null;
 }
 

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-panel.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-panel.tsx
@@ -23,7 +23,7 @@ export function ChatPanel({
   isDemoLocked,
 }: Readonly<ChatPanelProps>) {
   const chat = useLessonChat();
-  const { id, isLoading, input, setInput, append } = chat;
+  const { id, isLoading, input, setInput, append, ailaStreamingStatus } = chat;
 
   const { trackEvent } = useAnalytics();
   const containerClass = `grid w-full grid-cols-1 ${isEmptyScreen ? "sm:grid-cols-1" : ""} peer-[[data-state=open]]:group-[]:lg:pl-[250px] peer-[[data-state=open]]:group-[]:xl:pl-[300px]`;
@@ -47,7 +47,7 @@ export function ChatPanel({
             }}
             input={input}
             setInput={setInput}
-            isLoading={isLoading}
+            ailaStreamingStatus={ailaStreamingStatus}
             isEmptyScreen={isEmptyScreen}
           />
         )}

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.tsx
@@ -1,3 +1,5 @@
+import { useCallback, useEffect, useState, useRef } from "react";
+
 import { useLessonChat } from "@/components/ContextProviders/ChatProvider";
 import { Icon } from "@/components/Icon";
 import { useLessonPlanTracking } from "@/lib/analytics/lessonPlanTrackingContext";
@@ -11,28 +13,90 @@ interface QuickActionButtonsProps {
   isEmptyScreen: boolean;
 }
 
+type QueuedUserAction = "regenerate" | "continue";
+
 const QuickActionButtons = ({ isEmptyScreen }: QuickActionButtonsProps) => {
   const chat = useLessonChat();
   const { trackEvent } = useAnalytics();
   const lessonPlanTracking = useLessonPlanTracking();
   const { setDialogWindow } = useDialog();
+  const [queuedUserAction, setQueuedUserAction] =
+    useState<QueuedUserAction | null>(null);
+  const { messages, reload, append, id, stop, ailaStreamingStatus } = chat;
+  const isExecutingAction = useRef(false);
 
-  const { isLoading, messages, reload, append, id, stop } = chat;
+  const shouldAllowUserAction =
+    ["Idle", "Moderating"].includes(ailaStreamingStatus) && !queuedUserAction;
+  const shouldQueueUserAction = ailaStreamingStatus === "Moderating";
+
+  const handleRegenerate = useCallback(() => {
+    trackEvent("chat:regenerate", { id: id });
+    const lastUserMessage =
+      messages.findLast((m) => m.role === "user")?.content || "";
+    lessonPlanTracking.onClickRetry(lastUserMessage);
+    reload();
+  }, [reload, lessonPlanTracking, messages, trackEvent, id]);
+
+  const handleContinue = useCallback(async () => {
+    trackEvent("chat:continue");
+    lessonPlanTracking.onClickContinue();
+    await append({
+      content: "Continue",
+      role: "user",
+    });
+  }, [append, lessonPlanTracking, trackEvent]);
+
+  const queueUserAction = useCallback(
+    (action: QueuedUserAction) => {
+      setQueuedUserAction(action);
+    },
+    [setQueuedUserAction],
+  );
+
+  const executeQueuedAction = useCallback(async () => {
+    if (!queuedUserAction || shouldQueueUserAction || isExecutingAction.current)
+      return;
+
+    isExecutingAction.current = true;
+    const actionToExecute = queuedUserAction;
+    setQueuedUserAction(null);
+
+    try {
+      if (actionToExecute === "regenerate") {
+        handleRegenerate();
+      } else if (actionToExecute === "continue") {
+        await handleContinue();
+      }
+    } catch (error) {
+      console.error("Error handling queued action:", error);
+    } finally {
+      isExecutingAction.current = false;
+    }
+  }, [
+    queuedUserAction,
+    shouldQueueUserAction,
+    handleRegenerate,
+    handleContinue,
+  ]);
+
+  useEffect(() => {
+    executeQueuedAction();
+  }, [executeQueuedAction]);
 
   return (
     <div className="-ml-7 flex justify-between space-x-7 rounded-bl rounded-br pt-8">
-      {!isLoading && (
+      {shouldAllowUserAction && (
         <div className="flex items-center">
           <ChatButton
             data-testid="chat-continue"
             size="sm"
             variant="text-link"
             onClick={() => {
-              trackEvent("chat:regenerate", { id: id });
-              const lastUserMessage =
-                messages.findLast((m) => m.role === "user")?.content || "";
-              lessonPlanTracking.onClickRetry(lastUserMessage);
-              reload();
+              if (shouldQueueUserAction) {
+                queueUserAction("regenerate");
+                return;
+              }
+              handleRegenerate();
             }}
           >
             <span className="opacity-70">
@@ -51,33 +115,38 @@ const QuickActionButtons = ({ isEmptyScreen }: QuickActionButtonsProps) => {
           </ChatButton>
         </div>
       )}
-      {isLoading && isEmptyScreen && (
-        <ChatButton
-          size="sm"
-          variant="text-link"
-          onClick={() => {
-            trackEvent("chat:stop_generating");
-            stop();
-          }}
-          testId="chat-stop"
-        >
-          <span className="opacity-50">
-            <IconStop className="mr-3" />
-          </span>
-          <span className="font-light text-[#575757]">Stop</span>
-        </ChatButton>
-      )}
+      {[
+        "Loading",
+        "RequestMade",
+        "StreamingLessonPlan",
+        "StreamingChatResponse",
+      ].includes(ailaStreamingStatus) &&
+        isEmptyScreen && (
+          <ChatButton
+            size="sm"
+            variant="text-link"
+            onClick={() => {
+              trackEvent("chat:stop_generating");
+              stop();
+            }}
+            testId="chat-stop"
+          >
+            <span className="opacity-50">
+              <IconStop className="mr-3" />
+            </span>
+            <span className="font-light text-[#575757]">Stop</span>
+          </ChatButton>
+        )}
       <ChatButton
         size="sm"
         variant="primary"
-        disabled={isLoading}
+        disabled={!shouldAllowUserAction}
         onClick={async () => {
-          trackEvent("chat:continue");
-          lessonPlanTracking.onClickContinue();
-          await append({
-            content: "Continue",
-            role: "user",
-          });
+          if (shouldQueueUserAction) {
+            queueUserAction("continue");
+            return;
+          }
+          await handleContinue();
         }}
         testId="chat-continue"
       >

--- a/packages/aila/src/core/chat/AilaChat.ts
+++ b/packages/aila/src/core/chat/AilaChat.ts
@@ -368,6 +368,10 @@ export class AilaChat implements AilaChatService {
   public async moderate() {
     if (this._aila.options.useModeration) {
       invariant(this._aila.moderation, "Moderation not initialised");
+      await this.enqueue({
+        type: "comment",
+        value: "STARTING_MODERATION",
+      });
       const message = await this._aila.moderation.moderate({
         lessonPlan: this._aila.lesson.plan,
         messages: this._aila.messages,


### PR DESCRIPTION
## Description

- This makes some front end logic changes to make it possible for the user to interact with the chat and see the final message from Aila during the moderation step
- Adds a "comment" document from the server to say that moderation is starting (we already filter these out so it seemed the easiest way)
- If the chat streaming status is "Moderation" or "Idle" then the user is able to interact with both the quick actions and the message box
- If the user interacts with them, then it disables the component, waits for the streaming state to be "Idle" and then does the appropriate action.