### PR TITLE
fix: use NextResponse.json() in case of middleware errors

### DIFF
--- a/apps/nextjs/src/middleware.ts
+++ b/apps/nextjs/src/middleware.ts
@@ -11,7 +11,7 @@ function handleError(error: unknown): Response {
   wrappedError.cause = error;
   Sentry.captureException(wrappedError, { originalException: error });
 
-  return NextResponse.error();
+  return NextResponse.json({ error: "Internal Server Error" }, { status: 500 });
 }
 
 const nextMiddleware: NextMiddleware = async (request, event) => {


### PR DESCRIPTION
## Description

- currently PR'd as a hotfix to production
- attempt to get fewer of these errors https://oak-national-academy.sentry.io/issues/214659/?project=4507089597300816
- code copied from [NextResponse docs](https://nextjs.org/docs/app/api-reference/functions/next-response#json)
- hard to know if this is the issue, as there are few details in the Sentry event. But this is the only place we call `.error()` on a response object
- also, for this code to have been running, there would have been an error in this code:
```ts
    response = await authMiddleware(request, event);
    response = addCspHeaders(response, request);
```
