### PR TITLE
chore: instantiate errors with cause

### DIFF
--- a/packages/api/src/router/chatFeedback.ts
+++ b/packages/api/src/router/chatFeedback.ts
@@ -55,8 +55,7 @@ export const chatFeedbackRouter = router({
         });
         return response;
       } catch (cause) {
-        const err = new Error("Failed to create user modification");
-        err.cause = cause;
+        const err = new Error("Failed to create user modification", { cause });
         Sentry.captureException(err, {
           extra: input,
         });
@@ -113,8 +112,7 @@ export const chatFeedbackRouter = router({
 
         return response;
       } catch (cause) {
-        const err = new Error("Failed to flag section");
-        err.cause = cause;
+        const err = new Error("Failed to flag section", { cause });
         Sentry.captureException(err, {
           extra: { chatId, messageId, flagType },
         });


### PR DESCRIPTION
## Description

- instantiate Error with `{ cause }` rather than setting as property on instance. Seems to be better picked up by Sentry