### PR TITLE
chore: wrap auth middleware errors

### DIFF
--- a/apps/nextjs/src/middlewares/auth.middleware.ts
+++ b/apps/nextjs/src/middlewares/auth.middleware.ts
@@ -143,9 +143,14 @@ export async function authMiddleware(
 ): Promise<Response> {
   const configuredClerkMiddleware = clerkMiddleware(conditionallyProtectRoute);
 
-  const response = await configuredClerkMiddleware(request, event);
-  if (response) {
-    return response;
+  try {
+    const response = await configuredClerkMiddleware(request, event);
+    if (response) {
+      return response;
+    }
+  } catch (error) {
+    console.error("Error in authMiddleware", error);
+    throw new Error("Error in authMiddleware", { cause: error });
   }
 
   return NextResponse.next({ request });


### PR DESCRIPTION
Our middleware-related sentry errors don't give us much context:

`Error in nextMiddleware`
=> `Unexpected token [redacted]... is not valid JSON`

I'm hoping that wrapping the different places that might throw an error might help to narrow down the origin of the errors
