### PR TITLE
fix: refetch chat on mount to fix the blank chat issue on back navigation

### DIFF
--- a/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
@@ -105,10 +105,35 @@ function getModerationFromMessage(message?: { content: string }) {
 }
 
 export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
-  const { data: chat, isLoading: isChatLoading } =
-    trpc.chat.appSessions.getChat.useQuery({ id });
-  const { data: moderations, isLoading: isModerationsLoading } =
-    trpc.chat.appSessions.getModerations.useQuery({ id });
+  const {
+    data: chat,
+    isLoading: isChatLoading,
+    refetch: refetchChat,
+  } = trpc.chat.appSessions.getChat.useQuery(
+    { id },
+    {
+      refetchOnMount: true,
+      refetchOnWindowFocus: true,
+      staleTime: 0,
+    },
+  );
+  const {
+    data: moderations,
+    isLoading: isModerationsLoading,
+    refetch: refetchModerations,
+  } = trpc.chat.appSessions.getModerations.useQuery(
+    { id },
+    {
+      refetchOnMount: true,
+      refetchOnWindowFocus: true,
+      staleTime: 0,
+    },
+  );
+  // Ensure that we re-fetch on mount
+  useEffect(() => {
+    refetchChat();
+    refetchModerations();
+  }, [refetchChat, refetchModerations]);
   const trpcUtils = trpc.useUtils();
 
   const lessonPlanTracking = useLessonPlanTracking();

--- a/apps/nextjs/src/hooks/useTemporaryLessonPlanWithStreamingEdits.ts
+++ b/apps/nextjs/src/hooks/useTemporaryLessonPlanWithStreamingEdits.ts
@@ -42,7 +42,7 @@ function patchHasBeenApplied(
 export const useTemporaryLessonPlanWithStreamingEdits = ({
   lessonPlan,
   messages,
-  //isStreaming,
+  //isStreaming, // Disable partial patches for now
   messageHashes,
 }: {
   lessonPlan?: LooseLessonPlan;
@@ -54,7 +54,6 @@ export const useTemporaryLessonPlanWithStreamingEdits = ({
   validPatches: PatchDocument[];
   partialPatches: PatchDocument[];
 } => {
-  console.log("useTemporaryLessonPlanWithStreamingEdits", lessonPlan);
   const throttledAssistantMessages = useThrottle(messages, 100);
   const tempLessonPlanRef = useRef<LooseLessonPlan>(lessonPlan ?? {});
   const appliedPatchesRef = useRef<PatchDocumentWithHash[]>([]);

--- a/apps/nextjs/src/hooks/useTemporaryLessonPlanWithStreamingEdits.ts
+++ b/apps/nextjs/src/hooks/useTemporaryLessonPlanWithStreamingEdits.ts
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useMemo, useCallback } from "react";
+import { useEffect, useRef, useMemo } from "react";
 
 import {
   PatchDocument,

--- a/apps/nextjs/src/hooks/useTemporaryLessonPlanWithStreamingEdits.ts
+++ b/apps/nextjs/src/hooks/useTemporaryLessonPlanWithStreamingEdits.ts
@@ -54,6 +54,7 @@ export const useTemporaryLessonPlanWithStreamingEdits = ({
   validPatches: PatchDocument[];
   partialPatches: PatchDocument[];
 } => {
+  console.log("useTemporaryLessonPlanWithStreamingEdits", lessonPlan);
   const throttledAssistantMessages = useThrottle(messages, 100);
   const tempLessonPlanRef = useRef<LooseLessonPlan>({});
   const appliedPatchesRef = useRef<PatchDocumentWithHash[]>([]);
@@ -90,19 +91,20 @@ export const useTemporaryLessonPlanWithStreamingEdits = ({
     return newLessonPlan ?? workingLessonPlan;
   };
 
-  const applyPatchWhileStillStreaming = useCallback(
-    (patch: PatchDocument, workingLessonPlan: LooseLessonPlan) => {
-      if (!isStreaming) {
-        return workingLessonPlan;
-      }
-      const newLessonPlan: LooseLessonPlan | undefined = applyLessonPlanPatch(
-        { ...workingLessonPlan },
-        patch,
-      );
-      return newLessonPlan ?? workingLessonPlan;
-    },
-    [isStreaming],
-  );
+  // Disable partial patches for now
+  // const applyPatchWhileStillStreaming = useCallback(
+  //   (patch: PatchDocument, workingLessonPlan: LooseLessonPlan) => {
+  //     if (!isStreaming) {
+  //       return workingLessonPlan;
+  //     }
+  //     const newLessonPlan: LooseLessonPlan | undefined = applyLessonPlanPatch(
+  //       { ...workingLessonPlan },
+  //       patch,
+  //     );
+  //     return newLessonPlan ?? workingLessonPlan;
+  //   },
+  //   [isStreaming],
+  // );
 
   return useMemo(() => {
     if (!throttledAssistantMessages || !throttledAssistantMessages.length) {
@@ -140,7 +142,9 @@ export const useTemporaryLessonPlanWithStreamingEdits = ({
       }
     }
 
-    // Do not apply partial patches
+    // Do not apply partial patches for now
+    // Keeping this commented out for now because we
+    // will probably want to reintroduce this feature
     // const streamingPatch = partialPatches[partialPatches.length - 1];
 
     // if (streamingPatch) {
@@ -155,9 +159,5 @@ export const useTemporaryLessonPlanWithStreamingEdits = ({
       validPatches,
       partialPatches,
     };
-  }, [
-    throttledAssistantMessages,
-    messageHashes,
-    applyPatchWhileStillStreaming,
-  ]);
+  }, [throttledAssistantMessages, messageHashes]);
 };

--- a/apps/nextjs/src/hooks/useTemporaryLessonPlanWithStreamingEdits.ts
+++ b/apps/nextjs/src/hooks/useTemporaryLessonPlanWithStreamingEdits.ts
@@ -42,7 +42,7 @@ function patchHasBeenApplied(
 export const useTemporaryLessonPlanWithStreamingEdits = ({
   lessonPlan,
   messages,
-  isStreaming,
+  //isStreaming,
   messageHashes,
 }: {
   lessonPlan?: LooseLessonPlan;
@@ -56,7 +56,7 @@ export const useTemporaryLessonPlanWithStreamingEdits = ({
 } => {
   console.log("useTemporaryLessonPlanWithStreamingEdits", lessonPlan);
   const throttledAssistantMessages = useThrottle(messages, 100);
-  const tempLessonPlanRef = useRef<LooseLessonPlan>({});
+  const tempLessonPlanRef = useRef<LooseLessonPlan>(lessonPlan ?? {});
   const appliedPatchesRef = useRef<PatchDocumentWithHash[]>([]);
 
   // Update the ref when lessonPlan changes

--- a/apps/nextjs/src/hooks/useTemporaryLessonPlanWithStreamingEdits.ts
+++ b/apps/nextjs/src/hooks/useTemporaryLessonPlanWithStreamingEdits.ts
@@ -140,14 +140,15 @@ export const useTemporaryLessonPlanWithStreamingEdits = ({
       }
     }
 
-    const streamingPatch = partialPatches[partialPatches.length - 1];
+    // Do not apply partial patches
+    // const streamingPatch = partialPatches[partialPatches.length - 1];
 
-    if (streamingPatch) {
-      workingLessonPlan = applyPatchWhileStillStreaming(
-        streamingPatch,
-        workingLessonPlan,
-      );
-    }
+    // if (streamingPatch) {
+    //   workingLessonPlan = applyPatchWhileStillStreaming(
+    //     streamingPatch,
+    //     workingLessonPlan,
+    //   );
+    // }
 
     return {
       tempLessonPlan: workingLessonPlan,


### PR DESCRIPTION
## Description

- Addresses an issue where the chat is blank when navigating back from the downloads page

## How to test

1. Create a complete chat
2. Go to the download page
3. Press the back to lesson link at the top left
4. See that the chat has loaded
