### PR TITLE
fix: detect StreamingLessonPlan for mobile modal

### DIFF
--- a/apps/nextjs/src/hooks/useMobileLessonPullOutControl.ts
+++ b/apps/nextjs/src/hooks/useMobileLessonPullOutControl.ts
@@ -21,7 +21,7 @@ export const useMobileLessonPullOutControl = ({
   useEffect(() => {
     if (
       !userHasOverRiddenAutoPullOut &&
-      ailaStreamingStatus === "Loading" &&
+      ailaStreamingStatus === "StreamingLessonPlan" &&
       lessonPlan.title
     ) {
       setShowLessonMobile(true);


### PR DESCRIPTION
We now use `StreamingLessonPlan` instead of `Loading` after the first message. This prevented the mobile modal from showing automatically after the first message