### PR TITLE
build: use release token to merge RC PRs so that the release workflow…

### DIFF
--- a/.github/workflows/accept_release_candidate.yml
+++ b/.github/workflows/accept_release_candidate.yml
@@ -18,6 +18,7 @@ jobs:
       - name: "Merge pull request"
         uses: "actions/github-script@v7"
         with:
+          github-token: ${{ secrets.RELEASE_GITHUB_TOKEN }}
           script: |
             await github.rest.pulls.merge({
               merge_method: "merge",


### PR DESCRIPTION
Our accept_release_candidate workflow merges the RC pull request. That push should then be picked up by the release workflow. Because we're using the default github_token to merge, [github won't trigger the push event](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/triggering-a-workflow#triggering-a-workflow-from-a-workflow)

This PR uses `RELEASE_GITHUB_TOKEN` to merge the PR instead, which should trigger the push