### PR TITLE
test: allow one e2e retry in CI

### DIFF
--- a/apps/nextjs/playwright.config.ts
+++ b/apps/nextjs/playwright.config.ts
@@ -31,6 +31,7 @@ export default defineConfig({
   use: {
     trace: "retain-on-failure",
   },
+  retries: process.env.CI ? 1 : 0,
   outputDir: "./tests-e2e/test-results",
   forbidOnly: process.env.CI === "true",
 });


### PR DESCRIPTION
End to end tests can be flaky. While the ideal is to not have flaky tests, the reality is that failing tests on PRs lead developers to expect or ignore a failing check

This PR allows a retry in CI in case a failure is just flake