### PR TITLE
ci: add vercel ignore build script to ignore production merge commits

### DIFF
--- a/vercel-ignore-build.sh
+++ b/vercel-ignore-build.sh
@@ -1,0 +1,15 @@
+if [[ "$VERCEL_ENV" == "preview" ]]; then
+    echo "✅ - Preview build can proceed"
+    exit 0; # Allow the build to proceed
+elif [[ "$VERCEL_ENV" == "production" ]]; then
+    if [[ "$VERCEL_GIT_COMMIT_MESSAGE" =~ build\(release\ [vV][0-9]+\.[0-9]+\.[0-9]+\): ]]; then
+        echo "✅ - Production build can proceed"
+        exit 0; # Allow the build to proceed
+    else
+        echo "🛑 - Production build cancelled"
+        exit 1; # Cancel the build
+    fi
+else
+    echo "⚠️ - Unknown environment, build cancelled"
+    exit 1; # Cancel the build for unknown environments
+fi


### PR DESCRIPTION
## Description

- Adds a script to use [Vercel's ignored build step](https://vercel.com/docs/projects/overview#ignored-build-step) to stop the merge commit on `production` trying to build and deploy.

## How to test

1. The preview build for this branch should work.
2. On the production branch, the merge commit should not be built.

## Checklist

- [ ] Once merged, configure Vercel to use it in the Git settings of the project.
