### PR TITLE
fix: enable stop button to clear queuedAction

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.tsx
@@ -6,12 +6,40 @@ import { useLessonPlanTracking } from "@/lib/analytics/lessonPlanTrackingContext
 import useAnalytics from "@/lib/analytics/useAnalytics";
 
 import { useDialog } from "../DialogContext";
+import { AilaStreamingStatus } from "./Chat/hooks/useAilaStreamingStatus";
 import ChatButton from "./ui/chat-button";
 import { IconRefresh, IconStop } from "./ui/icons";
 
 interface QuickActionButtonsProps {
   isEmptyScreen: boolean;
 }
+
+const shouldAllowStop = (
+  ailaStreamingStatus: AilaStreamingStatus,
+  isEmptyScreen: boolean,
+  queuedUserAction: string | null,
+) => {
+  if (!isEmptyScreen) {
+    return false;
+  }
+
+  if (
+    [
+      "Loading",
+      "RequestMade",
+      "StreamingLessonPlan",
+      "StreamingChatResponse",
+    ].includes(ailaStreamingStatus)
+  ) {
+    return true;
+  }
+
+  if (queuedUserAction) {
+    return true;
+  }
+
+  return false;
+};
 
 const QuickActionButtons = ({ isEmptyScreen }: QuickActionButtonsProps) => {
   const chat = useLessonChat();
@@ -74,28 +102,26 @@ const QuickActionButtons = ({ isEmptyScreen }: QuickActionButtonsProps) => {
           </>
         )}
 
-        {[
-          "Loading",
-          "RequestMade",
-          "StreamingLessonPlan",
-          "StreamingChatResponse",
-        ].includes(ailaStreamingStatus) &&
-          isEmptyScreen && (
-            <ChatButton
-              size="sm"
-              variant="text-link"
-              onClick={() => {
-                trackEvent("chat:stop_generating");
-                stop();
-              }}
-              testId="chat-stop"
-            >
-              <span className="opacity-50">
-                <IconStop className="mr-3" />
-              </span>
-              <span className="font-light text-[#575757]">Stop</span>
-            </ChatButton>
-          )}
+        {shouldAllowStop(
+          ailaStreamingStatus,
+          isEmptyScreen,
+          queuedUserAction,
+        ) && (
+          <ChatButton
+            size="sm"
+            variant="text-link"
+            onClick={() => {
+              trackEvent("chat:stop_generating");
+              stop();
+            }}
+            testId="chat-stop"
+          >
+            <span className="opacity-50">
+              <IconStop className="mr-3" />
+            </span>
+            <span className="font-light text-[#575757]">Stop</span>
+          </ChatButton>
+        )}
       </div>
       <ChatButton
         size="sm"

--- a/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
@@ -171,7 +171,7 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
     messages,
     append,
     reload,
-    stop,
+    stop: stopStreaming,
     isLoading,
     input,
     setInput,
@@ -317,6 +317,14 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
       executeQueuedAction();
     }
   }, [hasFinished, executeQueuedAction]);
+
+  const stop = useCallback(() => {
+    if (queuedUserAction) {
+      setQueuedUserAction(null);
+    } else {
+      stopStreaming();
+    }
+  }, [queuedUserAction, setQueuedUserAction, stopStreaming]);
 
   /**
    *  If the state is being restored from a previous lesson plan, set the lesson plan


### PR DESCRIPTION
Our end-to-end tests look at the existence of the "stop" button to determine when the chat is streaming. This started failing in a test where it submitted a message while the chat was moderating

It actually highlights an issue with our new "queueing during moderation" UI

On main/production:
- When you queued a message in the chat, the stop button wouldn't appear until the queued message was sent and started streaming

With this branch:
- When you queue a message, you can click "stop" to unqueue it. This replicates the UI for a non-queued message