### PR TITLE
test: fix download test IDs

### DIFF
--- a/apps/nextjs/src/app/aila/[id]/download/DownloadView.tsx
+++ b/apps/nextjs/src/app/aila/[id]/download/DownloadView.tsx
@@ -85,7 +85,7 @@ export function DownloadView({ chat }: Readonly<DownloadViewProps>) {
                     downloadAvailable={!!exportAllAssets.readyToExport}
                     downloadLoading={exportAllAssets.status === "loading"}
                     data={exportAllAssets.data}
-                    data-testid="chat-download-lesson-plan"
+                    data-testid="chat-download-all-resources"
                     lesson={lessonPlan}
                     chatId={id}
                   />

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/index.tsx
@@ -55,6 +55,7 @@ const ExportButtons = ({
             <OakSmallSecondaryButton
               element={!isStreaming ? Link : "button"}
               disabled={isStreaming}
+              data-testId="chat-download-resources"
               href={demo.isSharingEnabled ? `/aila/download/${id}` : "#"}
               title={demo.isSharingEnabled ? undefined : "Not available"}
               onClick={() => {


### PR DESCRIPTION
A recent change to the download page broke the test IDs used in our e2e test. One was missing, and the other was duplicated