### PR TITLE
fix: feature flag "download all" button

### DIFF
--- a/apps/nextjs/src/components/AppComponents/download/DownloadAllButton.tsx
+++ b/apps/nextjs/src/components/AppComponents/download/DownloadAllButton.tsx
@@ -9,6 +9,7 @@ import { z } from "zod";
 import useAnalytics from "@/lib/analytics/useAnalytics";
 import { trackDownload } from "@/utils/trackDownload";
 import { trpc } from "@/utils/trpc";
+import { useClientSideFeatureFlag } from "@/utils/useClientSideFeatureFlag";
 
 import { getExportsConfig } from "../../ExportsDialogs/exports.helpers";
 import { Icon } from "../../Icon";
@@ -76,6 +77,12 @@ export const DownloadAllButton = ({
   const { track } = useAnalytics();
   const { mutateAsync: zipStatusMutateAsync } =
     trpc.exports.checkDownloadAllStatus.useMutation();
+
+  const isFeatureEnabled = useClientSideFeatureFlag("download-all-button");
+  if (!isFeatureEnabled) {
+    console.log("Download all button is disabled");
+    return null;
+  }
 
   if (data) {
     const fileIdsAndFormats:

--- a/apps/nextjs/src/components/ExportsDialogs/useExportAdditionalMaterials.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportAdditionalMaterials.ts
@@ -27,7 +27,6 @@ export function useExportAdditionalMaterials({
   const debouncedParseResult = useDebounce(parseResult, 500);
 
   useEffect(() => {
-    console.log("Use Export Lesson Slides");
     if (active) {
       const res = exportSlidesFullLessonSchema.safeParse(lesson);
       setParseResult(res);

--- a/apps/nextjs/src/components/ExportsDialogs/useExportAllLessonAssets.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportAllLessonAssets.ts
@@ -34,7 +34,6 @@ export function useExportAllLessonAssets({
   const debouncedParseResult = useDebounce(parseResult, 500);
 
   useEffect(() => {
-    console.log("Use Export Lesson Slides");
     if (active) {
       const res = exportSlidesFullLessonSchema.safeParse(lesson);
       setParseResult(res);

--- a/apps/nextjs/src/components/ExportsDialogs/useExportLessonSlides.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportLessonSlides.ts
@@ -27,7 +27,6 @@ export function useExportLessonSlides({
   const debouncedParseResult = useDebounce(parseResult, 500);
 
   useEffect(() => {
-    console.log("Use Export Lesson Slides");
     if (active) {
       const res = exportSlidesFullLessonSchema.safeParse(lesson);
       setParseResult(res);

--- a/apps/nextjs/src/components/ExportsDialogs/useExportQuizDesignerSlides.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportQuizDesignerSlides.ts
@@ -32,7 +32,6 @@ export function useExportQuizDesignerSlides({
   const debouncedParseResult = useDebounce(parseResult, 500);
 
   useEffect(() => {
-    console.log("Use Export Lesson Slides");
     if (active) {
       const res = exportableQuizAppStateSchema.safeParse(quiz);
       setParseResult(res);

--- a/apps/nextjs/src/utils/useClientSideFeatureFlag.ts
+++ b/apps/nextjs/src/utils/useClientSideFeatureFlag.ts
@@ -8,8 +8,11 @@ export function useClientSideFeatureFlag(flag: string): boolean {
   const [featureEnabled, setFeatureEnabled] = useState<boolean | undefined>();
 
   useEffect(() => {
+    const isDebug = process.env.NEXT_PUBLIC_POSTHOG_DEBUG === "true";
+
     return client.onFeatureFlags(() => {
-      setFeatureEnabled(client.isFeatureEnabled(flag));
+      const isEnabled = isDebug ? true : client.isFeatureEnabled(flag);
+      setFeatureEnabled(isEnabled);
     });
   }, [client, flag]);
 

--- a/apps/nextjs/src/utils/useClientSideFeatureFlag.ts
+++ b/apps/nextjs/src/utils/useClientSideFeatureFlag.ts
@@ -1,57 +1,17 @@
 import { useEffect, useState } from "react";
 
-import { useUser } from "@clerk/nextjs";
-
 import useAnalytics from "@/lib/analytics/useAnalytics";
 
-import { checkFeatureFlag } from "./checkFeatureFlag";
+export function useClientSideFeatureFlag(flag: string): boolean {
+  const { posthogAiBetaClient: client } = useAnalytics();
 
-let isUserIdentified = false;
-export function useClientSideFeatureFlag(
-  featureFlagId: string,
-): [boolean, boolean] {
-  const { user, isLoaded } = useUser();
-
-  const { posthogAiBetaClient } = useAnalytics();
-
-  const [isEnabled, setIsEnabled] = useState<boolean>(false);
-  const [isCheckComplete, setIsCheckComplete] = useState<boolean>(false);
+  const [featureEnabled, setFeatureEnabled] = useState<boolean | undefined>();
 
   useEffect(() => {
-    function checkFeatureFlagStatus() {
-      if (process.env.NEXT_PUBLIC_ENVIRONMENT !== "prd") {
-        setIsEnabled(true);
-        setIsCheckComplete(true);
-        return;
-      }
+    return client.onFeatureFlags(() => {
+      setFeatureEnabled(client.isFeatureEnabled(flag));
+    });
+  }, [client, flag]);
 
-      if (isLoaded && user) {
-        if (!isUserIdentified) {
-          const distinctId = posthogAiBetaClient.get_distinct_id();
-
-          if (distinctId !== user.id) {
-            posthogAiBetaClient.identify(user.id, {
-              email: user.primaryEmailAddress?.emailAddress,
-            });
-          }
-          isUserIdentified = true;
-        }
-        const isFeatureFlagEnabled = checkFeatureFlag(
-          posthogAiBetaClient,
-          featureFlagId,
-        );
-
-        setIsEnabled(isFeatureFlagEnabled);
-        setIsCheckComplete(true);
-      } else if (isLoaded && !user) {
-        console.log("User is not signed in");
-        setIsEnabled(false);
-        setIsCheckComplete(true);
-      }
-    }
-
-    checkFeatureFlagStatus();
-  }, [user, isLoaded, featureFlagId, posthogAiBetaClient]);
-
-  return [isEnabled, isCheckComplete];
+  return featureEnabled ?? false;
 }

--- a/apps/nextjs/src/utils/useClientSideFeatureFlag.ts
+++ b/apps/nextjs/src/utils/useClientSideFeatureFlag.ts
@@ -10,10 +10,14 @@ export function useClientSideFeatureFlag(flag: string): boolean {
   useEffect(() => {
     const isDebug = process.env.NEXT_PUBLIC_POSTHOG_DEBUG === "true";
 
-    return client.onFeatureFlags(() => {
-      const isEnabled = isDebug ? true : client.isFeatureEnabled(flag);
-      setFeatureEnabled(isEnabled);
-    });
+    if (isDebug) {
+      console.info(`Feature flag ${flag} is enabled in debug mode`);
+      setFeatureEnabled(true);
+    } else {
+      return client.onFeatureFlags(() => {
+        setFeatureEnabled(client.isFeatureEnabled(flag));
+      });
+    }
   }, [client, flag]);
 
   return featureEnabled ?? false;


### PR DESCRIPTION
The "download all" button is blocking our latest release. Rather than try to fix it further on main, let's disable it and fix it out-of-band

The feature hook wasn't being used, so it seems like a good opportunity to simplify it. Our analytics setup has changed and I don't think that we need to identify here any more

The features has been created in posthog staging and production


### After

![CleanShot 2024-10-01 at 16 35 12@2x](https://github.com/user-attachments/assets/1bcd6a5a-4bdf-4491-98a6-d526c2d83037)
