### PR TITLE
perf: add fts index to snippets table

### DIFF
--- a/packages/db/prisma/migrations/20241002105843_snippets_fts_index/migration.sql
+++ b/packages/db/prisma/migrations/20241002105843_snippets_fts_index/migration.sql
@@ -1,0 +1,4 @@
+-- Add full-text search index to the snippets table (for Open API performance)
+CREATE INDEX "idx_fts_snippets"
+ON "snippets"
+USING GIN ((to_tsvector('english', "source_content")) tsvector_ops);


### PR DESCRIPTION
## Description

- Adds a full-text search index to the snippets table that we had on the old production DB.
- @remy was reporting performance hits using the new DBs, we identified this as the probable culprit.
- The snippets table we're applying this too is pretty hefty, but as we're not writing to it it shouldn't be an issue.

## Issue(s)

Fixes #ENG-985

## How to test

1. Once applied to production, test the transcripts API route on the Open API.
