### PR TITLE
test: add @common-auth strategy to e2e tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ pnpm test-e2e
 
 Our Playwright tests are organised with tags:
 
-- `@authenticated`: Tests with this tag use a pre-created test user, reused without cleanup between tests.
+- `@common-auth`: Tests with this tag use the same test user ("typical" persona). Test run concurrently so shouldn't modify user state.
 - `@openai`: Indicates that the test calls the OpenAI API without a mock. These are excluded from CI runs due to potential slowness, flakiness, or expense. We aim to use mocks for these tests in the future.
 
 ### Testing in VSCode

--- a/apps/nextjs/playwright.config.ts
+++ b/apps/nextjs/playwright.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
         ...devices["Desktop Chrome"],
         storageState: "tests-e2e/.auth/user.json",
       },
-      dependencies: ["auth-setup"],
+      dependencies: ["setup", "auth-setup"],
     },
   ],
   reporter: process.env.CI

--- a/apps/nextjs/playwright.config.ts
+++ b/apps/nextjs/playwright.config.ts
@@ -9,27 +9,27 @@ export default defineConfig({
       testMatch: "global.setup.ts",
     },
     {
-      name: "auth-setup",
-      testMatch: "ui-auth.setup.ts",
+      name: "common-auth",
+      testMatch: "common-auth.setup.ts",
       dependencies: ["setup"],
     },
     {
-      name: "public",
-      grepInvert: /@authenticated/,
+      name: "individually-authenticated",
+      grepInvert: /@common-auth/,
       use: {
         ...devices["Desktop Chrome"],
       },
       dependencies: ["setup"],
     },
     {
-      name: "authenticated",
-      grep: /@authenticated/,
+      name: "common-authenticated",
+      grep: /@common-auth/,
 
       use: {
         ...devices["Desktop Chrome"],
-        storageState: "tests-e2e/.auth/user.json",
+        storageState: "tests-e2e/.auth/common-user.json",
       },
-      dependencies: ["auth-setup"],
+      dependencies: ["common-auth"],
     },
   ],
   reporter: process.env.CI
@@ -39,6 +39,8 @@ export default defineConfig({
     trace: "retain-on-failure",
   },
   retries: process.env.CI ? 1 : 0,
+  maxFailures: process.env.CI ? 10 : undefined,
+  workers: process.env.NODE_ENV === "development" ? 5 : undefined,
   outputDir: "./tests-e2e/test-results",
   forbidOnly: process.env.CI === "true",
 });

--- a/apps/nextjs/playwright.config.ts
+++ b/apps/nextjs/playwright.config.ts
@@ -29,7 +29,7 @@ export default defineConfig({
         ...devices["Desktop Chrome"],
         storageState: "tests-e2e/.auth/user.json",
       },
-      dependencies: ["setup", "auth-setup"],
+      dependencies: ["auth-setup"],
     },
   ],
   reporter: process.env.CI

--- a/apps/nextjs/tests-e2e/config/common-auth.setup.ts
+++ b/apps/nextjs/tests-e2e/config/common-auth.setup.ts
@@ -1,0 +1,28 @@
+import { Page, test as setup } from "@playwright/test";
+import path from "path";
+
+import { prepareUser } from "../helpers/auth";
+import { bypassVercelProtection } from "../helpers/vercel";
+import { TEST_BASE_URL } from "./config";
+
+const authFile = path.join(__dirname, "../.auth/common-user.json");
+
+const setTestChatIdCookie = async (page: Page, chatId: string | undefined) => {
+  await page.context().addCookies([
+    {
+      url: TEST_BASE_URL,
+      name: "typicalChatId",
+      value: chatId || "",
+    },
+  ]);
+};
+
+setup("prepare common user with 'typical' variant", async ({ page }) => {
+  await bypassVercelProtection(page);
+  await page.context().clearCookies();
+
+  const login = await prepareUser(page, "typical");
+
+  await setTestChatIdCookie(page, login.chatId);
+  await page.context().storageState({ path: authFile });
+});

--- a/apps/nextjs/tests-e2e/tests/aila-chat/auth.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/auth.test.ts
@@ -12,7 +12,7 @@ test.describe("Unauthenticated", () => {
   });
 });
 
-test.describe("Authenticated", { tag: "@authenticated" }, () => {
+test.describe("Authenticated", { tag: "@common-auth" }, () => {
   test("navigate to /aila as a signed-in user", async ({ page }) => {
     await bypassVercelProtection(page);
     await setupClerkTestingToken({ page });

--- a/apps/nextjs/tests-e2e/tests/aila-chat/downloads.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/downloads.test.ts
@@ -1,51 +1,62 @@
-import { test, expect } from "@playwright/test";
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
+import { test, expect, Page } from "@playwright/test";
 
 import { TEST_BASE_URL } from "../../config/config";
-import { prepareUser } from "../../helpers/auth";
 import { bypassVercelProtection } from "../../helpers/vercel";
 import { isFinished } from "./helpers";
 
-test("Downloading a completed lesson plan", async ({ page }) => {
-  test.slow();
+const getTestChatIdFromCookie = async (page: Page) => {
+  const cookies = await page.context().cookies();
+  const chatId = cookies.find((c) => c.name === "typicalChatId")?.value;
+  return chatId;
+};
 
-  await test.step("Setup", async () => {
-    await bypassVercelProtection(page);
-    const { chatId } = await prepareUser(page, "typical");
+test(
+  "Downloading a completed lesson plan",
+  { tag: "@common-auth" },
+  async ({ page }) => {
+    test.slow();
 
-    await page.goto(`${TEST_BASE_URL}/aila/${chatId}`);
-    await isFinished(page);
-  });
+    await test.step("Setup", async () => {
+      await bypassVercelProtection(page);
+      await setupClerkTestingToken({ page });
 
-  await test.step("Go to downloads page", async () => {
-    // Open 'download resources' menu
-    const downloadResources = page.getByTestId("chat-download-resources");
-    await downloadResources.click();
-    page.waitForURL(/aila\/.*\/download/);
-    page.getByRole("heading", { name: "Download resources" });
+      const chatId = await getTestChatIdFromCookie(page);
+      await page.goto(`${TEST_BASE_URL}/aila/${chatId}`);
+      await isFinished(page);
+    });
 
-    // Click to download lesson plan
-    const downloadLessonPlan = page.getByTestId("chat-download-lesson-plan");
-    await downloadLessonPlan.click();
+    await test.step("Go to downloads page", async () => {
+      // Open 'download resources' menu
+      const downloadResources = page.getByTestId("chat-download-resources");
+      await downloadResources.click();
+      page.waitForURL(/aila\/.*\/download/);
+      page.getByRole("heading", { name: "Download resources" });
 
-    // Skip feedback form
-    if (await page.getByLabel("Skip").isVisible()) {
-      await page.getByLabel("Skip").click();
-    }
+      // Click to download lesson plan
+      const downloadLessonPlan = page.getByTestId("chat-download-lesson-plan");
+      await downloadLessonPlan.click();
 
-    // Generating
-    await expect(downloadLessonPlan).toContainText(
-      "Generating Lesson plan for export",
-      { ignoreCase: true },
-    );
+      // Skip feedback form
+      if (await page.getByLabel("Skip").isVisible()) {
+        await page.getByLabel("Skip").click();
+      }
 
-    // Generated
-    await expect(downloadLessonPlan).toContainText(
-      "Download lesson plan (.docx)",
-      { ignoreCase: true, timeout: 30000 },
-    );
-    await expect(downloadLessonPlan).toContainText(
-      "Download Lesson plan (.pdf)",
-      { ignoreCase: true },
-    );
-  });
-});
+      // Generating
+      await expect(downloadLessonPlan).toContainText(
+        "Generating Lesson plan for export",
+        { ignoreCase: true },
+      );
+
+      // Generated
+      await expect(downloadLessonPlan).toContainText(
+        "Download lesson plan (.docx)",
+        { ignoreCase: true, timeout: 30000 },
+      );
+      await expect(downloadLessonPlan).toContainText(
+        "Download Lesson plan (.pdf)",
+        { ignoreCase: true },
+      );
+    });
+  },
+);

--- a/apps/nextjs/tests-e2e/tests/aila-chat/flexible-prompt-live.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/flexible-prompt-live.test.ts
@@ -7,52 +7,50 @@ import { continueChat, isFinished, waitForGeneration } from "./helpers";
 
 const generationTimeout = 75000;
 
-test.describe("Authenticated", { tag: "@authenticated" }, () => {
-  test(
-    "Aila flow with live OpenAI",
-    // This test calls OpenAI rather than fixtures, so we don't want to include it in CI
-    { tag: "@openai" },
-    async ({ page }) => {
-      test.setTimeout(generationTimeout * 5);
+test(
+  "Aila flow with live OpenAI",
+  // This test calls OpenAI rather than fixtures, so we don't want to include it in CI
+  { tag: ["@openai", "@common-auth"] },
+  async ({ page }) => {
+    test.setTimeout(generationTimeout * 5);
 
-      await test.step("Setup", async () => {
-        await clerkSetup();
-        await bypassVercelProtection(page);
-        await setupClerkTestingToken({ page });
+    await test.step("Setup", async () => {
+      await clerkSetup();
+      await bypassVercelProtection(page);
+      await setupClerkTestingToken({ page });
 
-        await page.goto(`${TEST_BASE_URL}/aila`);
-        await expect(page.getByTestId("chat-h1")).toBeInViewport();
-      });
+      await page.goto(`${TEST_BASE_URL}/aila`);
+      await expect(page.getByTestId("chat-h1")).toBeInViewport();
+    });
 
-      await test.step("Fill in the chat box", async () => {
-        const textbox = page.getByTestId("chat-input");
-        const sendMessage = page.getByTestId("send-message");
-        const message =
-          "Create a KS1 lesson on the Romans, create the whole lesson without asking me any questions. As short as possible.";
-        await textbox.fill(message);
-        await expect(textbox).toContainText(message);
+    await test.step("Fill in the chat box", async () => {
+      const textbox = page.getByTestId("chat-input");
+      const sendMessage = page.getByTestId("send-message");
+      const message =
+        "Create a KS1 lesson on the Romans, create the whole lesson without asking me any questions. As short as possible.";
+      await textbox.fill(message);
+      await expect(textbox).toContainText(message);
 
-        // TODO: the demo status doesn't seem to have been loaded yet so a demo modal is shown
-        await page.waitForTimeout(500);
+      // TODO: the demo status doesn't seem to have been loaded yet so a demo modal is shown
+      await page.waitForTimeout(500);
 
-        await sendMessage.click();
-      });
+      await sendMessage.click();
+    });
 
-      await test.step("Iterate through the lesson plan", async () => {
-        await page.waitForURL(/\/aila\/.+/);
+    await test.step("Iterate through the lesson plan", async () => {
+      await page.waitForURL(/\/aila\/.+/);
+      await waitForGeneration(page, generationTimeout);
+
+      for (let i = 0; i < 12; i++) {
+        await continueChat(page);
         await waitForGeneration(page, generationTimeout);
-
-        for (let i = 0; i < 12; i++) {
-          await continueChat(page);
-          await waitForGeneration(page, generationTimeout);
-          if (await isFinished(page)) {
-            break;
-          }
-          if (i === 11) {
-            throw new Error("Failed to finish the lesson plan after 12 tries");
-          }
+        if (await isFinished(page)) {
+          break;
         }
-      });
-    },
-  );
-});
+        if (i === 11) {
+          throw new Error("Failed to finish the lesson plan after 12 tries");
+        }
+      }
+    });
+  },
+);

--- a/apps/nextjs/tests-e2e/tests/aila-chat/full-romans.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/full-romans.test.ts
@@ -35,8 +35,10 @@ const applyFixtures = async (page: Page) => {
   };
 };
 
-test.describe("Authenticated", { tag: "@authenticated" }, () => {
-  test("Full aila flow with Romans fixture", async ({ page }) => {
+test(
+  "Full aila flow with Romans fixture",
+  { tag: "@common-auth" },
+  async ({ page }) => {
     const generationTimeout = FIXTURE_MODE === "record" ? 75000 : 50000;
     test.setTimeout(generationTimeout * 5);
 
@@ -98,5 +100,5 @@ test.describe("Authenticated", { tag: "@authenticated" }, () => {
 
       await isFinished(page);
     });
-  });
-});
+  },
+);

--- a/apps/nextjs/tests-e2e/tests/aila-chat/helpers.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/helpers.ts
@@ -2,7 +2,7 @@ import { expect, Page } from "@playwright/test";
 
 export async function waitForGeneration(page: Page, generationTimeout: number) {
   const loadingElement = page.getByTestId("chat-stop");
-  await expect(loadingElement).toBeVisible();
+  await expect(loadingElement).toBeVisible({ timeout: 10000 });
   await expect(loadingElement).not.toBeVisible({ timeout: generationTimeout });
 }
 

--- a/apps/nextjs/tests-e2e/tests/auth.test.ts
+++ b/apps/nextjs/tests-e2e/tests/auth.test.ts
@@ -1,11 +1,12 @@
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
-import { Page, expect, test as setup } from "@playwright/test";
-import path from "path";
+import { Page, expect, test } from "@playwright/test";
 
+import {
+  TEST_USER_EMAIL,
+  TEST_USER_PASSWORD,
+  TEST_BASE_URL,
+} from "../config/config";
 import { bypassVercelProtection } from "../helpers/vercel";
-import { TEST_USER_EMAIL, TEST_USER_PASSWORD, TEST_BASE_URL } from "./config";
-
-const authFile = path.join(__dirname, "../.auth/user.json");
 
 async function signInThroughUI(page: Page) {
   if (!TEST_USER_EMAIL || !TEST_USER_PASSWORD) {
@@ -29,7 +30,7 @@ async function signInThroughUI(page: Page) {
   await page.getByRole("button", { name: "Continue", exact: true }).click();
 }
 
-setup("authenticate through UI setup", async ({ page }) => {
+test("authenticate through Clerk UI", async ({ page }) => {
   await bypassVercelProtection(page);
 
   await page.context().clearCookies();
@@ -45,6 +46,4 @@ setup("authenticate through UI setup", async ({ page }) => {
   await signInThroughUI(page);
 
   await page.waitForURL(TEST_BASE_URL);
-
-  await page.context().storageState({ path: authFile });
 });

--- a/apps/nextjs/tests-e2e/tests/quiz-designer.test.ts
+++ b/apps/nextjs/tests-e2e/tests/quiz-designer.test.ts
@@ -6,7 +6,7 @@ import { bypassVercelProtection } from "../helpers/vercel";
 
 test(
   "navigate to /quiz-designer as a signed-in user",
-  { tag: "@authenticated" },
+  { tag: "@common-auth" },
   async ({ page }) => {
     await bypassVercelProtection(page);
     await setupClerkTestingToken({ page });


### PR DESCRIPTION
## Description

Our older e2e tests sign in by manually typing test credentials into the sign in form. We have a new approach which generates test users and signed them in through the clerk API. This PR brings those older tests in line with our new approach

- Keep the existing `@authenticated` setup step, but rename it to `@common-auth` as other tests can still authenticate individually
  - Call `prepareUser` from the common auth setup step
  - Save the chatId from prepareUser to a cookie, so individual tests can retrieve it and test against a completed chat
- Create a new auth.test.ts test file which goes through a clerk login manually
- Remove unnecessary `test.describe` wrappers as they add noise the test UI
- Set maximum concurrent workers to 5 in development. I found testing this that pressing the big green button in testflight can spam the dev server a bit too much

NOTE: This PR is branched off #179, so the base will change when that gets merged
