### PR TITLE
fix: return a 400 for invalid input to middleware

### DIFF
--- a/apps/nextjs/src/middleware.ts
+++ b/apps/nextjs/src/middleware.ts
@@ -7,6 +7,11 @@ import { NextMiddleware, NextResponse } from "next/server";
 import { sentryCleanup } from "./lib/sentry/sentryCleanup";
 
 function handleError(error: unknown, extra: Record<string, unknown>): Response {
+  if (error instanceof SyntaxError) {
+    console.error("Handled SyntaxError in nextMiddleware", error);
+    return NextResponse.json({ error: "Bad Request" }, { status: 400 });
+  }
+
   const wrappedError = new Error("Error in nextMiddleware", { cause: error });
   Sentry.captureException(wrappedError, { extra });
 


### PR DESCRIPTION
## Description

At the moment, parsing errors are triggering exceptions which get reported to Sentry. We should be able to assume that any SyntaxError is not an exception and can be handled with a 400 response