### PR TITLE
build: install specific playwright browsers

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -29,7 +29,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
       - name: Install Playwright
-        run: npx playwright install --with-deps
+        run: npx playwright install --with-deps chromium
       - name: Inject Doppler env vars
         uses: dopplerhq/secrets-fetch-action@v1.2.0
         id: doppler


### PR DESCRIPTION
When testing #186 I found that just installing chromium saves us 30 seconds or so in playwright build time. We may as well take that benefit from that (closed) PR