### PR TITLE
test: use html reporter and show popup on failure

### DIFF
--- a/apps/nextjs/playwright.config.ts
+++ b/apps/nextjs/playwright.config.ts
@@ -34,7 +34,7 @@ export default defineConfig({
   ],
   reporter: process.env.CI
     ? [["github"], ["@estruyf/github-actions-reporter"], ["html"]]
-    : "list",
+    : [["list"], ["html"]],
   use: {
     trace: "retain-on-failure",
   },


### PR DESCRIPTION
A small change! It's pretty hard to understand a playwright failure without a screenshot or report. This will pop up the interactive report in development if a test fails. Only when running `test-e2e`, not `test-e2e-ui`