### PR TITLE
fix: sanitize file names before downloading

### DIFF
--- a/apps/nextjs/src/app/api/aila-download-all/route.ts
+++ b/apps/nextjs/src/app/api/aila-download-all/route.ts
@@ -8,6 +8,8 @@ import { PassThrough } from "stream";
 
 import { withSentry } from "@/lib/sentry/withSentry";
 
+import { sanitizeFilename } from "../sanitizeFilename";
+
 type FileIdsAndFormats = {
   fileId: string;
   formats: ReadonlyArray<"pptx" | "docx" | "pdf">;
@@ -183,10 +185,12 @@ async function getHandler(req: Request): Promise<Response> {
 
   await kv.set(taskId, "complete");
 
+  const sanitizedLessonTitle = sanitizeFilename(lessonTitle);
+
   return new Response(readableStream, {
     status: 200,
     headers: new Headers({
-      "content-disposition": `attachment; filename=aila: ${lessonTitle} all resources.zip`,
+      "content-disposition": `attachment; filename=aila: ${sanitizedLessonTitle} all resources.zip`,
       "content-type": "application/zip",
     }),
   });

--- a/apps/nextjs/src/app/api/aila-download/route.ts
+++ b/apps/nextjs/src/app/api/aila-download/route.ts
@@ -5,6 +5,8 @@ import * as Sentry from "@sentry/node";
 
 import { withSentry } from "@/lib/sentry/withSentry";
 
+import { sanitizeFilename } from "../sanitizeFilename";
+
 // From: https://www.ericburel.tech/blog/nextjs-stream-files
 async function* nodeStreamToIterator(stream: NodeJS.ReadableStream) {
   for await (const chunk of stream) {
@@ -155,7 +157,8 @@ async function getHandler(req: Request): Promise<Response> {
   const stream = iteratorToStream(iterator);
 
   const shortId = lessonExport.id.slice(-8);
-  const filename = `${lessonTitle} - ${shortId} - ${getReadableExportType(lessonExport.exportType)}`;
+  const sanitizedLessonTitle = sanitizeFilename(lessonTitle);
+  const filename = `${sanitizedLessonTitle} - ${shortId} - ${getReadableExportType(lessonExport.exportType)}`;
 
   return new Response(stream, {
     status: 200,

--- a/apps/nextjs/src/app/api/sanitizeFilename.test.ts
+++ b/apps/nextjs/src/app/api/sanitizeFilename.test.ts
@@ -1,0 +1,11 @@
+import { sanitizeFilename } from "./sanitizeFilename";
+
+describe("sanitizeFilename", () => {
+  test("should remove special characters", () => {
+    const lessonTitle =
+      "The econonomy: Boom or Bust? You decide! Let's start, shall we?";
+    expect(sanitizeFilename(lessonTitle)).toBe(
+      "The econonomy Boom or Bust You decide Lets start shall we",
+    );
+  });
+});

--- a/apps/nextjs/src/app/api/sanitizeFilename.ts
+++ b/apps/nextjs/src/app/api/sanitizeFilename.ts
@@ -1,0 +1,4 @@
+export function sanitizeFilename(filename: string): string {
+  // Allow only alphanumeric characters, spaces, hyphens, and underscores
+  return filename.replace(/[^a-zA-Z0-9 _-]/g, "");
+}


### PR DESCRIPTION
## Description

- Strip out url and filename unfriendly characters from content disposition header when downloading
- Should fix https://oak-national-academy.sentry.io/issues/6482803
- Potentially fixes https://oaknationalacademy.slack.com/archives/C05RYE3JL4S/p1727855976518189
