### PR TITLE
fix: hook error on sign-in page

### DIFF
--- a/apps/nextjs/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/nextjs/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -1,4 +1,9 @@
-import { SignIn } from "@clerk/nextjs";
+"use client";
+
+import { useEffect } from "react";
+
+import { SignIn, SignedIn, SignedOut, useUser } from "@clerk/nextjs";
+import { useRouter } from "next/navigation";
 
 import SignUpSignInLayout from "@/components/SignUpSignInLayout";
 
@@ -8,12 +13,28 @@ const SignInPage = () => {
   return (
     <>
       <SignUpSignInLayout loaded={true}>
-        <SignIn path="/sign-in" routing="path" signUpUrl="/sign-up" />
+        <SignedOut>
+          <SignIn path="/sign-in" routing="path" signUpUrl="/sign-up" />
+        </SignedOut>
+        <SignedIn>
+          <RedirectToHome />
+        </SignedIn>
       </SignUpSignInLayout>
 
       <DetectStuckBannedUser />
     </>
   );
+};
+
+const RedirectToHome = () => {
+  const { user, isLoaded } = useUser();
+  const router = useRouter();
+  useEffect(() => {
+    if (user && isLoaded) {
+      router.push("/");
+    }
+  }, [router, user, isLoaded]);
+  return null;
 };
 
 export default SignInPage;


### PR DESCRIPTION
## Description

- This attempts to fix an issue where the sign in page was rendering with a different number of hooks
- If the user is logged in and visits /sign-in it redirects to /

## Issue(s)

Fixes [Sentry issue 3875705](https://oak-national-academy.sentry.io/issues/3875705/?query=is%3Aunresolved%20issue.priority%3A%5Bhigh%2C%20medium%5D&referrer=issue-stream&statsPeriod=1h&stream_index=0)
