### PR TITLE
fix: revert "fix: revert error to previous protocol (#139)

### DIFF
--- a/apps/nextjs/src/app/api/chat/errorHandling.test.ts
+++ b/apps/nextjs/src/app/api/chat/errorHandling.test.ts
@@ -6,7 +6,10 @@ import { RateLimitExceededError } from "@oakai/core/src/utils/rateLimiting/userB
 import { PrismaClientWithAccelerate } from "@oakai/db";
 import invariant from "tiny-invariant";
 
-import { consumeStream } from "@/utils/testHelpers/consumeStream";
+import {
+  consumeStream,
+  extractStreamMessage,
+} from "@/utils/testHelpers/consumeStream";
 
 import { handleChatException } from "./errorHandling";
 
@@ -35,7 +38,7 @@ describe("handleChatException", () => {
       expect(response.status).toBe(200);
 
       invariant(response.body instanceof ReadableStream);
-      const message = JSON.parse(await consumeStream(response.body));
+      const message = extractStreamMessage(await consumeStream(response.body));
 
       expect(message).toEqual({
         type: "error",
@@ -85,8 +88,7 @@ describe("handleChatException", () => {
       expect(response.status).toBe(200);
 
       const consumed = await consumeStream(response.body as ReadableStream);
-      expect(consumed).toMatch(/^\{/);
-      const message = JSON.parse(consumed);
+      const message = extractStreamMessage(consumed);
 
       expect(message).toEqual({
         type: "error",
@@ -112,7 +114,7 @@ describe("handleChatException", () => {
 
       expect(response.status).toBe(200);
 
-      const message = JSON.parse(
+      const message = extractStreamMessage(
         await consumeStream(response.body as ReadableStream),
       );
       expect(message).toEqual({

--- a/apps/nextjs/src/app/api/chat/protocol.ts
+++ b/apps/nextjs/src/app/api/chat/protocol.ts
@@ -5,7 +5,8 @@ import {
 import { StreamingTextResponse } from "ai";
 
 export function streamingJSON(message: ErrorDocument | ActionDocument) {
-  const errorMessage = JSON.stringify(message);
+  const jsonContent = JSON.stringify(message);
+  const errorMessage = `0:"${jsonContent.replace(/"/g, '\\"')}"`;
 
   const errorEncoder = new TextEncoder();
 

--- a/apps/nextjs/src/utils/testHelpers/consumeStream.ts
+++ b/apps/nextjs/src/utils/testHelpers/consumeStream.ts
@@ -14,3 +14,12 @@ export async function consumeStream(
 
   return result;
 }
+
+export function extractStreamMessage(streamedText: string) {
+  const content = streamedText.match(/0:"(.*)"/);
+  if (!content?.[1]) {
+    throw new Error("No message found in streamed text");
+  }
+  const strippedContent = content[1].replace(/\\"/g, '"');
+  return JSON.parse(strippedContent);
+}


### PR DESCRIPTION
This reverts commit e053b895503d5a29522404ce14e13239b6db7852.

We reverted the protocol changes for error messages like the friendly rate limit message in the Chat. Now that we're using the latest protocol with structured outputs, we need the new version again
