### PR TITLE
test: add a delay after generation to let romans test settle

### DIFF
--- a/apps/nextjs/tests-e2e/tests/aila-chat/full-romans.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/full-romans.test.ts
@@ -1,5 +1,5 @@
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
-import { test, expect } from "@playwright/test";
+import { test, expect, Page } from "@playwright/test";
 
 import { TEST_BASE_URL } from "../../config/config";
 import { bypassVercelProtection } from "../../helpers/vercel";
@@ -18,73 +18,75 @@ import {
 // const FIXTURE_MODE = "record" as FixtureMode;
 const FIXTURE_MODE = "replay" as FixtureMode;
 
-test.describe(() => {
-  // NOTE(2024-10-10): This test is flaky, with the "10 of 10" check often returning 6-8 sections
-  // Remove extra retries when it becomes more stable
-  if (process.env.CI === "true") {
-    test.describe.configure({ retries: 4 });
-  }
+test(
+  "Full aila flow with Romans fixture",
+  { tag: "@common-auth" },
+  async ({ page }, testInfo) => {
+    const generationTimeout = FIXTURE_MODE === "record" ? 75000 : 50000;
+    test.setTimeout(generationTimeout * 5);
 
-  test(
-    "Full aila flow with Romans fixture",
-    { tag: "@common-auth" },
-    async ({ page }) => {
-      const generationTimeout = FIXTURE_MODE === "record" ? 75000 : 50000;
-      test.setTimeout(generationTimeout * 5);
+    // The chat UI has a race condition when you submit a message too quickly after the previous response
+    // This is a temporary fix to fix test flake
+    async function letUiSettle() {
+      return await page.waitForTimeout(testInfo.retry === 0 ? 500 : 6000);
+    }
 
-      await test.step("Setup", async () => {
-        await bypassVercelProtection(page);
-        await setupClerkTestingToken({ page });
+    await test.step("Setup", async () => {
+      await bypassVercelProtection(page);
+      await setupClerkTestingToken({ page });
 
-        await page.goto(`${TEST_BASE_URL}/aila`);
-        await expect(page.getByTestId("chat-h1")).toBeInViewport();
-      });
+      await page.goto(`${TEST_BASE_URL}/aila`);
+      await expect(page.getByTestId("chat-h1")).toBeInViewport();
+    });
 
-      const { setFixture } = await applyLlmFixtures(page, FIXTURE_MODE);
+    const { setFixture } = await applyLlmFixtures(page, FIXTURE_MODE);
 
-      await test.step("Fill in the chat box", async () => {
-        const textbox = page.getByTestId("chat-input");
-        const sendMessage = page.getByTestId("send-message");
-        const message =
-          "Create a KS1 lesson on the end of Roman Britain. Ask a question for each quiz and cycle";
-        await textbox.fill(message);
-        await expect(textbox).toContainText(message);
+    await test.step("Fill in the chat box", async () => {
+      const textbox = page.getByTestId("chat-input");
+      const sendMessage = page.getByTestId("send-message");
+      const message =
+        "Create a KS1 lesson on the end of Roman Britain. Ask a question for each quiz and cycle";
+      await textbox.fill(message);
+      await expect(textbox).toContainText(message);
 
-        // Temporary fix: The test goes quicker than a real user and submits before the demo status has loaded
-        // This means that a demo modal would be shown when submitting
-        await page.waitForTimeout(500);
+      // Temporary fix: The test goes quicker than a real user and submits before the demo status has loaded
+      // This means that a demo modal would be shown when submitting
+      await page.waitForTimeout(500);
 
-        setFixture("roman-britain-1");
-        await sendMessage.click();
-      });
+      setFixture("roman-britain-1");
+      await sendMessage.click();
+    });
 
-      await test.step("Iterate through the fixtures", async () => {
-        await page.waitForURL(/\/aila\/.+/);
-        await waitForGeneration(page, generationTimeout);
-        await expectSectionsComplete(page, 1);
+    await test.step("Iterate through the fixtures", async () => {
+      await page.waitForURL(/\/aila\/.+/);
+      await waitForGeneration(page, generationTimeout);
+      await expectSectionsComplete(page, 1);
+      await letUiSettle();
 
-        setFixture("roman-britain-2");
-        await continueChat(page);
-        await waitForGeneration(page, generationTimeout);
-        await expectSectionsComplete(page, 3);
+      setFixture("roman-britain-2");
+      await continueChat(page);
+      await waitForGeneration(page, generationTimeout);
+      await expectSectionsComplete(page, 3);
+      await letUiSettle();
 
-        setFixture("roman-britain-3");
-        await continueChat(page);
-        await waitForGeneration(page, generationTimeout);
-        await expectSectionsComplete(page, 7);
+      setFixture("roman-britain-3");
+      await continueChat(page);
+      await waitForGeneration(page, generationTimeout);
+      await expectSectionsComplete(page, 7);
+      await letUiSettle();
 
-        setFixture("roman-britain-4");
-        await continueChat(page);
-        await waitForGeneration(page, generationTimeout);
-        await expectSectionsComplete(page, 10);
+      setFixture("roman-britain-4");
+      await continueChat(page);
+      await waitForGeneration(page, generationTimeout);
+      await expectSectionsComplete(page, 10);
+      await letUiSettle();
 
-        setFixture("roman-britain-5");
-        await continueChat(page);
-        await waitForGeneration(page, generationTimeout);
-        await expectSectionsComplete(page, 10);
+      setFixture("roman-britain-5");
+      await continueChat(page);
+      await waitForGeneration(page, generationTimeout);
+      await expectSectionsComplete(page, 10);
 
-        await expectFinished(page);
-      });
-    },
-  );
-});
+      await expectFinished(page);
+    });
+  },
+);


### PR DESCRIPTION
Our end-to-end test for the aila chat with fixtures is regularly failing. It got worse after removing an arbitrary delay before clicking the continue button

Problem:
  - The e2e tests do some things quicker than a typical user, for example the moderation step is a lot quicker. This could cause race conditions which we don't normally see
  - This doesn't mean that there isn't a bug, it could just be a rare one
  - We want tests to be snappy, but also not spend too much time optimising our code for them

Solution:
  - Use a small delay before clicking the continue button
  - If we know that the test run is a retry, assume that the error could have been this race condition and increase the delay before clicking continue

I think we could also look for a different element to indicate that the response is still streaming. I think that the "enqueue while moderating" will be active in these cases, but wouldn't be if we used a different element to determine a streaming response