### PR TITLE
build: deploy playwright reports to Vercel

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -52,30 +52,28 @@ jobs:
           VERCEL_AUTOMATION_BYPASS_SECRET: ${{ secrets.VERCEL_AUTOMATION_BYPASS_SECRET }}
           NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY: ${{ steps.doppler.outputs.NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY }}
           CLERK_SECRET_KEY: ${{ steps.doppler.outputs.CLERK_SECRET_KEY }}
-      - name: Upload Playwright report
-        id: upload-report
-        uses: actions/upload-artifact@v4
+      - name: Deploy Playwright report
+        id: deploy-report
         if: ${{ !cancelled() }}
-        with:
-          name: playwright-report
-          path: apps/nextjs/playwright-report
-          retention-days: 30
+        run: |
+          npx vercel link \
+            --cwd=apps/nextjs/playwright-report \
+            --scope=${{ secrets.TEST_REPORT_VERCEL_SCOPE }} \
+            --project=${{ secrets.TEST_REPORT_VERCEL_PROJECT }} \
+            --yes \
+            --token=${{ secrets.TEST_REPORT_VERCEL_TOKEN }}
+
+          DEPLOYMENT_URL=$(npx vercel deploy --cwd=apps/nextjs/playwright-report --yes --token=${{ secrets.TEST_REPORT_VERCEL_TOKEN }})
+          echo "deployment-url=${DEPLOYMENT_URL}" >> "$GITHUB_OUTPUT"
       - name: Comment PR with playwright report
         uses: thollander/actions-comment-pull-request@v2
         if: ${{ !cancelled() && steps.ref_from_sha.outputs.pr_number }}
         with:
           pr_number: ${{ steps.ref_from_sha.outputs.pr_number }}
           message: |
-            ### Playwright e2e tests
+            ### ${{ steps.run-tests.outcome == 'success' && '✅ Playwright tests passed' || '❌ Playwright tests failed' }}
 
-            [Job summary](https://github.com/oaknational/oak-ai-lesson-assistant/actions/runs/${{github.run_id}})
-
-            [Download report](${{ steps.upload-report.outputs.artifact-url }})
-
-            To view traces locally, unzip the report and run:
-            ```bash
-            npx playwright show-report ~/Downloads/playwright-report
-            ```
+            [View interactive report](${{ steps.deploy-report.outputs.deployment-url }})
           comment_tag: playwright-report
       - name: Upload playwright screenshots
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Description

- Playwright results are viewable in an interactive report. You can see an overview of the run, and the detailed replay of each test including steps, assertions, failures, JS console, network, etc
- This report is static HTML and only works properly when served over HTTP(S)
- We've looked at various ways to host these alongside our test runs, and it looks like just pushing to vercel is the simplest approach. We already have user access etc set up there