### PR TITLE
fix: remove lookbehind in regex for camelcase conversion

### DIFF
--- a/packages/core/src/utils/camelCaseToSentenceCase.ts
+++ b/packages/core/src/utils/camelCaseToSentenceCase.ts
@@ -2,5 +2,5 @@ export function camelCaseToSentenceCase(str: string) {
   return str
     .replace(/([A-Z0-9])/g, " $1") // Insert a space before each uppercase letter or digit
     .replace(/^./, (str) => str.toUpperCase())
-    .replace(/(?<=\s)[A-Z]/g, (str) => str.toLowerCase());
+    .replace(/\s[A-Z]/g, (str) => str.toLowerCase());
 }


### PR DESCRIPTION
## Description

- Fixes an issue where we are using a lookbehind in the regex for camelcase conversion
- This is not supported in all JS runtimes and is not polyfilled

## Issue(s)

Fixes [Sentry issue 8821397](https://oak-national-academy.sentry.io/issues/8821397)
