### PR TITLE
fix: silence unknown part type errors

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-message/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-message/index.tsx
@@ -13,6 +13,7 @@ import {
   PromptDocument,
   StateDocument,
   TextDocument,
+  UnknownDocument,
   parseMessageParts,
 } from "@oakai/aila/src/protocol/jsonPatchProtocol";
 import { isSafe } from "@oakai/core/src/utils/ailaModeration/helpers";
@@ -234,10 +235,14 @@ function ChatMessagePart({
     action: ActionMessagePart,
     moderation: ModerationMessagePart,
     id: IdMessagePart,
-  }[part.document.type];
+    unknown: UnknownMessagePart,
+  }[part.document.type] as React.ComponentType<{
+    part: typeof part.document;
+    moderationModalHelpers: ModerationModalHelpers;
+  }>;
 
   if (!PartComponent) {
-    console.log("Unknown part type", part.document.type, part); // eslint-disable-line no-console
+    console.log("Unknown part type", part.document.type, JSON.stringify(part)); // eslint-disable-line no-console
     return null;
   }
 
@@ -308,6 +313,11 @@ function ActionMessagePart({
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   part,
 }: Readonly<{ part: ActionDocument }>) {
+  return null;
+}
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+function UnknownMessagePart({ part }: Readonly<{ part: UnknownDocument }>) {
   return null;
 }
 


### PR DESCRIPTION
## Description

- We have a very chatty error on Sentry due to the "unknown" part type. 15k requests per 30 days. This silences these errors since the "unknown" occurs during streaming and part validation before a type is detected.

## Issue(s)

Fixes [Sentry 3220470](https://oak-national-academy.sentry.io/share/issue/52bd3813ca0e4b8aa404fcc034b83fc6/)

