### PR TITLE
test: skip auth test failing from missing test@ account

### DIFF
--- a/apps/nextjs/tests-e2e/tests/auth.test.ts
+++ b/apps/nextjs/tests-e2e/tests/auth.test.ts
@@ -30,7 +30,7 @@ async function signInThroughUI(page: Page) {
   await page.getByRole("button", { name: "Continue", exact: true }).click();
 }
 
-test("authenticate through Clerk UI", async ({ page }) => {
+test.skip("authenticate through Clerk UI", async ({ page }) => {
   await bypassVercelProtection(page);
 
   await page.context().clearCookies();


### PR DESCRIPTION
When we had clerk issues, we deleted a number of accounts in the development environment. One of those was the account used for this test. Until we reinstate it or make the test more useful, we can skip it and get green test runs in our PRs