### PR TITLE
fix: spacing on onboarding upgrade screen [AI-500]

### DIFF
--- a/apps/nextjs/src/components/Onboarding/LegacyUpgradeNotice.tsx
+++ b/apps/nextjs/src/components/Onboarding/LegacyUpgradeNotice.tsx
@@ -10,7 +10,7 @@ export const LegacyUpgradeNotice = () => {
     <SignUpSignInLayout loaded>
       <OakBox
         $mh="auto"
-        $ml="space-between-l"
+        $ml={[null, "space-between-l"]}
         $borderRadius="border-radius-m"
         $background="white"
         $pa="inner-padding-xl2"


### PR DESCRIPTION
This page isn't seen often and didn't get updated for mobile

Before:
<img width="211" alt="Screenshot 2024-09-05 at 12 03 49" src="https://github.com/user-attachments/assets/9555ba79-8e60-429c-8bb6-b29d3d53531a">
After:
![CleanShot 2024-10-15 at 16 57 49@2x](https://github.com/user-attachments/assets/3949f0f0-520d-4080-964d-a28201b554e8)
