### PR TITLE
fix: support data: protocol in CSP

### DIFF
--- a/apps/nextjs/src/middlewares/csp.ts
+++ b/apps/nextjs/src/middlewares/csp.ts
@@ -146,6 +146,7 @@ export const buildCspHeaders = (nonce: string, config: CspConfig) => {
       "'self'",
       "gstatic-fonts.thenational.academy",
       "fonts.gstatic.com",
+      "data:",
     ],
     "object-src": ["'none'"],
     "base-uri": ["'self'"],


### PR DESCRIPTION
## Description

- Microsoft Edge sometimes blocks fonts with the data: protocol
- This adds data: to the allow-list for font-src

## Issue(s)

Fixes [Sentry 414312](https://oak-national-academy.sentry.io/issues/414312/events/f6cc4a229235477dacf3702fd8610170/)
