### PR TITLE
fix: attempt to allow cloudinary images more explicitly

### DIFF
--- a/apps/nextjs/src/middlewares/csp.ts
+++ b/apps/nextjs/src/middlewares/csp.ts
@@ -139,6 +139,7 @@ export const buildCspHeaders = (nonce: string, config: CspConfig) => {
       "data:",
       "https://img.clerk.com",
       "https://res.cloudinary.com",
+      "https://res.cloudinary.com/oak-web-application/image/upload/",
       "https://*.hubspot.com",
       "https://*.hsforms.com",
     ],


### PR DESCRIPTION
## Description

- In some cases we see Cloudinary images being blocked by CSP, so this attempts to add a more specific line to see if it resolves it

## Issue(s)

[549118](https://oak-national-academy.sentry.io/issues/549118/events/6e932464d02f434aacea7ea8c4680c61)

