### PR TITLE
chore: remove chat `sharePath`

### DIFF
--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -580,7 +580,6 @@ export const chatSchema = z
     title: z.string(),
     userId: z.string(),
     lessonPlan: LessonPlanSchemaWhilstStreaming,
-    sharePath: z.string().optional(), // deprecated, will remove after migration
     isShared: z.boolean().optional(),
     createdAt: z.union([z.date(), z.number()]),
     startingMessage: z.string().optional(),
@@ -612,7 +611,6 @@ export const chatSchemaWithMissingMessageIds = z
     title: z.string(),
     userId: z.string(),
     lessonPlan: LessonPlanSchemaWhilstStreaming,
-    sharePath: z.string().optional(), // deprecated, will remove after migration
     isShared: z.boolean().optional(),
     createdAt: z.union([z.date(), z.number()]),
     startingMessage: z.string().optional(),

--- a/packages/db/prisma/migrations/20241016122132_remove_chat_sharepath/migration.sql
+++ b/packages/db/prisma/migrations/20241016122132_remove_chat_sharepath/migration.sql
@@ -1,0 +1,6 @@
+/*
+  This migration removes the redundant `sharePath` proprty from the output column from the `app_sessions` table.
+*/
+UPDATE app_sessions
+SET output = output - 'sharePath'
+WHERE output ? 'sharePath';


### PR DESCRIPTION
## Description

- adds a migration to remove `sharePath` from app_sessions.output
- removes sharePath from associated schema/types
