### PR TITLE
test: check streaming status directly

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-lhs-header.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-lhs-header.tsx
@@ -2,6 +2,8 @@ import React from "react";
 
 import { useRouter } from "#next/navigation";
 
+import { useLessonChat } from "@/components/ContextProviders/ChatProvider";
+
 import AiIcon from "../../AiIcon";
 import ChatButton from "./ui/chat-button";
 
@@ -17,10 +19,19 @@ const ChatLhsHeader = ({
   isDemoUser,
 }: Readonly<ChatLhsHeaderProps>) => {
   const router = useRouter();
+  const chat = useLessonChat();
 
   return (
     <>
       <div className="mt-6 hidden items-center justify-end gap-5 sm:flex">
+        {process.env.NEXT_PUBLIC_ENVIRONMENT !== "production" && (
+          <div
+            className="flex-grow text-left text-xs"
+            data-testid="chat-aila-streaming-status"
+          >
+            {chat.ailaStreamingStatus}
+          </div>
+        )}
         <ChatButton
           variant="secondary"
           onClick={() => {

--- a/apps/nextjs/tests-e2e/tests/aila-chat/helpers.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/helpers.ts
@@ -1,10 +1,20 @@
 import { expect, Page, test } from "@playwright/test";
 
+import { AilaStreamingStatus } from "@/components/AppComponents/Chat/Chat/hooks/useAilaStreamingStatus";
+
+export async function expectStreamingStatus(
+  page: Page,
+  status: AilaStreamingStatus,
+  args?: { timeout: number },
+) {
+  const statusElement = page.getByTestId("chat-aila-streaming-status");
+  await expect(statusElement).toHaveText(status, args);
+}
+
 export async function waitForGeneration(page: Page, generationTimeout: number) {
   return await test.step("Wait for generation", async () => {
-    const loadingElement = page.getByTestId("chat-stop");
-    await expect(loadingElement).toBeVisible({ timeout: 10000 });
-    await expect(loadingElement).not.toBeVisible({
+    await expectStreamingStatus(page, "RequestMade");
+    await expectStreamingStatus(page, "Idle", {
       timeout: generationTimeout,
     });
   });

--- a/apps/nextjs/tests-e2e/tests/banned-users.test.ts
+++ b/apps/nextjs/tests-e2e/tests/banned-users.test.ts
@@ -3,7 +3,7 @@ import { test, expect } from "@playwright/test";
 import { TEST_BASE_URL } from "../config/config";
 import { prepareUser } from "../helpers/auth";
 import { bypassVercelProtection } from "../helpers/vercel";
-import { applyLlmFixtures } from "./aila-chat/helpers";
+import { applyLlmFixtures, expectStreamingStatus } from "./aila-chat/helpers";
 
 const TOXIC_TAG = "mod:tox";
 
@@ -36,9 +36,7 @@ test("Users are banned after 3 toxic lessons", async ({ page }) => {
 
   await test.step("Wait for streaming", async () => {
     await page.waitForURL(/\/aila\/.+/);
-
-    const loadingElement = page.getByTestId("chat-stop");
-    await expect(loadingElement).toBeVisible({ timeout: 10000 });
+    await expectStreamingStatus(page, "RequestMade", { timeout: 10000 });
   });
 
   await test.step("Check account locked", async () => {


### PR DESCRIPTION
In #247 @stefl introduced a useful element on screen to show the streaming state. We can use this for more reliable e2e testing

This PR just adds that early and updates the test helpers