### PR TITLE
test: delete the oldest test user when creating a new one

### DIFF
--- a/packages/api/src/router/testSupport/prepareUser.ts
+++ b/packages/api/src/router/testSupport/prepareUser.ts
@@ -1,4 +1,5 @@
 import { clerkClient } from "@clerk/nextjs/server";
+import { waitUntil } from "@vercel/functions";
 import os from "os";
 import { z } from "zod";
 
@@ -71,6 +72,27 @@ const generateEmailAddress = (personaName: keyof typeof personas) => {
   return `${parts.join("+")}@thenational.academy`;
 };
 
+const deleteLastUsedTestUser = async () => {
+  const users = await clerkClient.users.getUserList({
+    orderBy: "+last_active_at",
+    limit: 500,
+  });
+
+  const NUMBERS_USER = /\d{5,10}.*@/; // jim+010203@thenational.academy
+  const lastUsedTestUser = users.data.find((u) => {
+    const email = u.primaryEmailAddress?.emailAddress ?? "";
+    return email.startsWith("test+") || email.match(NUMBERS_USER);
+  });
+
+  if (lastUsedTestUser) {
+    console.log(
+      "Deleting oldest test user",
+      lastUsedTestUser.primaryEmailAddress?.emailAddress,
+    );
+    await clerkClient.users.deleteUser(lastUsedTestUser.id);
+  }
+};
+
 const findOrCreateUser = async (
   email: string,
   personaName: keyof typeof personas,
@@ -108,6 +130,8 @@ const findOrCreateUser = async (
       region: persona.region,
     },
   });
+
+  waitUntil(deleteLastUsedTestUser());
 
   return newUser;
 };


### PR DESCRIPTION
Clerk has a 500 user limit in development, and test accounts are starting to fill it up

This PR updates the test user logic so that we delete the oldest test user whenever we have to create a new one. If for some reason an old PR is hanging around and its test users were deleted, it will silently recreate anyway

Example test emails include:
`test+......@thenational.academy`
`010203@thenational.academy`
`jimmy+02013@thenational.academy`

Old test users are determined based on the last sign in date