### PR TITLE
chore: add no-console to eslint

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -12,4 +12,7 @@ module.exports = {
   },
   plugins: ["@typescript-eslint"],
   extends: ["plugin:@typescript-eslint/recommended"],
+  rules: {
+    "no-console": "error"
+  }
 };

--- a/apps/nextjs/src/env/client.mjs
+++ b/apps/nextjs/src/env/client.mjs
@@ -1,4 +1,6 @@
 // @ts-check
+
+/* eslint no-console: "off" */
 import { clientEnv, clientSchema } from "./schema.mjs";
 
 const _clientEnv = clientSchema.safeParse(clientEnv);

--- a/apps/nextjs/src/env/server.mjs
+++ b/apps/nextjs/src/env/server.mjs
@@ -1,10 +1,13 @@
 // @ts-check
+
+/* eslint no-console: "off" */
+
 /**
  * This file is included in `/next.config.mjs` which ensures the app isn't built with invalid env vars.
  * It has to be a `.mjs`-file to be imported there.
  */
-import { serverSchema } from "./schema.mjs";
 import { env as clientEnv, formatErrors } from "./client.mjs";
+import { serverSchema } from "./schema.mjs";
 
 const _serverEnv = serverSchema.safeParse(process.env);
 

--- a/apps/nextjs/src/utils/useClientSideFeatureFlag.ts
+++ b/apps/nextjs/src/utils/useClientSideFeatureFlag.ts
@@ -1,6 +1,10 @@
 import { useEffect, useState } from "react";
 
+import { aiLogger } from "@oakai/logger";
+
 import useAnalytics from "@/lib/analytics/useAnalytics";
+
+const log = aiLogger("feature-flags");
 
 export function useClientSideFeatureFlag(flag: string): boolean {
   const { posthogAiBetaClient: client } = useAnalytics();
@@ -11,7 +15,7 @@ export function useClientSideFeatureFlag(flag: string): boolean {
     const isDebug = process.env.NEXT_PUBLIC_POSTHOG_DEBUG === "true";
 
     if (isDebug) {
-      console.info(`Feature flag ${flag} is enabled in debug mode`);
+      log.info(`Feature flag ${flag} is enabled in debug mode`);
       setFeatureEnabled(true);
     } else {
       return client.onFeatureFlags(() => {

--- a/packages/logger/.eslintrc.cjs
+++ b/packages/logger/.eslintrc.cjs
@@ -1,0 +1,7 @@
+/** @type {import("eslint").Linter.Config} */
+module.exports = {
+  extends: ["../../.eslintrc.cjs"],
+  rules: {
+    "no-console": "off",
+  },
+};


### PR DESCRIPTION
Now that we have a centralised logger #244, it will be useful to have a reminder about using the right log


@stefl I know you're hard at work on your PR, and I don't mind updating this PR after that's merged to avoid a conflict