### PR TITLE
fix: remove lessonReferences from prompt

### DIFF
--- a/packages/core/src/prompts/lesson-assistant/parts/interactingWithTheUser.ts
+++ b/packages/core/src/prompts/lesson-assistant/parts/interactingWithTheUser.ts
@@ -67,11 +67,6 @@ This may be indicative of an application error.
 For instance, if you have a lesson plan with all sections complete up until the exitQuiz, except for cycle1, this is indicative of an error and you should generate cycle1 again.
 Always trust the supplied lesson plan over the provided message history, because this represents the state of the lesson plan as it currently stands.`,
 
-    hasRelevantLessons
-      ? `* INCLUDING REFERENCES TO OTHER LESSON PLANS
-If the lessonReferences attribute is blank on the lesson plan, send a patch to add the lessonReferences attribute to the lesson plan and include the list of relevant lesson plan IDs in the value.`
-      : undefined,
-
     `OPTIONAL: STEP 1 ENSURE THAT YOU HAVE THE CORRECT CONTEXT
 In most scenarios you will be provided with title, keyStage, subject, topic (optionally)in the lesson plan.
 If they are not present, ask the user for them.

--- a/packages/core/src/prompts/lesson-assistant/parts/lessonComplete.ts
+++ b/packages/core/src/prompts/lesson-assistant/parts/lessonComplete.ts
@@ -2,7 +2,7 @@ export const lessonComplete = () => `ONCE THE LESSON IS COMPLETE
 The lesson is complete when all of the keys have values. Until then it is still in a draft state.
 If the user chooses to have a consistency check, go through the whole lesson, key by key to make sure that the lesson is consistent, that each key is present and is filled out correctly, that the spelling is correct, that the capitalisation is correct, and that the lesson is of high quality.
 Ensure that the title of the lesson now matches closely with the learning and objectives of the lesson.
-Each of these keys in the lesson plan should have a value and valid content: title, subject, topic, keyStage, basedOn, lessonReferences, learningOutcome, learningCycles, priorKnowledge, keyLearningPoints, misconceptions, keywords, starterQuiz, cycle1, cycle2, cycle3, exitQuiz, additionalMaterials.
+Each of these keys in the lesson plan should have a value and valid content: title, subject, topic, keyStage, basedOn, learningOutcome, learningCycles, priorKnowledge, keyLearningPoints, misconceptions, keywords, starterQuiz, cycle1, cycle2, cycle3, exitQuiz, additionalMaterials.
 If you find any missing sections or issues with any of the sections, you should respond with a JSON PATCH document that corrects the issue.
 There is a common problem where the Starter Quiz questions are not testing the correct knowledge.
 Sometimes, the quiz contains questions that test the content that will be delivered within the lesson, rather than the content that the pupils should have learnt from the previous lesson.


### PR DESCRIPTION
## Description

`lessonReferences` isn't in the schema, so this removes it from the prompt.

See this from an example bug it has caused:

```json
{
    "type": "patch",
    "reasoning": "Including the relevant lesson plan IDs to provide context for the user.",
    "value": {
        "type": "string-array",
        "op": "add",
        "path": "/learningCycles",
        "value": [
            "F63JsTLhsw-dKUs1yPf9m",
            "r1F76TUL4kA2glhwMQD08",
            "oanlozx7p8fLgQHSPHEkf",
            "dibWRSkTYzld4sxuJF-kD",
            "7kytsvMjNGEdlVTPrW16H"
        ]
    }
}
```

