### PR TITLE
fix: report chat completion errors

### DIFF
--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -47,6 +47,9 @@ export class AilaStreamHandler {
       this._isStreaming = false;
       try {
         await this._chat.complete();
+      } catch (e) {
+        this._chat.aila.errorReporter?.reportError(e);
+        throw new AilaChatError("Chat completion failed", { cause: e });
       } finally {
         this.closeController();
       }


### PR DESCRIPTION
My local e2e test for banned users has been broken. After lots of divide-and-conquer console.logs, I found that the cause was a problem connecting to my local inngest when handling a toxic moderation. As soon the code made that call, the following lines weren't executing

It turns out that errors thrown in `chat.complete` are being swallowed. This PR makes sure they get logged, and that they're reported to Sentry

### Testing

Check out main, and throw an error in [AilaChat.complete](https://github.com/oaknational/oak-ai-lesson-assistant/blob/c4d85cc46c914c452947f62ee253d9ee5a025e71/packages/aila/src/core/chat/AilaChat.ts#L356). You should see that it stops the completion and doesn't report an error

Try the same on this branch and see an error in the log