### PR TITLE
fix: reinstate prebuilding the chat route in local dev

### DIFF
--- a/apps/nextjs/src/app/api/chat/route.ts
+++ b/apps/nextjs/src/app/api/chat/route.ts
@@ -10,4 +10,10 @@ async function postHandler(req: NextRequest): Promise<Response> {
   return handleChatPostRequest(req, config);
 }
 
+async function getHandler(): Promise<Response> {
+  return new Response("Server is ready", { status: 200 });
+}
+
 export const POST = withSentry(postHandler);
+
+export const GET = withSentry(getHandler);


### PR DESCRIPTION
## Description

- Adds a GET route to /chat for the purposes of warming it up in local dev
