### PR TITLE
chore: hide generated fixtures and recordings in PRs

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+apps/nextjs/tests-e2e/recordings/*.chunks.txt linguist-generated=true
+apps/nextjs/tests-e2e/recordings/*.json linguist-generated=true
+**/*/__snapshots__/*.snap linguist-generated=true


### PR DESCRIPTION
## Description

- In PRs we see all of the generated fixtures and recordings we use in tests
- This adds a .gitattributes file which sets their status as generated
- Doing so automatically puts them into a hidden state in the PR
- You can still review them in the PR, but by default it shows them in a closed state with a notice that they are generated
- We could add other files to this as we go