### PR TITLE
fix: ensure that the patch enqueuer exists when enqueuing

### DIFF
--- a/packages/aila/src/core/chat/AilaChat.ts
+++ b/packages/aila/src/core/chat/AilaChat.ts
@@ -214,14 +214,20 @@ export class AilaChat implements AilaChatService {
   }
 
   public async enqueue(message: JsonPatchDocumentOptional) {
-    await this._patchEnqueuer.enqueueMessage(message);
+    // Optional "?"" necessary to avoid a "terminated" error
+    if (this?._patchEnqueuer) {
+      await this._patchEnqueuer.enqueueMessage(message);
+    }
   }
 
   public async enqueuePatch(
     path: string,
     value: string | string[] | number | object,
   ) {
-    await this._patchEnqueuer.enqueuePatch(path, value);
+    // Optional "?"" necessary to avoid a "terminated" error
+    if (this?._patchEnqueuer) {
+      await this._patchEnqueuer.enqueuePatch(path, value);
+    }
   }
 
   private async startNewGeneration() {


### PR DESCRIPTION
## Description

- We have an occasional error where if the connection to /chat is terminated, the server will 500 because the enqueuer or the AilaChat instance itself goes away
- This has a check before enqueuing a message that the enqueuer still exists
