### PR TITLE
fix: logger to stdout for info and warn

### DIFF
--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -7,6 +7,8 @@ if (typeof window !== "undefined") {
 }
 
 const debugBase = debug("ai");
+// By default debug logs to stderr, we want to use stdout
+debugBase.log = console.log.bind(console);
 
 type ChildKey =
   | "admin"
@@ -67,9 +69,6 @@ type ChildKey =
  */
 export function aiLogger(childKey: ChildKey) {
   const debugLogger = debugBase.extend(childKey);
-
-  // By default debug logs to stderr, we want to use stdout
-  debugLogger.log = console.log.bind(console);
 
   return {
     info: debugLogger,


### PR DESCRIPTION
## Description

- 'debug' defaults to stderr, meaning all logs look like errors
- this PR sets it to stdout, which should fix that

<img width="1248" alt="image" src="https://github.com/user-attachments/assets/1da76712-fa71-40f5-9f6d-dbf01dd79de4">

