### PR TITLE
chore: run the local Postgres DB on a non-default Postgres port

### DIFF
--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -47,7 +47,7 @@
     "docker-clear": "docker ps -a | grep -q oak-ai-beta && docker stop oak-ai-beta && docker rm oak-ai-beta || echo \"Container oak-ai-beta does not exist.\"",
     "docker-psql": " docker exec -it oak-ai-beta psql -U oai",
     "docker-reset": "pnpm run docker-clear && pnpm run docker-run",
-    "docker-run": "docker run --name oak-ai-beta -p 5432:5432 -d oai-pg",
+    "docker-run": "docker run --name oak-ai-beta -p 8432:5432 -d oai-pg",
     "schema-format": "pnpm with-env prisma format",
     "script-add-metadata-to-lesson-summaries": "ts-node --compiler-options {\\\"module\\\":\\\"CommonJS\\\"} ./scripts/processing/add_metadata_to_lesson_summaries.ts",
     "script-batch-process-clean-questions": "ts-node --compiler-options {\\\"module\\\":\\\"CommonJS\\\"} ./scripts/processing/batch_process_clean_questions.ts",


### PR DESCRIPTION
## Description

- Sets the Postgres port to 8432 instead of the default 5432 in local development
- This means you can have Postgres running on your machine without a clash with the Oak Docker instance

If/when we merge this we will need to update the DB connection string in Doppler and rerun `pnpm docker-reset` in the db package.