### PR TITLE
chore: csp support for turbo and add environment type

### DIFF
--- a/apps/nextjs/src/middleware.test.ts
+++ b/apps/nextjs/src/middleware.test.ts
@@ -1,7 +1,12 @@
 import { NextRequest, NextFetchEvent, NextResponse } from "next/server";
 
 import { handleError } from "./middleware";
-import { CspConfig, addCspHeaders, buildCspHeaders } from "./middlewares/csp";
+import {
+  CspConfig,
+  CspEnvironment,
+  addCspHeaders,
+  buildCspHeaders,
+} from "./middlewares/csp";
 
 describe("handleError", () => {
   let mockRequest: NextRequest;
@@ -83,6 +88,7 @@ describe("addCspHeaders", () => {
         devConsent: false,
         mux: true,
         vercel: false,
+        localhost: false,
       },
     };
   });
@@ -151,7 +157,10 @@ describe("addCspHeaders", () => {
   });
 
   it("includes development-specific directives when environment is development", () => {
-    const config = { ...defaultConfig, environment: "development" };
+    const config = {
+      ...defaultConfig,
+      environment: "development" as CspEnvironment,
+    };
     const result = addCspHeaders(mockResponse, mockRequest, config);
 
     const cspHeader = result.headers.get("Content-Security-Policy");
@@ -230,6 +239,7 @@ describe("buildCspHeaders", () => {
       devConsent: false,
       mux: true,
       vercel: false,
+      localhost: false,
     },
   };
 

--- a/apps/nextjs/src/middleware.ts
+++ b/apps/nextjs/src/middleware.ts
@@ -12,21 +12,56 @@ import { authMiddleware } from "./middlewares/auth.middleware";
 import { CspConfig, addCspHeaders } from "./middlewares/csp";
 import { logError } from "./middlewares/middlewareErrorLogging";
 
+const parseEnvironment = (
+  env: string | undefined,
+): "development" | "preview" | "production" | "test" => {
+  if (
+    env === "development" ||
+    env === "preview" ||
+    env === "production" ||
+    env === "test"
+  ) {
+    return env;
+  }
+  switch (env) {
+    case "dev":
+      return "development";
+    case "stg":
+      return "preview";
+    case "prd":
+      return "production";
+    default:
+      return "development";
+  }
+};
+
+const parseVercelEnv = (
+  env: string | undefined,
+): "development" | "preview" | "production" => {
+  if (env === "development" || env === "preview" || env === "production") {
+    return env;
+  }
+  return "development";
+};
+
+const environment = parseEnvironment(process.env.NEXT_PUBLIC_ENVIRONMENT);
+
 const cspConfig: CspConfig = {
   strictCsp: process.env.STRICT_CSP === "true",
-  environment: process.env.NEXT_PUBLIC_ENVIRONMENT || "",
+  environment,
   sentryEnv: process.env.NEXT_PUBLIC_SENTRY_ENV || "",
   sentryRelease: process.env.NEXT_PUBLIC_APP_VERSION || "",
   sentryReportUri: process.env.SENTRY_REPORT_URI || "",
   cspReportSampleRate: process.env.NEXT_PUBLIC_CSP_REPORT_SAMPLE_RATE || "1",
-  vercelEnv: process.env.VERCEL_ENV || "",
+  vercelEnv: parseVercelEnv(process.env.VERCEL_ENV),
   enabledPolicies: {
-    clerk: ["dev", "stg"].includes(process.env.NEXT_PUBLIC_ENVIRONMENT || ""),
-    avo: ["dev", "stg"].includes(process.env.NEXT_PUBLIC_ENVIRONMENT || ""),
+    clerk: ["development", "preview"].includes(environment),
+    avo: ["development", "preview"].includes(environment),
     posthog: process.env.NEXT_PUBLIC_ENVIRONMENT === "dev",
     devConsent: process.env.NEXT_PUBLIC_ENVIRONMENT === "dev",
     mux: true,
     vercel: process.env.VERCEL_ENV === "preview",
+    localhost: ["development", "test"].includes(environment),
   },
 };
 

--- a/apps/nextjs/src/middlewares/__snapshots__/csp.test.ts.snap
+++ b/apps/nextjs/src/middlewares/__snapshots__/csp.test.ts.snap
@@ -3,7 +3,7 @@
 exports[`CSP Policies Snapshot should match development environment snapshot 1`] = `
 "default-src 'self'
 media-src 'self' 'self' https://*.mux.com https://stream.mux.com blob:
-script-src 'self' 'nonce-REPLACED_NONCE' 'strict-dynamic' https: http: 'unsafe-inline' 'unsafe-eval' https://cdn.mux.com https://mux.com https://*.mux.com https://stream.mux.com
+script-src 'self' 'nonce-REPLACED_NONCE' 'strict-dynamic' https: http: 'unsafe-inline' 'unsafe-eval' https://cdn.mux.com https://mux.com https://*.mux.com https://stream.mux.com http://localhost:*
 style-src 'self' 'unsafe-inline' https://*.mux.com
 connect-src 'self' *.thenational.academy *.hubspot.com *.clerk.accounts.dev https://api.avo.app/ https://eu.i.posthog.com https://europe-west2-oak-ai-beta-staging.cloudfunctions.net https://mux.com https://*.mux.com https://stream.mux.com https://inferred.litix.io
 worker-src 'self' blob:
@@ -13,7 +13,7 @@ object-src 'none'
 base-uri 'self'
 frame-src 'self' *.thenational.academy https://challenges.cloudflare.com https://*.mux.com https://www.avo.app/ https://stream.mux.com
 form-action 'self'
-frame-ancestors 'none'
+frame-ancestors 'none' http://localhost:*
 report-uri https://sentry.io/report&sentry_environment=test&sentry_release=1.0.0"
 `;
 
@@ -47,6 +47,24 @@ font-src 'self' gstatic-fonts.thenational.academy fonts.gstatic.com
 object-src 'none'
 base-uri 'self'
 frame-src 'self' *.thenational.academy https://challenges.cloudflare.com https://*.mux.com https://stream.mux.com
+form-action 'self'
+frame-ancestors 'none'
+report-uri https://sentry.io/report&sentry_environment=test&sentry_release=1.0.0
+upgrade-insecure-requests"
+`;
+
+exports[`CSP Policies Snapshot should match test environment snapshot 1`] = `
+"default-src 'self'
+media-src 'self' 'self' https://*.mux.com https://stream.mux.com blob:
+script-src 'self' 'nonce-REPLACED_NONCE'  https: http: 'unsafe-inline' 'unsafe-eval' https://cdn.mux.com https://mux.com https://*.mux.com https://stream.mux.com
+style-src 'self' 'unsafe-inline' https://*.mux.com
+connect-src 'self' *.thenational.academy *.hubspot.com *.clerk.accounts.dev https://api.avo.app/ https://mux.com https://*.mux.com https://stream.mux.com https://inferred.litix.io
+worker-src 'self' blob:
+img-src 'self' blob: data: https://img.clerk.com https://res.cloudinary.com https://*.hubspot.com https://*.hsforms.com https://*.mux.com https://stream.mux.com
+font-src 'self' gstatic-fonts.thenational.academy fonts.gstatic.com
+object-src 'none'
+base-uri 'self'
+frame-src 'self' *.thenational.academy https://challenges.cloudflare.com https://*.mux.com https://www.avo.app/ https://stream.mux.com
 form-action 'self'
 frame-ancestors 'none'
 report-uri https://sentry.io/report&sentry_environment=test&sentry_release=1.0.0

--- a/apps/nextjs/src/middlewares/csp.test.ts
+++ b/apps/nextjs/src/middlewares/csp.test.ts
@@ -1,11 +1,12 @@
+// To re-generate the snapshots run:
+// pnpm --filter @oakai/nextjs test -- -u src/middlewares/csp.test.ts
 import { NextRequest } from "next/server";
 
-import { addCspHeaders, CspConfig } from "./csp";
+import { addCspHeaders, CspConfig, CspEnvironment } from "./csp";
 
-const environments = ["development", "production", "preview"] as const;
-type Environment = (typeof environments)[number];
+const environments = ["development", "production", "preview", "test"] as const;
 
-function generatePoliciesForEnvironment(env: Environment): string {
+function generatePoliciesForEnvironment(env: CspEnvironment): string {
   const mockRequest = new NextRequest("https://example.com");
   const mockResponse = new Response();
 
@@ -24,6 +25,7 @@ function generatePoliciesForEnvironment(env: Environment): string {
       devConsent: env === "development",
       mux: true,
       vercel: env === "preview",
+      localhost: env === "development",
     },
   };
 


### PR DESCRIPTION
## Description

- Alters the CSP header generation to support Turbo by using UUID instead of the crypto library (it has trouble with it)
- Adds a stricter definition of the environment name to save us getting mixed up between "prd" and "production"
- Fixes a bug that I think is in production right now
- Adds support for skipping the frame rules so that mobile tests run in dev
