### PR TITLE
chore: use DEBUG logging var on the frontend

### DIFF
--- a/apps/nextjs/.storybook/main.ts
+++ b/apps/nextjs/.storybook/main.ts
@@ -2,6 +2,8 @@ import type { StorybookConfig } from "@storybook/nextjs";
 import { join, dirname, resolve } from "path";
 import webpack from "webpack";
 
+process.env.NEXT_PUBLIC_DEBUG = process.env.DEBUG;
+
 /**
  * This function is used to resolve the absolute path of a package.
  * It is needed in projects that use Yarn PnP or are set up within a monorepo.

--- a/apps/nextjs/jest.setup.js
+++ b/apps/nextjs/jest.setup.js
@@ -1,5 +1,7 @@
 require("@testing-library/jest-dom");
 
+process.env.NEXT_PUBLIC_DEBUG = process.env.DEBUG;
+
 // Mock Next.js Image component
 jest.mock("next/image", () => ({
   __esModule: true,

--- a/apps/nextjs/next.config.js
+++ b/apps/nextjs/next.config.js
@@ -88,6 +88,7 @@ const getConfig = async (phase) => {
     env: {
       NEXT_PUBLIC_APP_VERSION: appVersion,
       NEXT_PUBLIC_RELEASE_STAGE: releaseStage,
+      NEXT_PUBLIC_DEBUG: process.env.DEBUG,
     },
 
     productionBrowserSourceMaps: true,

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -1,13 +1,12 @@
 import debug from "debug";
+import invariant from "tiny-invariant";
 
 import browserLogger from "./browser";
 import type { StructuredLogger } from "./structuredLogger";
 import structuredLogger from "./structuredLogger";
 
 if (typeof window !== "undefined") {
-  if (!process.env.NEXT_PUBLIC_DEBUG) {
-    throw new Error("NEXT_PUBLIC_DEBUG is not set");
-  }
+  invariant(process.env.NEXT_PUBLIC_DEBUG, "NEXT_PUBLIC_DEBUG is not set");
   debug.enable(process.env.NEXT_PUBLIC_DEBUG);
 }
 

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -5,7 +5,10 @@ import type { StructuredLogger } from "./structuredLogger";
 import structuredLogger from "./structuredLogger";
 
 if (typeof window !== "undefined") {
-  debug.enable("ai:*");
+  if (!process.env.NEXT_PUBLIC_DEBUG) {
+    throw new Error("NEXT_PUBLIC_DEBUG is not set");
+  }
+  debug.enable(process.env.NEXT_PUBLIC_DEBUG);
 }
 
 const debugBase = debug("ai");


### PR DESCRIPTION
The `DEBUG` env var has helped me to keep local server logs clear and help me focus on specific areas I'm working on. At the moment that variable isn't configured on the frontend

This PR forwards the value in `DEBUG` to the frontend as well so we can filter logs there