### PR TITLE
test: reduce workers for jest in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,4 +43,4 @@ jobs:
           inject-env-vars: true
 
       - name: Run tests
-        run: pnpm turbo test --cache-dir=".turbo"
+        run: pnpm turbo test --cache-dir=".turbo" -- --maxWorkers=33%


### PR DESCRIPTION
We updated the `test` script in package.json, but it turns out that the github workflow for testing calls turbo directly

This brings individual test file times down from ~40s to ~5s, as we don't have 3 jest processes each using the maximum available cores