### PR TITLE
test: prevent jest from bypassing inngest dev mode

### DIFF
--- a/packages/core/src/client.ts
+++ b/packages/core/src/client.ts
@@ -45,5 +45,5 @@ export const inngest = new Inngest({
   env: inngestEnv,
   logger: structuredLogger,
   middleware: [eventLogger(inngestEnv, inngestEventKey)],
-  isDev: process.env.NODE_ENV === "development" && !isJestEnvironment(),
+  isDev: process.env.NODE_ENV === "development" || isJestEnvironment(),
 });


### PR DESCRIPTION
Our inngest client skips dev mode if running in a jest test. I think this must be a typo. If you break an inngest mock, it will send to the inngest cloud