### PR TITLE
fix: use browserLogger for errors in the browser

### DIFF
--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -1,5 +1,6 @@
 import debug from "debug";
 
+import browserLogger from "./browser";
 import structuredLogger, { StructuredLogger } from "./structuredLogger";
 
 if (typeof window !== "undefined") {
@@ -53,6 +54,11 @@ type ChildKey =
   | "trpc"
   | "ui";
 
+const errorLogger =
+  typeof window === "undefined"
+    ? structuredLogger.error.bind(structuredLogger)
+    : browserLogger.error.bind(browserLogger);
+
 /**
  * The AI logger uses namespaces so that we can selectively toggle noisy logs.
  * Logs are selected with the DEBUG environment variable.
@@ -73,7 +79,7 @@ export function aiLogger(childKey: ChildKey) {
   return {
     info: debugLogger,
     warn: debugLogger,
-    error: structuredLogger.error.bind(structuredLogger),
+    error: errorLogger.bind(structuredLogger),
   };
 }
 


### PR DESCRIPTION
I was looking at a frontend error in Sentry, and I spotted that this was logged:

> Invalid use of @oakai/logger, use logger/browser, logMessage=Oak consent client error

That makes sense as we globally replaced `console.error` commands with the central structuredLogger

This PR makes `aiLogger().error` choose between a server and browser logger as required