### PR TITLE
fix: use noengine in ci

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         run: pnpm install
 
       - name: Generate prisma client
-        run: pnpm db-generate
+        run: pnpm db-generate:no-engine
 
       - name: Inject Doppler env vars
         uses: dopplerhq/secrets-fetch-action@v1.2.0

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "clean:workspaces": "turbo clean",
     "db-export:dev": "doppler run --config dev -- bash scripts/db_export.sh",
     "db-generate": "turbo db-generate",
+    "db-generate:no-engine": "turbo db-generate:no-engine",
     "db-migrate": "turbo db-migrate",
     "db-publish:stg": "doppler run --config stg -- bash scripts/db_publish.sh",
     "db-push": "turbo db-push",


### PR DESCRIPTION
## Description

- We should use the --noengine option for Prisma client generation in CI
