### PR TITLE
fix: set VS Code to prefer type imports

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -194,5 +194,6 @@
   "yaml.schemas": {
     "file:///c%3A/Users/Simon/.vscode/extensions/atlassian.atlascode-2.8.6/resources/schemas/pipelines-schema.json": "bitbucket-pipelines.yml",
     "https://www.artillery.io/schema.json": []
-  }
+  },
+  "typescript.preferences.preferTypeOnlyAutoImports": true
 }


### PR DESCRIPTION
## Description

- Sets `"typescript.preferences.preferTypeOnlyAutoImports": true` so that VS Code will prefer to use type-only imports

