### PR TITLE
fix: ensure that flag and modify button metadata uses strings (WIP)

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/flag-button.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/flag-button.tsx
@@ -1,11 +1,13 @@
 import { useEffect, useRef, useState } from "react";
 
 import { getLastAssistantMessage } from "@oakai/aila/src/helpers/chat/getLastAssistantMessage";
+import type { LessonPlanSectionWhileStreaming } from "@oakai/aila/src/protocol/schema";
 import type { AilaUserFlagType } from "@oakai/db";
 import { OakBox, OakP, OakRadioGroup } from "@oaknational/oak-components";
 import styled from "styled-components";
 
 import { useLessonChat } from "@/components/ContextProviders/ChatProvider";
+import { isPlainObject } from "@/utils/isPlainObject";
 import { trpc } from "@/utils/trpc";
 
 import ActionButton from "./action-button";
@@ -26,7 +28,7 @@ type FlagButtonOptions = typeof flagOptions;
 type FlagButtonProps = {
   sectionTitle: string;
   sectionPath: string;
-  sectionValue: Record<string, unknown> | string | Array<unknown>;
+  sectionValue: LessonPlanSectionWhileStreaming;
 };
 
 const FlagButton = ({
@@ -48,6 +50,21 @@ const FlagButton = ({
 
   const { mutateAsync } = trpc.chat.chatFeedback.flagSection.useMutation();
 
+  const prepareSectionValue = (
+    value: LessonPlanSectionWhileStreaming,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  ): string | any[] | Record<string, unknown> => {
+    if (
+      typeof value === "string" ||
+      Array.isArray(value) ||
+      isPlainObject(value)
+    ) {
+      return value;
+    }
+    // For numbers or any other types, convert to string
+    return String(value);
+  };
+
   const flagSectionContent = async () => {
     if (selectedRadio && lastAssistantMessage) {
       const payload = {
@@ -56,7 +73,7 @@ const FlagButton = ({
         flagType: selectedRadio.enumValue,
         userComment: userFeedbackText,
         sectionPath,
-        sectionValue,
+        sectionValue: prepareSectionValue(sectionValue),
       };
       await mutateAsync(payload);
     }
@@ -93,7 +110,7 @@ const FlagButton = ({
           >
             {flagOptions.map((option) => (
               <FlagButtonFormItem
-                key={`flagbuttonformitem-${option.enumValue}`}
+                key={`flagButtonFormItem-${option.enumValue}`}
                 option={option}
                 setSelectedRadio={setSelectedRadio}
                 setDisplayTextBox={setDisplayTextBox}

--- a/apps/nextjs/src/utils/isPlainObject.ts
+++ b/apps/nextjs/src/utils/isPlainObject.ts
@@ -1,0 +1,7 @@
+// Type guard to check if the value is a plain object
+
+export const isPlainObject = (
+  value: unknown,
+): value is Record<string, unknown> => {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+};


### PR DESCRIPTION
## Description

- While refactoring and adding better type constraints, I discovered that numbers are not allowable in the modifySection.sectionValue type
- This stores numbers as strings if we have attempted to set a section value to a number
- Waiting to merge other PRs to add this