### PR TITLE
feat: allow us to configure the server port for local testing

### DIFF
--- a/apps/nextjs/tests-e2e/config/config.ts
+++ b/apps/nextjs/tests-e2e/config/config.ts
@@ -7,6 +7,6 @@ export const TEST_USER_EMAIL = process.env.TEST_USER_EMAIL;
 export const TEST_USER_PASSWORD = process.env.TEST_USER_PASSWORD;
 export const PORT = process.env.PORT ?? 2525;
 export const TEST_BASE_URL =
-  process.env.TEST_BASE_URL || `http://localhost:${PORT}`;
+  process.env.TEST_BASE_URL ?? `http://localhost:${PORT}`;
 export const VERCEL_AUTOMATION_BYPASS_SECRET =
   process.env.VERCEL_AUTOMATION_BYPASS_SECRET;

--- a/apps/nextjs/tests-e2e/config/config.ts
+++ b/apps/nextjs/tests-e2e/config/config.ts
@@ -5,7 +5,8 @@ dotenv.config({ path: path.join(process.cwd(), ".env") });
 
 export const TEST_USER_EMAIL = process.env.TEST_USER_EMAIL;
 export const TEST_USER_PASSWORD = process.env.TEST_USER_PASSWORD;
+export const PORT = process.env.PORT ?? 2525;
 export const TEST_BASE_URL =
-  process.env.TEST_BASE_URL || "http://localhost:2525";
+  process.env.TEST_BASE_URL || `http://localhost:${PORT}`;
 export const VERCEL_AUTOMATION_BYPASS_SECRET =
   process.env.VERCEL_AUTOMATION_BYPASS_SECRET;


### PR DESCRIPTION
## Description

- In local development we might want to have a different server other than the default (eg. if we want to run a server not in development mode, or using a different database)
