### PR TITLE
fix: await handling stream errors + try/catch

### DIFF
--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -44,7 +44,12 @@ export class AilaStreamHandler {
         await this.readFromStream();
       }
     } catch (e) {
-      this.handleStreamError(e);
+      try {
+        await this.handleStreamError(e);
+      } catch (error) {
+        this._chat.aila.errorReporter?.reportError(error);
+        log.error("Error handling stream error", error);
+      }
       log.info("Stream error", e, this._chat.iteration, this._chat.id);
     } finally {
       this._isStreaming = false;


### PR DESCRIPTION
## Description

- Handles an edge case where handling the stream error might itself throw
- Also ensures we await the handling of stream errors