### PR TITLE
fix: promisify chat API route get handler

### DIFF
--- a/apps/nextjs/src/app/api/chat/route.ts
+++ b/apps/nextjs/src/app/api/chat/route.ts
@@ -12,7 +12,7 @@ async function postHandler(req: NextRequest): Promise<Response> {
 }
 
 async function getHandler(): Promise<Response> {
-  return new Response("Server is ready", { status: 200 });
+  return Promise.resolve(new Response("Server is ready", { status: 200 }));
 }
 
 export const POST = withSentry(postHandler);


### PR DESCRIPTION
## Description

- The GET handler for the /chat API route needs to be promisified

