### PR TITLE
build: temporarily disable the prompts dependency when building RCs

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -39,7 +39,7 @@
     },
     "build": {
       "cache": true,
-      "dependsOn": ["^db-generate:no-engine", "^prompts"],
+      "dependsOn": ["^db-generate:no-engine"],
       "outputs": [
         ".next/**",
         "!.next/cache/**",


### PR DESCRIPTION
```
@oakai/core:prompts: prisma:error 
@oakai/core:prompts: Invalid `this.prisma.prompt.create()` invocation in
@oakai/core:prompts: /vercel/path0/packages/core/src/models/promptVariants.ts:57:46
@oakai/core:prompts: 
@oakai/core:prompts:   54 >`SELECT MAX(version) AS max_version FROM prompts WHERE slug = ${slug}`;
@oakai/core:prompts:   55 const maxVersion = maxVersionRow[0]?.max_version ?? 0;
@oakai/core:prompts:   56 const version = maxVersion + 1;
@oakai/core:prompts: → 57 const created = await this.prisma.prompt.create(
@oakai/core:prompts: Unique constraint failed on the fields: (`hash`)
@oakai/core:prompts: PrismaClientKnownRequestError: 
@oakai/core:prompts: Invalid `this.prisma.prompt.create()` invocation in
@oakai/core:prompts: /vercel/path0/packages/core/src/models/promptVariants.ts:57:46
@oakai/core:prompts: 
@oakai/core:prompts:   54 >`SELECT MAX(version) AS max_version FROM prompts WHERE slug = ${slug}`;
@oakai/core:prompts:   55 const maxVersion = maxVersionRow[0]?.max_version ?? 0;
@oakai/core:prompts:   56 const version = maxVersion + 1;
@oakai/core:prompts: → 57 const created = await this.prisma.prompt.create(
@oakai/core:prompts: Unique constraint failed on the fields: (`hash`)
@oakai/core:prompts:     at Mn.handleRequestError (/vercel/path0/node_modules/@prisma/client/runtime/library.js:121:7753)
@oakai/core:prompts:     at Mn.handleAndLogRequestError (/vercel/path0/node_modules/@prisma/client/runtime/library.js:121:7061)
@oakai/core:prompts:     at Mn.request (/vercel/path0/node_modules/@prisma/client/runtime/library.js:121:6745)
@oakai/core:prompts:     at processTicksAndRejections (node:internal/process/task_queues:95:5)
@oakai/core:prompts:     at async l (/vercel/path0/node_modules/@prisma/client/runtime/library.js:130:9633)
@oakai/core:prompts:     at async PromptVariants.setCurrent (/vercel/path0/packages/core/src/models/promptVariants.ts:57:21)
@oakai/core:prompts:     at async main (/vercel/path0/packages/core/src/scripts/setupPrompts.ts:38:7) {
@oakai/core:prompts:   code: 'P2002',
@oakai/core:prompts:   clientVersion: '5.21.1',
@oakai/core:prompts:   meta: { modelName: 'Prompt', target: [ 'hash' ] }
@oakai/core:prompts: }
```