### PR TITLE
fix: skip instrumentation when running turbopack - fix HMR

### DIFF
--- a/apps/nextjs/src/instrumentation.ts
+++ b/apps/nextjs/src/instrumentation.ts
@@ -1,6 +1,12 @@
 import * as Sentry from "@sentry/nextjs";
 
 export async function register() {
+  // https://github.com/oaknational/oak-ai-lesson-assistant/pull/328
+  // https://github.com/vercel/next.js/issues/70424
+  if (process.env.TURBOPACK) {
+    return;
+  }
+
   if (process.env.NEXT_RUNTIME === "nodejs") {
     await import("../sentry.server.config");
   }


### PR DESCRIPTION
We get errors like this when HMR kicks in with turbopack

It's tricky to debug. You seem to have to restart the server to reset the state that can break

```
Error: Module [project]/node_modules/next/dist/esm/client/components/error-boundary.js [app-ssr] (ecmascript) was instantiated because it was required from module [project]/node_modules/next/dist/esm/build/templates/app-page.js?page=/page { COMPONENT_0 => "[project]/apps/nextjs/src/app/layout.tsx [app-rsc] (ecmascript, Next.js server component)", COMPONENT_1 => "[project]/apps/nextjs/src/app/not-found.tsx [app-rsc] (ecmascript, Next.js server component)", COMPONENT_2 => "[project]/apps/nextjs/src/app/page.tsx [app-rsc] (ecmascript, Next.js server component)", METADATA_3 => "[project]/apps/nextjs/src/app/twitter-image.png.mjs { IMAGE => \"[project]/apps/nextjs/src/app/twitter-image.png [app-rsc] (static)\" } [app-rsc] (structured image object, ecmascript)", METADATA_4 => "[project]/apps/nextjs/src/app/opengraph-image.png.mjs { IMAGE => \"[project]/apps/nextjs/src/app/opengraph-image.png [app-rsc] (static)\" } [app-rsc] (structured image object, ecmascript)" } [app-rsc] (ecmascript) <locals>, but the module factory is not available. It might have been deleted in an HMR update.
    at instantiateModule (/Users/adz/Documents/code/oak-ai-lesson-assistant-3/apps/nextjs/.next/server/chunks/ssr/[turbopack]_runtime.js:492:15)
    at getOrInstantiateModuleFromParent (/Users/adz/Documents/code/oak-ai-lesson-assistant-3/apps/nextjs/.next/server/chunks/ssr/[turbopack]_runtime.js:572:12)
    at commonJsRequire (/Users/adz/Documents/code/oak-ai-lesson-assistant-3/apps/nextjs/.next/server/chunks/ssr/[turbopack]_runtime.js:136:20)
    at require (/Users/adz/Documents/code/oak-ai-lesson-assistant-3/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:39:19729)
    at /Users/adz/Documents/code/oak-ai-lesson-assistant-3/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:35:89291
    at eo (/Users/adz/Documents/code/oak-ai-lesson-assistant-3/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:35:89476)
    at /Users/adz/Documents/code/oak-ai-lesson-assistant-3/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:35:91705
    at Object._fromJSON (/Users/adz/Documents/code/oak-ai-lesson-assistant-3/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:35:92261)
    at JSON.parse (<anonymous>)
    at eu (/Users/adz/Documents/code/oak-ai-lesson-assistant-3/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:35:89970)
    at en (/Users/adz/Documents/code/oak-ai-lesson-assistant-3/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:35:89038)
    at /Users/adz/Documents/code/oak-ai-lesson-assistant-3/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:35:96196
    at /Users/adz/Documents/code/oak-ai-lesson-assistant-3/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:35:96213
    at /Users/adz/Documents/code/oak-ai-lesson-assistant-3/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:35:96246
    at /Users/adz/Documents/code/oak-ai-lesson-assistant-3/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:35:96263
    at t (/Users/adz/Documents/code/oak-ai-lesson-assistant-3/node_modules/next/dist/compiled/next-server/app-page.runtime.dev.js:35:96486)
```

