### PR TITLE
feat: use featureFlagGroup claim for feature flags

### DIFF
--- a/apps/nextjs/src/lib/feature-flags/bootstrap.ts
+++ b/apps/nextjs/src/lib/feature-flags/bootstrap.ts
@@ -32,15 +32,21 @@ function getDistinctIdFromCookie(headers: ReadonlyHeaders) {
 }
 
 export async function getBootstrappedFeatures(headers: ReadonlyHeaders) {
-  const { userId } = auth();
+  const { userId, sessionClaims } = auth();
 
   const distinctId = userId ?? getDistinctIdFromCookie(headers) ?? "0";
   log.info("Evaluating feature flags for", distinctId);
+
+  const personProperties = sessionClaims?.labs?.featureFlagGroup
+    ? { featureFlagGroup: sessionClaims.labs.featureFlagGroup }
+    : undefined;
+
   const features = await posthogAiBetaServerClient.getAllFlags(distinctId, {
-    // Only bootstrap flags which don't depend on user properties
-    // These are typically flags representing new features
+    // Only bootstrap flags which don't depend on PII
     onlyEvaluateLocally: true,
+    personProperties,
   });
+
   log.info("Bootstrapping feature flags", features);
   return features;
 }

--- a/apps/nextjs/src/lib/feature-flags/bootstrap.ts
+++ b/apps/nextjs/src/lib/feature-flags/bootstrap.ts
@@ -35,11 +35,11 @@ export async function getBootstrappedFeatures(headers: ReadonlyHeaders) {
   const { userId, sessionClaims } = auth();
 
   const distinctId = userId ?? getDistinctIdFromCookie(headers) ?? "0";
-  log.info("Evaluating feature flags for", distinctId);
 
   const personProperties = sessionClaims?.labs?.featureFlagGroup
     ? { featureFlagGroup: sessionClaims.labs.featureFlagGroup }
     : undefined;
+  log.info("Evaluating", distinctId, personProperties ?? "(no properties)");
 
   const features = await posthogAiBetaServerClient.getAllFlags(distinctId, {
     // Only bootstrap flags which don't depend on PII

--- a/apps/nextjs/src/middlewares/auth.middleware.ts
+++ b/apps/nextjs/src/middlewares/auth.middleware.ts
@@ -13,6 +13,7 @@ declare global {
     labs: {
       isDemoUser: boolean | null;
       isOnboarded: boolean | null;
+      featureFlagGroup: string | null;
     };
   }
 }

--- a/packages/core/src/analytics/posthogAiBetaServerClient/featureFlagEvaluation.ts
+++ b/packages/core/src/analytics/posthogAiBetaServerClient/featureFlagEvaluation.ts
@@ -27,7 +27,7 @@ export const cachedFetch: PostHog["fetch"] = async (url, options) => {
   if (url.includes("api/feature_flag/local_evaluation")) {
     const kvCachedResponse = await getKv();
     if (kvCachedResponse) {
-      log.info("evaluations fetched from KV");
+      log.info("Evaluations fetched from KV");
       return kvCachedResponse;
     }
     const result = await fetch(url, options);
@@ -35,7 +35,7 @@ export const cachedFetch: PostHog["fetch"] = async (url, options) => {
     if (result.ok) {
       const cachedResult = result.clone();
       await setKv(cachedResult);
-      log.info("evaluations cached to KV");
+      log.info("Evaluations cached to KV");
     } else {
       log.error("failed to load evaluations", { status: result.status });
     }


### PR DESCRIPTION
In #320 we added local evaluation of feature flags. Local evaluation calculates the feature flags for the user, but only has user data from the session token. That works for feature flags which are either on or off, but we sometimes want feature flags for a specific group of users, like the AI team or external testers

This work:
- Adds featureFlagGroup to the labs Clerk metadata. We can manually populate this with `ai-team` for the team
- Passes the `featureFlagGroup` into the feature flag evaluation, so that we can calculate the user's flags without needing their email address

Testing:
- See that the [download-all-button](https://eu.posthog.com/project/8837/feature_flags/35349) feature flag is enabled for the group `ai-team`
- Log in with a user with `ai-team` set in clerk metadata (I've set it for all of our Oak emails)
- Load the homepage
  - Look for `Bootstrapping feature flags { 'download-all-button': true }` in the server log
- Sign in with another account
  - Look for `Bootstrapping feature flags { 'download-all-button': false }` in the server log
