### PR TITLE
chore: unify feature flag loggers

### DIFF
--- a/apps/nextjs/src/lib/feature-flags/bootstrap.ts
+++ b/apps/nextjs/src/lib/feature-flags/bootstrap.ts
@@ -7,7 +7,7 @@ import cookie from "cookie";
 import type { ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
 import invariant from "tiny-invariant";
 
-const log = aiLogger("analytics:feature-flags");
+const log = aiLogger("feature-flags");
 
 /**
  * We use posthog feature flags to toggle functionality without deploying code changes.

--- a/packages/core/src/analytics/posthogAiBetaServerClient/featureFlagEvaluation.ts
+++ b/packages/core/src/analytics/posthogAiBetaServerClient/featureFlagEvaluation.ts
@@ -4,7 +4,7 @@ import type { PostHog } from "posthog-node";
 
 const KV_KEY = "posthog-feature-flag-local-evaluation";
 
-const log = aiLogger("analytics:feature-flags");
+const log = aiLogger("feature-flags");
 
 const setKv = async (response: Response) => {
   const value = await response.text();

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -31,7 +31,6 @@ type ChildKey =
   | "aila:rag"
   | "aila:testing"
   | "analytics"
-  | "analytics:feature-flags"
   | "app"
   | "auth"
   | "chat"


### PR DESCRIPTION
Just a small one. I noticed that I'd accidentally created both `feature-flags` and `analytics:feature-flags` loggers 