### PR TITLE
fix: null render in sidebar provider

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/sidebar-actions.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/sidebar-actions.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { within } from "@storybook/test";
 
 import { SidebarActions } from "./sidebar-actions";
 
@@ -26,14 +27,24 @@ export const Default: Story = {
   },
 };
 
+export const SharePending: Story = {
+  args: {
+    ...Default.args,
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const deleteButton = canvas.getByRole("button", { name: "Share" });
+    deleteButton.click();
+  },
+};
+
 export const RemovePending: Story = {
   args: {
     ...Default.args,
   },
   play: async ({ canvasElement }) => {
-    const deleteButton = canvasElement.querySelector("button:nth-child(2)");
-    if (deleteButton instanceof HTMLElement) {
-      deleteButton.click();
-    }
+    const canvas = within(canvasElement);
+    const deleteButton = canvas.getByRole("button", { name: "Delete" });
+    deleteButton.click();
   },
 };

--- a/apps/nextjs/src/lib/hooks/use-sidebar.tsx
+++ b/apps/nextjs/src/lib/hooks/use-sidebar.tsx
@@ -27,7 +27,7 @@ interface SidebarProviderProps {
 }
 
 export function SidebarProvider({ children }: SidebarProviderProps) {
-  const [isSidebarOpen, setSidebarOpen] = React.useState(true);
+  const [isSidebarOpen, setSidebarOpen] = React.useState(false);
   const [isLoading, setLoading] = React.useState(true);
 
   React.useEffect(() => {
@@ -45,10 +45,6 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
       return newState;
     });
   };
-
-  if (isLoading) {
-    return null;
-  }
 
   return (
     <SidebarContext.Provider


### PR DESCRIPTION
I found that these storybook interactions weren't working as the first render was empty. After some digging, I found that that sidebar provider renders the whole page as null on its first render while it's loading from localstorage

This means that all of our pages have been rendering as a blank page, then updating to have content

It also means that in non-dev nextjs builds, the initial server render was wild! Huge icons and other problems from the lack of styling. I've based this PR on #341 to fix that

# Testing

- The sidebar opens and closes as expected
- The general page UI hasn't started flashing or shifting when reloading the page