### PR TITLE
chore: create sidebar storybook folder

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-history.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-history.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { ChatHistory } from "./chat-history";
 
 const meta: Meta<typeof ChatHistory> = {
-  title: "Components/Chat/ChatHistory",
+  title: "Components/Sidebar/ChatHistory",
   component: ChatHistory,
   parameters: {
     layout: "centered",

--- a/apps/nextjs/src/components/AppComponents/Chat/clear-history.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/clear-history.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { ClearHistory } from "./clear-history";
 
 const meta: Meta<typeof ClearHistory> = {
-  title: "Components/Chat/ClearHistory",
+  title: "Components/Sidebar/ClearHistory",
   component: ClearHistory,
   tags: ["autodocs"],
   argTypes: {

--- a/apps/nextjs/src/components/AppComponents/Chat/sidebar-actions.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/sidebar-actions.stories.tsx
@@ -3,7 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { SidebarActions } from "./sidebar-actions";
 
 const meta: Meta<typeof SidebarActions> = {
-  title: "Components/Chat/SidebarActions",
+  title: "Components/Sidebar/Actions",
   component: SidebarActions,
   parameters: {
     layout: "centered",


### PR DESCRIPTION
At the moment all the stories are within the Chat folder. Half of them relate to the sidebar so it made sense to me to split them out

I thought about moving the actual components into a sidebar subfolder, but I don't know if there's a method to our flat chat component folder