### PR TITLE
test: delete test users with null activeAt

### DIFF
--- a/packages/api/src/router/testSupport/prepareUser.ts
+++ b/packages/api/src/router/testSupport/prepareUser.ts
@@ -1,4 +1,5 @@
 import { clerkClient } from "@clerk/nextjs/server";
+import { isClerkAPIResponseError } from "@clerk/shared";
 import { aiLogger } from "@oakai/logger";
 import { waitUntil } from "@vercel/functions";
 import os from "os";
@@ -75,24 +76,50 @@ const generateEmailAddress = (personaName: keyof typeof personas) => {
   return `${parts.join("+")}@thenational.academy`;
 };
 
-const deleteLastUsedTestUser = async () => {
-  const users = await clerkClient.users.getUserList({
-    orderBy: "+last_active_at",
+const deleteOldTestUser = async () => {
+  const result = await clerkClient.users.getUserList({
     limit: 500,
   });
 
   const NUMBERS_USER = /\d{5,10}.*@/; // jim+010203@thenational.academy
-  const lastUsedTestUser = users.data.find((u) => {
+  const testUsers = result.data.filter((u) => {
     const email = u.primaryEmailAddress?.emailAddress ?? "";
     return email.startsWith("test+") || email.match(NUMBERS_USER);
   });
 
-  if (lastUsedTestUser) {
-    log.info(
-      "Deleting oldest test user",
-      lastUsedTestUser.primaryEmailAddress?.emailAddress,
-    );
-    await clerkClient.users.deleteUser(lastUsedTestUser.id);
+  if (testUsers.length < 100) {
+    log.info(`less than 100 test users. Skipping cleanup.`);
+    return;
+  }
+
+  const users = testUsers.sort(
+    (a, b) =>
+      new Date(a.lastActiveAt ?? a.createdAt).getTime() -
+      new Date(b.lastActiveAt ?? b.createdAt).getTime(),
+  );
+
+  // If multiple personas are created at the same time and both try to delete the
+  // oldest user they will conflict. Add some randomness to reduce conflicts
+  const randomOffset = Math.floor(Math.random() * 8);
+  const userToDelete = users[randomOffset];
+
+  if (userToDelete) {
+    try {
+      await clerkClient.users.deleteUser(userToDelete.id);
+      log.info(
+        "Deleted old test user",
+        userToDelete.primaryEmailAddress?.emailAddress,
+      );
+    } catch (e) {
+      if (isClerkAPIResponseError(e) && e.status === 404) {
+        log.info(
+          `${userToDelete.primaryEmailAddress?.emailAddress} already deleted, retrying`,
+        );
+        deleteOldTestUser();
+      } else {
+        throw e;
+      }
+    }
   }
 };
 
@@ -134,7 +161,7 @@ const findOrCreateUser = async (
     },
   });
 
-  waitUntil(deleteLastUsedTestUser());
+  waitUntil(deleteOldTestUser());
 
   return newUser;
 };


### PR DESCRIPTION
I noticed in Clerk that we're recycling a small number of test users at the moment. Maybe 15 or so. Looking at the code for the test user pool, it's because some test users have been created but have no lastActiveAt. They then get sorted at the end of the clerk response after the most recently active users

This PR takes a different approach to cleanup:
- Filter staging users by whether the have a test email address
- Sort test users by lastActiveAt OR createdAt
- Delete one of the oldest 8 users (to reduce conflicts between simultaneous runs)