### PR TITLE
fix: set up server side styled-components

### DIFF
--- a/apps/nextjs/next.config.js
+++ b/apps/nextjs/next.config.js
@@ -77,6 +77,9 @@ const getConfig = async (phase) => {
       domains: ["oaknationalacademy-res.cloudinary.com"],
     },
     transpilePackages: ["@oakai/api", "@oakai/db", "@oakai/exports"],
+    compiler: {
+      styledComponents: true,
+    },
     // We already do linting on GH actions
     eslint: {
       ignoreDuringBuilds: !!process.env.CI,

--- a/apps/nextjs/src/app/layout.tsx
+++ b/apps/nextjs/src/app/layout.tsx
@@ -28,6 +28,8 @@ import { SentryIdentify } from "@/lib/sentry/SentryIdentify";
 import { cn } from "@/lib/utils";
 import { TRPCReactProvider } from "@/utils/trpc";
 
+import StyledComponentsRegistry from "./styles-registry";
+
 const provided_vercel_url =
   process.env.VERCEL_URL && process.env.VERCEL_URL?.length > 0
     ? process.env.VERCEL_URL
@@ -82,61 +84,63 @@ export default async function RootLayout({
 
   return (
     <html lang="en" suppressHydrationWarning className={lexend.variable}>
-      <ClerkProvider>
-        <body
-          className={cn(
-            "overflow-x-hidden font-sans antialiased",
-            GeistMono.variable,
-          )}
-        >
-          <Theme
-            accentColor="blue"
-            grayColor="olive"
-            scaling="110%"
-            color="#22222"
-            style={{ overflowX: "hidden" }}
+      <StyledComponentsRegistry>
+        <ClerkProvider>
+          <body
+            className={cn(
+              "overflow-x-hidden font-sans antialiased",
+              GeistMono.variable,
+            )}
           >
-            <TRPCReactProvider>
-              <FontProvider>
-                <Toaster />
-                <Providers>
-                  <SentryIdentify />
-                  <CookieConsentProvider>
-                    <AnalyticsProvider
-                      avoOptions={{
-                        webDebugger: false,
-                        inspector: undefined,
-                        webDebuggerOptions: {
-                          position: WebDebuggerPosition.BottomLeft({
-                            bottom: 0,
-                            left: 0,
-                          }),
-                        },
-                      }}
-                      bootstrappedFeatures={bootstrappedFeatures}
-                    >
-                      <GleapProvider>{children}</GleapProvider>
-                    </AnalyticsProvider>
-                  </CookieConsentProvider>
-                </Providers>
-              </FontProvider>
-            </TRPCReactProvider>
-          </Theme>
+            <Theme
+              accentColor="blue"
+              grayColor="olive"
+              scaling="110%"
+              color="#22222"
+              style={{ overflowX: "hidden" }}
+            >
+              <TRPCReactProvider>
+                <FontProvider>
+                  <Toaster />
+                  <Providers>
+                    <SentryIdentify />
+                    <CookieConsentProvider>
+                      <AnalyticsProvider
+                        avoOptions={{
+                          webDebugger: false,
+                          inspector: undefined,
+                          webDebuggerOptions: {
+                            position: WebDebuggerPosition.BottomLeft({
+                              bottom: 0,
+                              left: 0,
+                            }),
+                          },
+                        }}
+                        bootstrappedFeatures={bootstrappedFeatures}
+                      >
+                        <GleapProvider>{children}</GleapProvider>
+                      </AnalyticsProvider>
+                    </CookieConsentProvider>
+                  </Providers>
+                </FontProvider>
+              </TRPCReactProvider>
+            </Theme>
 
-          {/* react-hot-toast uses "goober" to set styles.
+            {/* react-hot-toast uses "goober" to set styles.
               Goober creates a _goober tag which would be blocked by CSP
               We can pre-create it with a nonce ourselves
               See https://github.com/cristianbote/goober/issues/471 */}
-          <style
-            id="_goober"
-            nonce={nonce ?? undefined}
-            suppressHydrationWarning
-            // eslint-disable-next-line react/jsx-no-comment-textnodes
-          >
-            /* css comment for goober */
-          </style>
-        </body>
-      </ClerkProvider>
+            <style
+              id="_goober"
+              nonce={nonce ?? undefined}
+              suppressHydrationWarning
+              // eslint-disable-next-line react/jsx-no-comment-textnodes
+            >
+              /* css comment for goober */
+            </style>
+          </body>
+        </ClerkProvider>
+      </StyledComponentsRegistry>
     </html>
   );
 }

--- a/apps/nextjs/src/app/styles-registry.tsx
+++ b/apps/nextjs/src/app/styles-registry.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import React, { useState } from "react";
+
+import { useServerInsertedHTML } from "next/navigation";
+import { ServerStyleSheet, StyleSheetManager } from "styled-components";
+
+// https://nextjs.org/docs/app/building-your-application/styling/css-in-js#styled-components
+export default function StyledComponentsRegistry({
+  children,
+}: {
+  children: React.ReactNode;
+}) {
+  // Only create stylesheet once with lazy initial state
+  // x-ref: https://reactjs.org/docs/hooks-reference.html#lazy-initial-state
+  const [styledComponentsStyleSheet] = useState(() => new ServerStyleSheet());
+
+  useServerInsertedHTML(() => {
+    const styles = styledComponentsStyleSheet.getStyleElement();
+    styledComponentsStyleSheet.instance.clearTag();
+    return <>{styles}</>;
+  });
+
+  if (typeof window !== "undefined") return <>{children}</>;
+
+  return (
+    <StyleSheetManager sheet={styledComponentsStyleSheet.instance}>
+      {children}
+    </StyleSheetManager>
+  );
+}


### PR DESCRIPTION
In #337 I noticed that the initial render for our app is always blank. I had a suspicion that this would be hiding some surprises

If you load that page without JS enabled you'll see that the initial render is missing the styled components styling. I've followed the [official guide](https://nextjs.org/docs/app/building-your-application/styling/css-in-js#styled-components) to integration styled components, and checked that it's the same approach the OWA uses