### PR TITLE
fix: add missing prisma import

### DIFF
--- a/packages/api/src/router/chats.ts
+++ b/packages/api/src/router/chats.ts
@@ -1,3 +1,4 @@
+import { prisma } from "@oakai/db/client";
 import * as Sentry from "@sentry/nextjs";
 import { TRPCError } from "@trpc/server";
 import { isTruthy } from "remeda";


### PR DESCRIPTION
## Description

- The "prisma" import is missing from this file because we have a global prisma type definition in packages/db/client
