### PR TITLE
fix: only categorise initial user input once

### DIFF
--- a/apps/nextjs/src/app/api/chat/config.ts
+++ b/apps/nextjs/src/app/api/chat/config.ts
@@ -17,7 +17,7 @@ export const defaultConfig: Config = {
   prisma: globalPrisma,
   createAila: async (options) => {
     const webActionsPlugin = createWebActionsPlugin(globalPrisma);
-    return new Aila({
+    const createdAila = new Aila({
       ...options,
       plugins: [...(options.plugins || []), webActionsPlugin],
       prisma: options.prisma ?? globalPrisma,
@@ -26,5 +26,7 @@ export const defaultConfig: Config = {
         userId: undefined,
       },
     });
+    await createdAila.initialise();
+    return createdAila;
   },
 };

--- a/apps/nextjs/src/app/api/chat/route.test.ts
+++ b/apps/nextjs/src/app/api/chat/route.test.ts
@@ -57,7 +57,9 @@ describe("Chat API Route", () => {
             chatCategoriser: mockChatCategoriser,
           },
         };
-        return new Aila(ailaConfig);
+        const ailaInstance = new Aila(ailaConfig);
+        await ailaInstance.initialise();
+        return ailaInstance;
       }),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       prisma: {} as any,

--- a/packages/aila/src/core/Aila.test.ts
+++ b/packages/aila/src/core/Aila.test.ts
@@ -1,6 +1,7 @@
 import type { Polly } from "@pollyjs/core";
 
 import { setupPolly } from "../../tests/mocks/setupPolly";
+import type { AilaCategorisation } from "../features/categorisation";
 import { MockCategoriser } from "../features/categorisation/categorisers/MockCategoriser";
 import { Aila } from "./Aila";
 import { AilaAuthenticationError } from "./AilaError";
@@ -71,6 +72,96 @@ describe("Aila", () => {
 
       await ailaInstance.initialise();
 
+      expect(ailaInstance.lesson.plan.title).toBe("Roman Britain");
+      expect(ailaInstance.lesson.plan.subject).toBe("history");
+      expect(ailaInstance.lesson.plan.keyStage).toBe("key-stage-2");
+    });
+
+    it("should use the categoriser to determine the lesson plan from user input if the lesson plan is not already set up", async () => {
+      const mockCategoriser = {
+        categorise: jest.fn().mockResolvedValue({
+          keyStage: "key-stage-2",
+          subject: "history",
+          title: "Roman Britain",
+          topic: "The Roman Empire",
+        }),
+      };
+
+      const ailaInstance = new Aila({
+        lessonPlan: {},
+        chat: {
+          id: "123",
+          userId: "user123",
+          messages: [
+            {
+              id: "1",
+              role: "user",
+              content:
+                "Create a lesson about Roman Britain for Key Stage 2 History",
+            },
+          ],
+        },
+        options: {
+          usePersistence: false,
+          useRag: false,
+          useAnalytics: false,
+          useModeration: false,
+        },
+        plugins: [],
+        services: {
+          chatCategoriser: mockCategoriser as unknown as AilaCategorisation,
+        },
+      });
+
+      await ailaInstance.initialise();
+
+      expect(mockCategoriser.categorise).toHaveBeenCalledTimes(1);
+      expect(ailaInstance.lesson.plan.title).toBe("Roman Britain");
+      expect(ailaInstance.lesson.plan.subject).toBe("history");
+      expect(ailaInstance.lesson.plan.keyStage).toBe("key-stage-2");
+    });
+
+    it("should not use the categoriser to determine the lesson plan from user input if the lesson plan is already set up", async () => {
+      const mockCategoriser = {
+        categorise: jest.fn().mockResolvedValue({
+          keyStage: "key-stage-2",
+          subject: "history",
+          title: "Roman Britain",
+          topic: "The Roman Empire",
+        }),
+      };
+      const ailaInstance = new Aila({
+        lessonPlan: {
+          title: "Roman Britain",
+          subject: "history",
+          keyStage: "key-stage-2",
+        },
+        chat: {
+          id: "123",
+          userId: "user123",
+          messages: [
+            {
+              id: "1",
+              role: "user",
+              content:
+                "Create a lesson about Roman Britain for Key Stage 2 History",
+            },
+          ],
+        },
+        options: {
+          usePersistence: false,
+          useRag: false,
+          useAnalytics: false,
+          useModeration: false,
+        },
+        plugins: [],
+        services: {
+          chatCategoriser: mockCategoriser as unknown as AilaCategorisation,
+        },
+      });
+
+      await ailaInstance.initialise();
+      expect(mockCategoriser.categorise).toHaveBeenCalledTimes(0);
       expect(ailaInstance.lesson.plan.title).toBe("Roman Britain");
       expect(ailaInstance.lesson.plan.subject).toBe("history");
       expect(ailaInstance.lesson.plan.keyStage).toBe("key-stage-2");

--- a/packages/aila/src/core/Aila.test.ts
+++ b/packages/aila/src/core/Aila.test.ts
@@ -226,6 +226,8 @@ describe("Aila", () => {
       expect(ailaInstance.lesson.plan.subject).not.toBeDefined();
       expect(ailaInstance.lesson.plan.keyStage).not.toBeDefined();
 
+      await ailaInstance.initialise();
+
       await ailaInstance.generateSync({
         input: "Glaciation",
       });
@@ -294,6 +296,8 @@ describe("Aila", () => {
           chatLlmService,
         },
       });
+
+      await ailaInstance.initialise();
 
       await ailaInstance.generateSync({
         input:


### PR DESCRIPTION
## Description

Back-end only, no user-facing change other than speeding up each message by a few seconds in the initial response time.

- We currently have a bug where we categorise the lesson plan each time we send a message
- This is because we were failing to call the aila.initialise() method consistently
- This add a private boolean flag to Aila to store that it has been initialised
- generate and generateAsync will throw if the instance has not been initialised
- Updates tests to call the initialise method
- Update the Aila test to ensure we only categorise empty lesson plans once
- We have this separate initialise method because it is async and cannot be called in the constructor (unless I am mistaken!)

## How to test
* Run the dev server
* Start a new lesson
* See a log for aila:categorisation with the initial message as input
* Send a another message
* No further aila:categorisation logs appear