### PR TITLE
chore: add expired exports cron job to public routes

### DIFF
--- a/apps/nextjs/src/middlewares/auth.middleware.ts
+++ b/apps/nextjs/src/middlewares/auth.middleware.ts
@@ -23,6 +23,7 @@ const publicRoutes = [
   "/aila/health",
   "/api/trpc/main/health.check",
   "/api/trpc/chat/chat.health.check",
+  "/api/cron-jobs/expired-exports",
   /**
    * The inngest route is protected using a signing key
    * @see https://www.inngest.com/docs/faq#my-app-s-serve-endpoint-requires-authentication-what-should-i-do


### PR DESCRIPTION
## Description

- Cron job was being redirected to clerk login page, this PR adds it to the public route

## Issue(s)

Fixes #

## How to test

` curl -H "Authorization: Bearer [CRON_SECRET]" http://localhost:2525/api/cron-jobs/expired-exports`
 
 You should see an update on the cron job not - 
`/sign-in?redirect_url=http%3A%2F%2Flocalhost%3A2525%2Fapi%2Fcron-jobs%2Fexpired-exports%   `

## Screenshots


## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
