### PR TITLE
feat: link to hubspot form from requests for full access and higher rate - AI-626 AI-627

### DIFF
--- a/apps/nextjs/src/app/faqs/index.tsx
+++ b/apps/nextjs/src/app/faqs/index.tsx
@@ -722,7 +722,7 @@ const FAQPage = () => {
                 the volume of requests that can be made, lessons, and resources
                 that can be generated. If you&apos;re reaching these limits,
                 we&apos;d love to hear from you, and you can{" "}
-                <OakLink href="https://forms.gle/tHsYMZJR367zydsG8">
+                <OakLink href="https://share.hsforms.com/118hyngR-QSS0J7vZEVlRSgbvumd">
                   request a higher limit.
                 </OakLink>
               </OakP>

--- a/apps/nextjs/src/components/ContextProviders/Demo.tsx
+++ b/apps/nextjs/src/components/ContextProviders/Demo.tsx
@@ -54,7 +54,8 @@ export function DemoProvider({ children }: Readonly<DemoProviderProps>) {
             isDemoUser,
             appSessionsRemaining,
             appSessionsPerMonth: DEMO_APP_SESSIONS_PER_30D,
-            contactHref: "mailto:help@thenational.academy",
+            contactHref:
+              "https://share.hsforms.com/1R9ulYSNPQgqElEHde3KdhAbvumd",
             isSharingEnabled,
           }
         : {


### PR DESCRIPTION
## Description

- Updates email for demo teacher access banner and request a higher limit link in FAQ to hubspot forms
- Dopper secrets updated for RATELIMIT_FORM_URL

## Issue(s)

Fixes #

## How to test

/faqs.  - [request a higher limit.](https://share.hsforms.com/118hyngR-QSS0J7vZEVlRSgbvumd)
/alia.   - [contact us for full access](https://share.hsforms.com/1R9ulYSNPQgqElEHde3KdhAbvumd) - with demo account enabled



## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
