### PR TITLE
test: stories for right hand side of lesson planner

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -56,7 +56,6 @@
     "@radix-ui/themes": "^1.0.0",
     "@sanity/client": "^6.21.3",
     "@sentry/nextjs": "^8.35.0",
-    "@storybook/testing-react": "^2.0.1",
     "@tanstack/react-query": "^4.16.1",
     "@testing-library/jest-dom": "^6.4.8",
     "@testing-library/react": "^16.0.0",

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.stories.tsx
@@ -1,0 +1,72 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import type { ChatContextProps } from "@/components/ContextProviders/ChatProvider";
+import { ChatContext } from "@/components/ContextProviders/ChatProvider";
+
+import LessonPlanDisplay from "./chat-lessonPlanDisplay";
+
+const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
+  <ChatContext.Provider
+    value={
+      {
+        id: "123",
+        lastModeration: null,
+        messages: [],
+        lessonPlan: {
+          title: "About Frogs",
+          keyStage: "Key Stage 2",
+          subject: "Science",
+          topic: "Amphibians",
+          basedOn: "Frogs in Modern Britain",
+          learningOutcome:
+            "To understand the importance of frogs in British society and culture",
+        },
+        ailaStreamingStatus: "Idle",
+        ...parameters.chatContext,
+      } as unknown as ChatContextProps
+    }
+  >
+    <Story />
+  </ChatContext.Provider>
+);
+
+const meta: Meta<typeof LessonPlanDisplay> = {
+  title: "Components/Chat/LessonPlanDisplay",
+  component: LessonPlanDisplay,
+  tags: ["autodocs"],
+  decorators: [ChatDecorator],
+  args: {
+    documentContainerRef: { current: null },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<typeof LessonPlanDisplay>;
+
+export const Default: Story = {
+  args: {},
+  parameters: {
+    chatContext: {},
+  },
+};
+
+export const Loading: Story = {
+  args: {},
+  parameters: {
+    chatContext: {
+      lessonPlan: {},
+    },
+  },
+};
+
+export const WithModeration: Story = {
+  args: {},
+  parameters: {
+    chatContext: {
+      lastModeration: {
+        categories: ["l/strong-language"],
+      },
+    },
+  },
+};

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.stories.tsx
@@ -31,7 +31,7 @@ const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
 );
 
 const meta: Meta<typeof LessonPlanDisplay> = {
-  title: "Components/Chat/LessonPlanDisplay",
+  title: "Components/LessonPlan/LessonPlanDisplay",
   component: LessonPlanDisplay,
   tags: ["autodocs"],
   decorators: [ChatDecorator],

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.tsx
@@ -1,16 +1,13 @@
 import React, { useRef, useState } from "react";
 
-import { OakIcon, OakSmallSecondaryButton } from "@oaknational/oak-components";
-import Link from "next/link";
-
 import { useLessonChat } from "@/components/ContextProviders/ChatProvider";
 
 import AiIcon from "../../AiIcon";
 import type { DemoContextProps } from "../../ContextProviders/Demo";
-import { useDialog } from "../DialogContext";
 import LessonPlanDisplay from "./chat-lessonPlanDisplay";
 import ExportButtons from "./export-buttons";
 import { LessonPlanProgressBar } from "./export-buttons/LessonPlanProgressBar";
+import { MobileExportButtons } from "./export-buttons/MobileExportButtons";
 import ChatButton from "./ui/chat-button";
 
 type ChatRightHandSideLessonProps = {
@@ -24,8 +21,7 @@ const ChatRightHandSideLesson = ({
   closeMobileLessonPullOut,
   demo,
 }: Readonly<ChatRightHandSideLessonProps>) => {
-  const { id, messages } = useLessonChat();
-  const { setDialogWindow } = useDialog();
+  const { messages } = useLessonChat();
 
   const chatEndRef = useRef<HTMLDivElement>(null);
 
@@ -71,46 +67,10 @@ const ChatRightHandSideLesson = ({
         sectionRefs={sectionRefs}
         documentContainerRef={documentContainerRef}
       />
+      <MobileExportButtons
+        closeMobileLessonPullOut={closeMobileLessonPullOut}
+      />
 
-      <div className="ml-[-10px] mt-27 flex justify-between px-14 pt-6 sm:hidden">
-        <button
-          onClick={() => {
-            closeMobileLessonPullOut();
-          }}
-          className={`${demo.isDemoUser ? "mt-25" : ""} flex items-center justify-center gap-3 `}
-        >
-          <span className="scale-75">
-            <OakIcon iconName="cross" />
-          </span>
-          <span className="text-base font-bold">Hide lesson</span>
-        </button>
-      </div>
-      <div className="sticky top-25 z-10 flex gap-10 bg-white p-12 sm:hidden">
-        <OakSmallSecondaryButton
-          element={Link}
-          iconName="download"
-          href={demo.isSharingEnabled ? `/aila/download/${id}` : "#"}
-          onClick={() => {
-            if (!demo.isSharingEnabled) {
-              setDialogWindow("demo-share-locked");
-            }
-          }}
-        >
-          Download
-        </OakSmallSecondaryButton>
-        <OakSmallSecondaryButton
-          iconName="share"
-          onClick={() => {
-            if (demo.isSharingEnabled) {
-              setDialogWindow("share-chat");
-            } else {
-              setDialogWindow("demo-share-locked");
-            }
-          }}
-        >
-          Share
-        </OakSmallSecondaryButton>
-      </div>
       <button
         className="sticky top-32 z-10 block w-full bg-white px-14 pb-9 pt-12 sm:hidden"
         onClick={() => {

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/index.stories.tsx
@@ -8,6 +8,8 @@ import DropDownSection from "./";
 
 const MAX_INT32 = 2 ** 31 - 1;
 
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
 const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
   <ChatContext.Provider
     value={
@@ -83,7 +85,9 @@ export const Closed: Story = {
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     const toggleButton = await canvas.findByRole("button", { name: "toggle" });
+    await sleep(10);
     await userEvent.click(toggleButton);
+    await canvas.findByAltText("chevron-down");
   },
 };
 

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/index.stories.tsx
@@ -41,12 +41,8 @@ const meta: Meta<typeof DropDownSection> = {
   tags: ["autodocs"],
   args: {
     objectKey: "learningOutcome",
-    // objectKey,
-    // sectionRefs,
     value:
       "I can explain the reasons why frogs are so important to British society and culture",
-    // userHasCancelledAutoScroll,
-    // showLessonMobile,
     documentContainerRef: { current: null },
     streamingTimeout: 0,
   },

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/index.stories.tsx
@@ -1,0 +1,143 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { userEvent, within } from "@storybook/test";
+
+import type { ChatContextProps } from "@/components/ContextProviders/ChatProvider";
+import { ChatContext } from "@/components/ContextProviders/ChatProvider";
+
+import DropDownSection from "./";
+
+const MAX_INT32 = 2 ** 31 - 1;
+
+const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
+  <ChatContext.Provider
+    value={
+      {
+        id: "123",
+        lastModeration: null,
+        messages: [],
+        lessonPlan: {
+          title: "About Frogs",
+          keyStage: "Key Stage 2",
+          subject: "Science",
+          topic: "Amphibians",
+          basedOn: "Frogs in Modern Britain",
+          learningOutcome:
+            "To understand the importance of frogs in British society and culture",
+        },
+        ailaStreamingStatus: "Idle",
+        ...parameters.chatContext,
+      } as unknown as ChatContextProps
+    }
+  >
+    <Story />
+  </ChatContext.Provider>
+);
+
+const meta: Meta<typeof DropDownSection> = {
+  title: "Components/LessonPlan/DropDownSection",
+  component: DropDownSection,
+  tags: ["autodocs"],
+  args: {
+    objectKey: "learningOutcome",
+    // objectKey,
+    // sectionRefs,
+    value:
+      "I can explain the reasons why frogs are so important to British society and culture",
+    // userHasCancelledAutoScroll,
+    // showLessonMobile,
+    documentContainerRef: { current: null },
+    streamingTimeout: 0,
+  },
+  decorators: [ChatDecorator],
+};
+
+export default meta;
+type Story = StoryObj<typeof DropDownSection>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Markdown: Story = {
+  args: {
+    value: `# Title 1
+## Title 2
+### Title 3
+- **Bold**
+- *Italic*
+- Normal`,
+  },
+};
+
+export const Streaming: Story = {
+  args: { streamingTimeout: MAX_INT32 },
+};
+
+export const Closed: Story = {
+  parameters: {
+    docs: {
+      // NOTE: This should run the play function in the docs page, but seems broken
+      story: { autoplay: true },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const toggleButton = await canvas.findByRole("button", { name: "toggle" });
+    await userEvent.click(toggleButton);
+  },
+};
+
+export const AdditionalMaterials: Story = {
+  args: {
+    objectKey: "additionalMaterials",
+    value: "None",
+  },
+};
+
+export const Modify: Story = {
+  parameters: {
+    docs: {
+      // NOTE: This should run the play function in the docs page, but seems broken
+      story: { autoplay: true },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const modifyButton = await canvas.findByRole("button", { name: "Modify" });
+    await userEvent.click(modifyButton);
+  },
+};
+
+export const ModifyAdditionalMaterials: Story = {
+  parameters: {
+    docs: {
+      // NOTE: This should run the play function in the docs page, but seems broken
+      story: { autoplay: true },
+    },
+  },
+  args: {
+    objectKey: "additionalMaterials",
+    value: "None",
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const modifyButton = await canvas.findByRole("button", {
+      name: "Add additional materials",
+    });
+    await userEvent.click(modifyButton);
+  },
+};
+
+export const Flag: Story = {
+  parameters: {
+    docs: {
+      // NOTE: This should run the play function in the docs page, but seems broken
+      story: { autoplay: true },
+    },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    const flagButton = await canvas.findByRole("button", { name: "Flag" });
+    await userEvent.click(flagButton);
+  },
+};

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/index.tsx
@@ -12,14 +12,9 @@ import { scrollToRef } from "@/utils/scrollToRef";
 import Skeleton from "../../common/Skeleton";
 import ChatSection from "./chat-section";
 
-const DropDownSection = ({
-  objectKey,
-  sectionRefs,
-  value,
-  documentContainerRef,
-  userHasCancelledAutoScroll,
-  showLessonMobile,
-}: {
+const HALF_SECOND = 500;
+
+type DropDownSectionProps = {
   objectKey: string;
   sectionRefs: Record<string, React.MutableRefObject<HTMLDivElement | null>>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -27,7 +22,18 @@ const DropDownSection = ({
   documentContainerRef: React.MutableRefObject<HTMLDivElement | null>;
   userHasCancelledAutoScroll: boolean;
   showLessonMobile: boolean;
-}) => {
+  streamingTimeout?: number;
+};
+
+const DropDownSection = ({
+  objectKey,
+  sectionRefs,
+  value,
+  documentContainerRef,
+  userHasCancelledAutoScroll,
+  showLessonMobile,
+  streamingTimeout = HALF_SECOND,
+}: DropDownSectionProps) => {
   const sectionRef = useRef(null);
   if (sectionRefs) sectionRefs[objectKey] = sectionRef;
   const [isOpen, setIsOpen] = useState(false);
@@ -68,7 +74,7 @@ const DropDownSection = ({
       const timer = setTimeout(() => {
         setStatus("isLoaded");
         setPrevValue(value);
-      }, 500); // 0.5 seconds delay
+      }, streamingTimeout);
 
       return () => clearTimeout(timer);
     } else {
@@ -101,7 +107,7 @@ const DropDownSection = ({
           {status === "isLoaded" && <Icon icon="tick" size="sm" />}
         </OakBox>
 
-        <FullWidthButton onClick={() => setIsOpen(!isOpen)}>
+        <FullWidthButton onClick={() => setIsOpen(!isOpen)} aria-label="toggle">
           <OakFlex $width="100%" $justifyContent="space-between">
             <OakP $font="heading-6">{sectionTitle(objectKey)}</OakP>
             <Icon icon={isOpen ? "chevron-up" : "chevron-down"} size="sm" />

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/LessonPlanProgressDropdown.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/LessonPlanProgressDropdown.stories.tsx
@@ -9,7 +9,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import { LessonPlanProgressDropdown } from "./LessonPlanProgressDropdown";
 
 const meta: Meta<typeof LessonPlanProgressDropdown> = {
-  title: "Components/LessonPlanProgressDropdown",
+  title: "Components/LessonPlan/LessonPlanProgressDropdown",
   component: LessonPlanProgressDropdown,
   tags: ["autodocs"],
 };

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import type { ChatContextProps } from "@/components/ContextProviders/ChatProvider";
 import { ChatContext } from "@/components/ContextProviders/ChatProvider";
-import { DemoProvider } from "@/components/ContextProviders/Demo";
+import { DemoContext } from "@/components/ContextProviders/Demo";
 
 import { MobileExportButtons } from "./MobileExportButtons";
 
@@ -19,10 +19,16 @@ const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
   </ChatContext.Provider>
 );
 
-const DemoDecorator: Story["decorators"] = (Story) => (
-  <DemoProvider>
+const DemoDecorator: Story["decorators"] = (Story, { parameters }) => (
+  <DemoContext.Provider
+    value={{
+      isDemoUser: false,
+      isSharingEnabled: true,
+      ...parameters.demoContext,
+    }}
+  >
     <Story />
-  </DemoProvider>
+  </DemoContext.Provider>
 );
 
 const meta: Meta<typeof MobileExportButtons> = {
@@ -40,5 +46,11 @@ type Story = StoryObj<typeof MobileExportButtons>;
 
 export const Default: Story = {};
 
-// TODO
-export const SharingDisabled: Story = {};
+export const SharingDisabled: Story = {
+  parameters: {
+    demoContext: {
+      isDemoUser: true,
+      isSharingEnabled: false,
+    },
+  },
+};

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.stories.tsx
@@ -1,0 +1,44 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import type { ChatContextProps } from "@/components/ContextProviders/ChatProvider";
+import { ChatContext } from "@/components/ContextProviders/ChatProvider";
+import { DemoProvider } from "@/components/ContextProviders/Demo";
+
+import { MobileExportButtons } from "./MobileExportButtons";
+
+const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
+  <ChatContext.Provider
+    value={
+      {
+        id: "123",
+        ...parameters.chatContext,
+      } as unknown as ChatContextProps
+    }
+  >
+    <Story />
+  </ChatContext.Provider>
+);
+
+const DemoDecorator: Story["decorators"] = (Story) => (
+  <DemoProvider>
+    <Story />
+  </DemoProvider>
+);
+
+const meta: Meta<typeof MobileExportButtons> = {
+  title: "Components/LessonPlan/MobileExportButtons",
+  component: MobileExportButtons,
+  tags: ["autodocs"],
+  decorators: [ChatDecorator, DemoDecorator],
+  args: {
+    closeMobileLessonPullOut: () => {},
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof MobileExportButtons>;
+
+export const Default: Story = {};
+
+// TODO
+export const SharingDisabled: Story = {};

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.stories.tsx
@@ -36,6 +36,11 @@ const meta: Meta<typeof MobileExportButtons> = {
   component: MobileExportButtons,
   tags: ["autodocs"],
   decorators: [ChatDecorator, DemoDecorator],
+  parameters: {
+    viewport: {
+      defaultViewport: "mobile1",
+    },
+  },
   args: {
     closeMobileLessonPullOut: () => {},
   },

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.tsx
@@ -1,0 +1,63 @@
+import { OakIcon, OakSmallSecondaryButton } from "@oaknational/oak-components";
+import Link from "next/link";
+
+import { useLessonChat } from "@/components/ContextProviders/ChatProvider";
+import { useDemoUser } from "@/components/ContextProviders/Demo";
+
+import { useDialog } from "../../DialogContext";
+
+type MobileExportButtonsProps = {
+  closeMobileLessonPullOut: () => void;
+};
+
+export const MobileExportButtons = ({
+  closeMobileLessonPullOut,
+}: MobileExportButtonsProps) => {
+  const { id } = useLessonChat();
+  const { setDialogWindow } = useDialog();
+  const demo = useDemoUser();
+
+  return (
+    <>
+      <div className="ml-[-10px] mt-27 flex justify-between px-14 pt-6 sm:hidden">
+        <button
+          onClick={() => {
+            closeMobileLessonPullOut();
+          }}
+          className={`${demo.isDemoUser ? "mt-25" : ""} flex items-center justify-center gap-3 `}
+        >
+          <span className="scale-75">
+            <OakIcon iconName="cross" />
+          </span>
+          <span className="text-base font-bold">Hide lesson</span>
+        </button>
+      </div>
+      <div className="sticky top-25 z-10 flex gap-10 bg-white p-12 sm:hidden">
+        <OakSmallSecondaryButton
+          element={Link}
+          iconName="download"
+          href={demo.isSharingEnabled ? `/aila/download/${id}` : "#"}
+          onClick={() => {
+            if (!demo.isSharingEnabled) {
+              setDialogWindow("demo-share-locked");
+            }
+          }}
+        >
+          Download
+        </OakSmallSecondaryButton>
+        <OakSmallSecondaryButton
+          iconName="share"
+          onClick={() => {
+            if (demo.isSharingEnabled) {
+              setDialogWindow("share-chat");
+            } else {
+              setDialogWindow("demo-share-locked");
+            }
+          }}
+        >
+          Share
+        </OakSmallSecondaryButton>
+      </div>
+    </>
+  );
+};

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/index.stories.tsx
@@ -2,7 +2,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import type { ChatContextProps } from "@/components/ContextProviders/ChatProvider";
 import { ChatContext } from "@/components/ContextProviders/ChatProvider";
-import { DemoProvider } from "@/components/ContextProviders/Demo";
+import { DemoContext } from "@/components/ContextProviders/Demo";
 
 import ExportButtons from "./";
 
@@ -21,10 +21,16 @@ const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
   </ChatContext.Provider>
 );
 
-const DemoDecorator: Story["decorators"] = (Story) => (
-  <DemoProvider>
+const DemoDecorator: Story["decorators"] = (Story, { parameters }) => (
+  <DemoContext.Provider
+    value={{
+      isDemoUser: false,
+      isSharingEnabled: true,
+      ...parameters.demoContext,
+    }}
+  >
     <Story />
-  </DemoProvider>
+  </DemoContext.Provider>
 );
 
 const meta: Meta<typeof ExportButtons> = {
@@ -51,5 +57,11 @@ export const IsStreaming: Story = {
   },
 };
 
-// TODO
-export const SharingDisabled: Story = {};
+export const SharingDisabled: Story = {
+  parameters: {
+    demoContext: {
+      isDemoUser: true,
+      isSharingEnabled: false,
+    },
+  },
+};

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/index.stories.tsx
@@ -1,0 +1,55 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import type { ChatContextProps } from "@/components/ContextProviders/ChatProvider";
+import { ChatContext } from "@/components/ContextProviders/ChatProvider";
+import { DemoProvider } from "@/components/ContextProviders/Demo";
+
+import ExportButtons from "./";
+
+const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
+  <ChatContext.Provider
+    value={
+      {
+        id: "123",
+        isStreaming: false,
+        lessonPlan: {},
+        ...parameters.chatContext,
+      } as unknown as ChatContextProps
+    }
+  >
+    <Story />
+  </ChatContext.Provider>
+);
+
+const DemoDecorator: Story["decorators"] = (Story) => (
+  <DemoProvider>
+    <Story />
+  </DemoProvider>
+);
+
+const meta: Meta<typeof ExportButtons> = {
+  title: "Components/LessonPlan/ExportButtons",
+  component: ExportButtons,
+  tags: ["autodocs"],
+  decorators: [ChatDecorator, DemoDecorator],
+  args: {
+    sectionRefs: {},
+    documentContainerRef: { current: null },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof ExportButtons>;
+
+export const Default: Story = {};
+
+export const IsStreaming: Story = {
+  parameters: {
+    chatContext: {
+      isStreaming: true,
+    },
+  },
+};
+
+// TODO
+export const SharingDisabled: Story = {};

--- a/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
@@ -66,7 +66,7 @@ export type ChatContextProps = {
   executeQueuedAction: () => Promise<void>;
 };
 
-const ChatContext = createContext<ChatContextProps | null>(null);
+export const ChatContext = createContext<ChatContextProps | null>(null);
 
 export type ChatProviderProps = {
   id: string;

--- a/apps/nextjs/src/components/ContextProviders/Demo.tsx
+++ b/apps/nextjs/src/components/ContextProviders/Demo.tsx
@@ -27,7 +27,7 @@ export type DemoContextProps =
       isSharingEnabled: boolean;
     };
 
-const DemoContext = createContext<DemoContextProps | null>(null);
+export const DemoContext = createContext<DemoContextProps | null>(null);
 
 export type DemoProviderProps = Readonly<{ children: React.ReactNode }>;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -164,9 +164,6 @@ importers:
       '@sentry/nextjs':
         specifier: ^8.35.0
         version: 8.35.0(@opentelemetry/api@1.9.0)(@opentelemetry/core@1.26.0)(@opentelemetry/instrumentation@0.53.0)(@opentelemetry/sdk-trace-base@1.26.0)(next@14.2.5)(react@18.2.0)(webpack@5.93.0)
-      '@storybook/testing-react':
-        specifier: ^2.0.1
-        version: 2.0.1(@storybook/client-logger@7.6.20)(@storybook/preview-api@7.6.20)(@storybook/react@8.4.1)(@storybook/types@7.6.20)(react@18.2.0)
       '@tanstack/react-query':
         specifier: ^4.16.1
         version: 4.19.1(react-dom@18.2.0)(react@18.2.0)
@@ -8559,35 +8556,13 @@ packages:
       - webpack-cli
     dev: true
 
-  /@storybook/channels@7.6.20:
-    resolution: {integrity: sha512-4hkgPSH6bJclB2OvLnkZOGZW1WptJs09mhQ6j6qLjgBZzL/ZdD6priWSd7iXrmPiN5TzUobkG4P4Dp7FjkiO7A==}
-    dependencies:
-      '@storybook/client-logger': 7.6.20
-      '@storybook/core-events': 7.6.20
-      '@storybook/global': 5.0.0
-      qs: 6.13.0
-      telejson: 7.2.0
-      tiny-invariant: 1.3.3
-    dev: false
-
-  /@storybook/client-logger@7.6.20:
-    resolution: {integrity: sha512-NwG0VIJQCmKrSaN5GBDFyQgTAHLNishUPLW1NrzqTDNAhfZUoef64rPQlinbopa0H4OXmlB+QxbQIb3ubeXmSQ==}
-    dependencies:
-      '@storybook/global': 5.0.0
-    dev: false
-
   /@storybook/components@8.4.1(storybook@8.4.1):
     resolution: {integrity: sha512-bMPclbBhrWxhFlwqrC/h4fPLl05ouoi5D8SkQTHjeVxWN9eDnMVi76xM0YDct302Z3f0x5S3plIulp+4XRxrvg==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
       storybook: 8.4.1(prettier@3.3.3)
-
-  /@storybook/core-events@7.6.20:
-    resolution: {integrity: sha512-tlVDuVbDiNkvPDFAu+0ou3xBBYbx9zUURQz4G9fAq0ScgBOs/bpzcRrFb4mLpemUViBAd47tfZKdH4MAX45KVQ==}
-    dependencies:
-      ts-dedent: 2.2.0
-    dev: false
+    dev: true
 
   /@storybook/core-webpack@8.4.1(storybook@8.4.1):
     resolution: {integrity: sha512-TptbDGaj9a8wJMF4g+C8t02CXl4BSd0BA/qGWBvzn3j4FJqeQ/m8elOXLYZrPbQKI6PjP0J4ayHkXdX2h0/tUw==}
@@ -8646,6 +8621,7 @@ packages:
 
   /@storybook/global@5.0.0:
     resolution: {integrity: sha512-FcOqPAXACP0I3oJ/ws6/rrPT9WGhu915Cg8D02a9YxLo0DE9zI+a9A5gRGvmQ09fiWPukqI8ZAEoQEdWUKMQdQ==}
+    dev: true
 
   /@storybook/icons@1.2.12(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-UxgyK5W3/UV4VrI3dl6ajGfHM4aOqMAkFLWe2KibeQudLf6NJpDrDMSHwZj+3iKC4jFU7dkKbbtH2h/al4sW3Q==}
@@ -8666,6 +8642,7 @@ packages:
       '@storybook/global': 5.0.0
       '@vitest/utils': 2.1.4
       storybook: 8.4.1(prettier@3.3.3)
+    dev: true
 
   /@storybook/manager-api@8.4.1(storybook@8.4.1):
     resolution: {integrity: sha512-7hb2k4zsp6lREGZbQ85QOlsC8EIMZXuY9Pg12VUgaZd+LmLjLuaqtrxRz3SwIgIWsRpFun9AHO0X37DmYNGTSw==}
@@ -8673,6 +8650,7 @@ packages:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
       storybook: 8.4.1(prettier@3.3.3)
+    dev: true
 
   /@storybook/nextjs@8.4.1(esbuild@0.21.5)(next@14.2.5)(react-dom@18.2.0)(react@18.2.0)(storybook@8.4.1)(typescript@5.3.3)(webpack@5.93.0):
     resolution: {integrity: sha512-SOEI8qOY+yLsRsvjokSevqtA+E+cXHDBObwPUJKmRxIAEwbP1uJEFnbvpZULs1pQl1gYsZQxEndbkTmM5pwtoQ==}
@@ -8793,31 +8771,13 @@ packages:
       - webpack-cli
     dev: true
 
-  /@storybook/preview-api@7.6.20:
-    resolution: {integrity: sha512-3ic2m9LDZEPwZk02wIhNc3n3rNvbi7VDKn52hDXfAxnL5EYm7yDICAkaWcVaTfblru2zn0EDJt7ROpthscTW5w==}
-    dependencies:
-      '@storybook/channels': 7.6.20
-      '@storybook/client-logger': 7.6.20
-      '@storybook/core-events': 7.6.20
-      '@storybook/csf': 0.1.11
-      '@storybook/global': 5.0.0
-      '@storybook/types': 7.6.20
-      '@types/qs': 6.9.15
-      dequal: 2.0.3
-      lodash: 4.17.21
-      memoizerific: 1.11.3
-      qs: 6.13.0
-      synchronous-promise: 2.0.17
-      ts-dedent: 2.2.0
-      util-deprecate: 1.0.2
-    dev: false
-
   /@storybook/preview-api@8.4.1(storybook@8.4.1):
     resolution: {integrity: sha512-VdnESYfXCUasNtMd5s1Q8DPqMnAUdpROn8mE8UAD79Cy7DSNesI1q0SATuJqh5iYCT/+3Tpjfghsr2zC/mOh8w==}
     peerDependencies:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
       storybook: 8.4.1(prettier@3.3.3)
+    dev: true
 
   /@storybook/react-docgen-typescript-plugin@1.0.6--canary.9.0c3f3b7.0(typescript@5.3.3)(webpack@5.93.0):
     resolution: {integrity: sha512-KUqXC3oa9JuQ0kZJLBhVdS4lOneKTOopnNBK4tUAgoxWQ3u/IjzdueZjFr7gyBrXMoU6duutk3RQR9u8ZpYJ4Q==}
@@ -8848,6 +8808,7 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       storybook: 8.4.1(prettier@3.3.3)
+    dev: true
 
   /@storybook/react@8.4.1(@storybook/test@8.4.1)(react-dom@18.2.0)(react@18.2.0)(storybook@8.4.1)(typescript@5.3.3):
     resolution: {integrity: sha512-ZwszrzV47nWQEZ0X4LyNgv5OFq4iy/7LpmxW6IncIO7PWm70OWG2BVtKFNsNQx0LY+hOtllWZbvg06mPQzahFA==}
@@ -8875,6 +8836,7 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
       storybook: 8.4.1(prettier@3.3.3)
       typescript: 5.3.3
+    dev: true
 
   /@storybook/test@8.4.1(storybook@8.4.1):
     resolution: {integrity: sha512-najn9kCxB8NaHykhD7Fv+Iq0FnxmIJYOJlYiI8NMgVLwaSDFf6gnqAY6HHVPRqkhej8TuT1L2e2RxKqzWEB+mA==}
@@ -8890,25 +8852,7 @@ packages:
       '@vitest/expect': 2.0.5
       '@vitest/spy': 2.0.5
       storybook: 8.4.1(prettier@3.3.3)
-
-  /@storybook/testing-react@2.0.1(@storybook/client-logger@7.6.20)(@storybook/preview-api@7.6.20)(@storybook/react@8.4.1)(@storybook/types@7.6.20)(react@18.2.0):
-    resolution: {integrity: sha512-D0fT7f0TUU8+usR+0NSyCYQCYDWernQqGZou32ISsoBkY9IiH1JMY4hQE8zUaGozu9eMlaa2wieWIMsjWovpdw==}
-    engines: {node: '>=10'}
-    deprecated: In Storybook 7, this package has been promoted to a first-class Storybook functionality. This means that you no longer need it! Instead, you can import the same utilities, but from the @storybook/react package. Please migrate when you can.
-    peerDependencies:
-      '@storybook/client-logger': ^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0
-      '@storybook/preview-api': ^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0
-      '@storybook/react': ^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0
-      '@storybook/types': ^7.0.0-beta.0 || ^7.0.0-rc.0 || ^7.0.0
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-    dependencies:
-      '@storybook/client-logger': 7.6.20
-      '@storybook/csf': 0.1.11
-      '@storybook/preview-api': 7.6.20
-      '@storybook/react': 8.4.1(@storybook/test@8.4.1)(react-dom@18.2.0)(react@18.2.0)(storybook@8.4.1)(typescript@5.3.3)
-      '@storybook/types': 7.6.20
-      react: 18.2.0
-    dev: false
+    dev: true
 
   /@storybook/theming@8.4.1(storybook@8.4.1):
     resolution: {integrity: sha512-Sz24isryVFZaVahXkjgnCsMAQqQeeKg41AtLsldlYdesIo6fr5tc6/SkTUy+CYadK4Dkhqp+vVRDnwToYYRGhA==}
@@ -8916,15 +8860,7 @@ packages:
       storybook: ^8.2.0 || ^8.3.0-0 || ^8.4.0-0 || ^8.5.0-0 || ^8.6.0-0
     dependencies:
       storybook: 8.4.1(prettier@3.3.3)
-
-  /@storybook/types@7.6.20:
-    resolution: {integrity: sha512-GncdY3x0LpbhmUAAJwXYtJDUQEwfF175gsjH0/fxPkxPoV7Sef9TM41jQLJW/5+6TnZoCZP/+aJZTJtq3ni23Q==}
-    dependencies:
-      '@storybook/channels': 7.6.20
-      '@types/babel__core': 7.20.5
-      '@types/express': 4.17.21
-      file-system-cache: 2.3.0
-    dev: false
+    dev: true
 
   /@swc/counter@0.1.3:
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -9013,6 +8949,7 @@ packages:
       dom-accessibility-api: 0.6.3
       lodash: 4.17.21
       redent: 3.0.0
+    dev: true
 
   /@testing-library/react@16.0.0(@testing-library/dom@10.4.0)(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
     resolution: {integrity: sha512-guuxUKRWQ+FgNX0h0NS0FIq3Q3uLtWVpBzcLOggmfMoUpgBnzBzvLLd4fbm6yS8ydJd94cIfY4yP9qUQjM2KwQ==}
@@ -9044,6 +8981,7 @@ packages:
       '@testing-library/dom': '>=7.21.4'
     dependencies:
       '@testing-library/dom': 10.4.0
+    dev: true
 
   /@tootallnate/once@2.0.0:
     resolution: {integrity: sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==}
@@ -9150,29 +9088,26 @@ packages:
       '@types/babel__generator': 7.6.8
       '@types/babel__template': 7.4.4
       '@types/babel__traverse': 7.20.6
+    dev: true
 
   /@types/babel__generator@7.6.8:
     resolution: {integrity: sha512-ASsj+tpEDsEiFr1arWrlN6V3mdfjRMZt6LtK/Vp/kreFLnr5QH5+DhvD5nINYZXzwJvXeGq+05iUXcAzVrqWtw==}
     dependencies:
       '@babel/types': 7.24.5
+    dev: true
 
   /@types/babel__template@7.4.4:
     resolution: {integrity: sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==}
     dependencies:
       '@babel/parser': 7.24.5
       '@babel/types': 7.24.5
+    dev: true
 
   /@types/babel__traverse@7.20.6:
     resolution: {integrity: sha512-r1bzfrm0tomOI8g1SzvCaQHo6Lcv6zu0EA+W2kHrt8dyrHQxGzBBL4kdkzIS+jBMV+EYcMAEAqXqYaLJq5rOZg==}
     dependencies:
       '@babel/types': 7.24.5
-
-  /@types/body-parser@1.19.5:
-    resolution: {integrity: sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==}
-    dependencies:
-      '@types/connect': 3.4.38
-      '@types/node': 18.18.5
-    dev: false
+    dev: true
 
   /@types/buffer-from@1.1.3:
     resolution: {integrity: sha512-2lq4YC9uLUMGHkl2IDtX4tCXSo2+hwMpOJcY1qiIk1kybc31rIlPyM1HCVJhkPFIo75a/pOVxqyvwuf5TpCG/w==}
@@ -9190,12 +9125,6 @@ packages:
 
   /@types/connect@3.4.36:
     resolution: {integrity: sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==}
-    dependencies:
-      '@types/node': 18.18.5
-    dev: false
-
-  /@types/connect@3.4.38:
-    resolution: {integrity: sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==}
     dependencies:
       '@types/node': 18.18.5
     dev: false
@@ -9253,24 +9182,6 @@ packages:
     resolution: {integrity: sha512-XQmGcbnxUNa06HR3VBVkc9+A2Vpi9ZyLJcdS5dwaQQ/4ZMWFO+5c90FnMUpbtMZwB/FChoYHwuVg8TvkECacTA==}
     dev: false
 
-  /@types/express-serve-static-core@4.19.3:
-    resolution: {integrity: sha512-KOzM7MhcBFlmnlr/fzISFF5vGWVSvN6fTd4T+ExOt08bA/dA5kpSzY52nMsI1KDFmUREpJelPYyuslLRSjjgCg==}
-    dependencies:
-      '@types/node': 18.18.5
-      '@types/qs': 6.9.15
-      '@types/range-parser': 1.2.7
-      '@types/send': 0.17.4
-    dev: false
-
-  /@types/express@4.17.21:
-    resolution: {integrity: sha512-ejlPM315qwLpaQlQDTjPdsUFSc6ZsP4AN6AlWnogPjQ7CVi7PYF3YVz+CY3jE2pwYf7E/7HlDAN0rV2GxTG0HQ==}
-    dependencies:
-      '@types/body-parser': 1.19.5
-      '@types/express-serve-static-core': 4.19.3
-      '@types/qs': 6.9.15
-      '@types/serve-static': 1.15.7
-    dev: false
-
   /@types/file-saver@2.0.6:
     resolution: {integrity: sha512-Mw671DVqoMHbjw0w4v2iiOro01dlT/WhWp5uwecBa0Wg8c+bcZOjgF1ndBnlaxhtvFCgTRBtsGivSVhrK/vnag==}
     dev: true
@@ -9312,10 +9223,6 @@ packages:
 
   /@types/http-cache-semantics@4.0.4:
     resolution: {integrity: sha512-1m0bIFVc7eJWyve9S0RnuRgcQqF/Xd5QsUZAZeQFr1Q3/p9JWoQQEqmVy+DPTNpGXwhgIetAoYF8JSc33q29QA==}
-
-  /@types/http-errors@2.0.4:
-    resolution: {integrity: sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==}
-    dev: false
 
   /@types/istanbul-lib-coverage@2.0.6:
     resolution: {integrity: sha512-2QF/t/auWm0lsy8XtKVPG19v3sSOQlJe/YHZgfjb/KBBHOGSV+J2q/S671rcq9uTBrLAXmZpqJiaQbMT+zNU1w==}
@@ -9383,10 +9290,6 @@ packages:
   /@types/mdx@2.0.13:
     resolution: {integrity: sha512-+OWZQfAYyio6YkJb3HLxDrvnx6SWWDbC0zVPfBRzUk0/nqoDyf6dNxQi3eArPe8rJ473nobTMQ/8Zk+LxJ+Yuw==}
     dev: true
-
-  /@types/mime@1.3.5:
-    resolution: {integrity: sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==}
-    dev: false
 
   /@types/minimist@1.2.3:
     resolution: {integrity: sha512-ZYFzrvyWUNhaPomn80dsMNgMeXxNWZBdkuG/hWlUvXvbdUH8ZERNBGXnU87McuGcWDsyzX2aChCv/SVN348k3A==}
@@ -9472,10 +9375,6 @@ packages:
       types-ramda: 0.30.1
     dev: false
 
-  /@types/range-parser@1.2.7:
-    resolution: {integrity: sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==}
-    dev: false
-
   /@types/react-dom@18.2.19:
     resolution: {integrity: sha512-aZvQL6uUbIJpjZk4U8JZGbau9KDeAwMfmhyWorxgBkqDIEf6ROjRozcmPIicqsUwPUjbkDfHKgGee1Lq65APcA==}
     dependencies:
@@ -9515,21 +9414,6 @@ packages:
   /@types/semver@7.5.0:
     resolution: {integrity: sha512-G8hZ6XJiHnuhQKR7ZmysCeJWE08o8T0AXtk5darsCaTVsYZhhgUrq53jizaR2FvsoeCwJhlmwTjkXBY5Pn/ZHw==}
     dev: true
-
-  /@types/send@0.17.4:
-    resolution: {integrity: sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==}
-    dependencies:
-      '@types/mime': 1.3.5
-      '@types/node': 18.18.5
-    dev: false
-
-  /@types/serve-static@1.15.7:
-    resolution: {integrity: sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==}
-    dependencies:
-      '@types/http-errors': 2.0.4
-      '@types/node': 18.18.5
-      '@types/send': 0.17.4
-    dev: false
 
   /@types/set-cookie-parser@2.4.9:
     resolution: {integrity: sha512-bCorlULvl0xTdjj4BPUHX4cqs9I+go2TfW/7Do1nnFYWS0CPP429Qr1AY42kiFhCwLpvAkWFr1XIBHd8j6/MCQ==}
@@ -9844,21 +9728,25 @@ packages:
       '@vitest/utils': 2.0.5
       chai: 5.1.2
       tinyrainbow: 1.2.0
+    dev: true
 
   /@vitest/pretty-format@2.0.5:
     resolution: {integrity: sha512-h8k+1oWHfwTkyTkb9egzwNMfJAEx4veaPSnMeKbVSjp4euqGSbQlm5+6VHwTr7u4FJslVVsUG5nopCaAYdOmSQ==}
     dependencies:
       tinyrainbow: 1.2.0
+    dev: true
 
   /@vitest/pretty-format@2.1.4:
     resolution: {integrity: sha512-L95zIAkEuTDbUX1IsjRl+vyBSLh3PwLLgKpghl37aCK9Jvw0iP+wKwIFhfjdUtA2myLgjrG6VU6JCFLv8q/3Ww==}
     dependencies:
       tinyrainbow: 1.2.0
+    dev: true
 
   /@vitest/spy@2.0.5:
     resolution: {integrity: sha512-c/jdthAhvJdpfVuaexSrnawxZz6pywlTPe84LUB2m/4t3rl2fTo9NFGBG4oWgaD+FTgDDV8hJ/nibT7IfH3JfA==}
     dependencies:
       tinyspy: 3.0.2
+    dev: true
 
   /@vitest/utils@2.0.5:
     resolution: {integrity: sha512-d8HKbqIcya+GR67mkZbrzhS5kKhtp8dQLcmRZLGTscGVg7yImT82cIrhtn2L8+VujWcy6KZweApgNmPsTAO/UQ==}
@@ -9867,6 +9755,7 @@ packages:
       estree-walker: 3.0.3
       loupe: 3.1.2
       tinyrainbow: 1.2.0
+    dev: true
 
   /@vitest/utils@2.1.4:
     resolution: {integrity: sha512-MXDnZn0Awl2S86PSNIim5PWXgIAx8CIkzu35mBdSApUip6RFOGXBCf3YFyeEu8n1IHk4bWD46DeYFu9mQlFIRg==}
@@ -9874,6 +9763,7 @@ packages:
       '@vitest/pretty-format': 2.1.4
       loupe: 3.1.2
       tinyrainbow: 1.2.0
+    dev: true
 
   /@vue/compiler-core@3.4.26:
     resolution: {integrity: sha512-N9Vil6Hvw7NaiyFUFBPXrAyETIGlQ8KcFMkyk6hW1Cl6NvoqvP+Y8p1Eqvx+UdqsnrnI9+HMUEJegzia3mhXmQ==}
@@ -10601,6 +10491,7 @@ packages:
   /assertion-error@2.0.1:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
+    dev: true
 
   /ast-types-flow@0.0.8:
     resolution: {integrity: sha512-OH/2E5Fg20h2aPrbe+QL8JZQFko0YZaF+j4mnQ7BGhfavO7OpSLa8a0y9sBwomHdSbkhTS8TQNayBfnW5DwbvQ==}
@@ -11349,6 +11240,7 @@ packages:
       deep-eql: 5.0.2
       loupe: 3.1.2
       pathval: 2.0.0
+    dev: true
 
   /chalk@2.4.2:
     resolution: {integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==}
@@ -11463,6 +11355,7 @@ packages:
   /check-error@2.1.1:
     resolution: {integrity: sha512-OAlb+T7V4Op9OwdkjmguYRqncdlx5JiofwOAUkmTF+jNdHwzTaTs4sRAGpzLF3oOz5xAyDGrPgeIDFQmDOTiJw==}
     engines: {node: '>= 16'}
+    dev: true
 
   /cheerio-select@2.1.0:
     resolution: {integrity: sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==}
@@ -12567,6 +12460,7 @@ packages:
   /deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
+    dev: true
 
   /deep-equal@2.2.3:
     resolution: {integrity: sha512-ZIwpnevOurS8bpT4192sqAowWM76JDKSHYzMLty3BZGSswgq6pBaH3DhCSW5xVAZICZyKdOBPjwww5wfgT/6PA==}
@@ -14033,13 +13927,6 @@ packages:
     resolution: {integrity: sha512-P9bmyZ3h/PRG+Nzga+rbdI4OEpNDzAVyy74uVO9ATgzLK6VtAsYybF/+TOCvrc0MO793d6+42lLyZTw7/ArVzA==}
     dev: false
 
-  /file-system-cache@2.3.0:
-    resolution: {integrity: sha512-l4DMNdsIPsVnKrgEXbJwDJsA5mB8rGwHYERMgqQx/xAUtChPJMre1bXBzDEqqVbWv9AIbFezXMxeEkZDSrXUOQ==}
-    dependencies:
-      fs-extra: 11.1.1
-      ramda: 0.29.0
-    dev: false
-
   /filesize@10.1.4:
     resolution: {integrity: sha512-ryBwPIIeErmxgPnm6cbESAzXjuEFubs+yKYLBZvg3CaiNcmkJChoOGcBSrZ6IwkMwPABwPpVXE6IlNdGJJrvEg==}
     engines: {node: '>= 10.4.0'}
@@ -14285,15 +14172,6 @@ packages:
       jsonfile: 6.1.0
       universalify: 2.0.1
     dev: true
-
-  /fs-extra@11.1.1:
-    resolution: {integrity: sha512-MGIE4HOvQCeUCzmlHs0vXpih4ysz4wg9qiSAu6cd42lVwPbTM1TjV7RusoyQqMmk/95gdQZX72u+YW+c3eEpFQ==}
-    engines: {node: '>=14.14'}
-    dependencies:
-      graceful-fs: 4.2.11
-      jsonfile: 6.1.0
-      universalify: 2.0.1
-    dev: false
 
   /fs-extra@11.2.0:
     resolution: {integrity: sha512-PmDi3uwK5nFuXh7XDTlVnS17xJS7vW36is2+w3xcv8SVxiB4NyATf4ctkVY5bkSjX0Y4nbvZCq1/EjtEyr9ktw==}
@@ -17488,6 +17366,7 @@ packages:
 
   /loupe@3.1.2:
     resolution: {integrity: sha512-23I4pFZHmAemUnz8WZXbYRSKYj801VDaNv9ETuMh7IrMc7VuVVSo+Z9iLE3ni30+U48iDWfi30d3twAXBYmnCg==}
+    dev: true
 
   /lower-case-first@1.0.2:
     resolution: {integrity: sha512-UuxaYakO7XeONbKrZf5FEgkantPf5DUqDayzP5VXZrtRPdH86s4kN47I8B3TW10S4QKiE3ziHNf3kRN//okHjA==}
@@ -17604,6 +17483,7 @@ packages:
 
   /map-or-similar@1.5.0:
     resolution: {integrity: sha512-0aF7ZmVon1igznGI4VS30yugpduQW3y3GkcgGJOp7d8x8QrizhigUxjI/m2UojsXXto+jLAH3KSz+xOJTiORjg==}
+    dev: true
 
   /markdown-table@3.0.3:
     resolution: {integrity: sha512-Z1NL3Tb1M9wH4XESsCDEksWoKTdlUafKc4pt0GRwjUyXaCFZ+dc3g2erqB6zm3szA2IUSi7VnPI+o/9jnxh9hw==}
@@ -17815,6 +17695,7 @@ packages:
     resolution: {integrity: sha512-/EuHYwAPdLtXwAwSZkh/Gutery6pD2KYd44oQLhAvQp/50mpyduZh8Q7PYHXTCJ+wuXxt7oij2LXyIJOOYFPog==}
     dependencies:
       map-or-similar: 1.5.0
+    dev: true
 
   /meow@12.1.1:
     resolution: {integrity: sha512-BhXM0Au22RwUneMPwSCnyhTOizdWoIEPU9sp0Aqa1PnDMR5Wv2FGXYDjuzJEIX+Eo2Rb8xuYe5jrnm5QowQFkw==}
@@ -19507,6 +19388,7 @@ packages:
   /pathval@2.0.0:
     resolution: {integrity: sha512-vE7JKRyES09KiunauX7nd2Q9/L7lhok4smP9RZTDeD4MVs72Dp2qNFVz39Nz5a0FVEW0BJR6C0DYrq6unoziZA==}
     engines: {node: '>= 14.16'}
+    dev: true
 
   /pbkdf2@3.1.2:
     resolution: {integrity: sha512-iuh7L6jA7JEGu2WxDwtQP1ddOpaJNC4KlDEFfdQajSGgGPNi4OyDc2R7QnbY2bR9QjBVGwgvTdNJZoE7RaxUMA==}
@@ -20249,10 +20131,6 @@ packages:
 
   /radix3@1.1.0:
     resolution: {integrity: sha512-pNsHDxbGORSvuSScqNJ+3Km6QAVqk8CfsCBIEoDgpqLrkD2f3QM4I7d1ozJJ172OmIcoUcerZaNWqtLkRXTV3A==}
-    dev: false
-
-  /ramda@0.29.0:
-    resolution: {integrity: sha512-BBea6L67bYLtdbOqfp8f58fPMqEwx0doL+pAi8TZyp2YWz8R9G8z9x75CZI8W+ftqhFHCpEX2cRnUUXK130iKA==}
     dev: false
 
   /ramda@0.30.1:
@@ -22196,10 +22074,6 @@ packages:
     resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
     dev: false
 
-  /synchronous-promise@2.0.17:
-    resolution: {integrity: sha512-AsS729u2RHUfEra9xJrE39peJcc2stq2+poBXX8bcM08Y6g9j/i/PUzwNQqkaJde7Ntg1TO7bSREbR5sdosQ+g==}
-    dev: false
-
   /synckit@0.8.4:
     resolution: {integrity: sha512-Dn2ZkzMdSX827QbowGbU/4yjWuvNaCoScLLoMo/yKbu+P4GBR6cRGKZH27k6a9bRzdqcyd1DE96pQtQ6uNkmyw==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -22295,12 +22169,6 @@ packages:
     transitivePeerDependencies:
       - encoding
       - supports-color
-    dev: false
-
-  /telejson@7.2.0:
-    resolution: {integrity: sha512-1QTEcJkJEhc8OnStBx/ILRu5J2p0GjvWsBx56bmZRqnrkdBMUe+nX92jxV+p3dB4CP6PZCdJMQJwCggkNBMzkQ==}
-    dependencies:
-      memoizerific: 1.11.3
     dev: false
 
   /temp-dir@3.0.0:
@@ -22425,10 +22293,12 @@ packages:
   /tinyrainbow@1.2.0:
     resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
     engines: {node: '>=14.0.0'}
+    dev: true
 
   /tinyspy@3.0.2:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
+    dev: true
 
   /title-case@2.1.1:
     resolution: {integrity: sha512-EkJoZ2O3zdCz3zJsYCsxyq2OC5hrxR9mfdd5I+w8h/tmFfeOxJ+vvkxsKxdmN0WtS9zLdHEgfgVOiMVgv+Po4Q==}


### PR DESCRIPTION
Stories for:

- LessonPlanDisplay: The right hand side view that pulls it all together
- ExportButtons
- MobileExportButtons: These are extracted from LessonPlanDisplay
- DropDownSection: Including variants for different states, content, and for the modify dropdown

These components use the ChatContext, so I've specified a mock context in each file. If we find we're doing this a lot and that there are some consistent use cases we can find a reusable pattern later

### Challenges:
- There's a snapshot to show a collapsed section. That needed a `play` function to click the component. In both the "docs" page and chromatic I had to add a 50ms timeout before clicking
- The mobile export buttons only render on mobile, so I had to specify a mobile viewport

You can view the changes [in chromatic](https://www.chromatic.com/review?appId=672908473f629875f0be294f&number=377&type=linked&view=changes)