### PR TITLE
fix: revert tabindex change

### DIFF
--- a/apps/nextjs/src/components/DialogControl/ContentOptions/ModalFooterButtons.tsx
+++ b/apps/nextjs/src/components/DialogControl/ContentOptions/ModalFooterButtons.tsx
@@ -23,7 +23,7 @@ const ModalFooterButtons = ({
       <OakLinkNoUnderline
         onClick={() => closeDialog()}
         element="button"
-        tabIndex={0}
+        tabIndex={1}
       >
         <OakSpan $font="body-2-bold" $color="black" $textDecoration="none">
           Cancel

--- a/apps/nextjs/src/components/Feedback/index.tsx
+++ b/apps/nextjs/src/components/Feedback/index.tsx
@@ -130,7 +130,7 @@ const FeedBack = ({
                   {question.question}
                 </label>
                 <textarea
-                  tabIndex={0}
+                  tabIndex={1}
                   className="h-32 w-full min-w-[300px] rounded border-2 border-black p-10"
                   onChange={(e) => {
                     setUsersResponse({
@@ -146,7 +146,7 @@ const FeedBack = ({
         })}
         <div className="flex justify-center">
           <OakPrimaryButton
-            tabIndex={0}
+            tabIndex={1}
             onClick={() => {
               submitSurvey(usersResponse);
               onSubmit();


### PR DESCRIPTION
## Description

- I accepted a Sonar rule to not have positive integer tabindex values
- This changed UX for keyboard navigation
- So this reverts it and we can address this in a different way later