### PR TITLE
fix: memoize the sidebar context provider's value

### DIFF
--- a/apps/nextjs/src/lib/hooks/use-sidebar.tsx
+++ b/apps/nextjs/src/lib/hooks/use-sidebar.tsx
@@ -1,36 +1,41 @@
 "use client";
 
-import * as React from "react";
+import {
+  createContext,
+  useContext,
+  useMemo,
+  useState,
+  useEffect,
+  useCallback,
+} from "react";
 
 const LOCAL_STORAGE_KEY = "sidebar";
 
-interface SidebarContext {
+export interface SidebarContext {
   isSidebarOpen: boolean;
   toggleSidebar: () => void;
   isLoading: boolean;
 }
 
-const SidebarContext = React.createContext<SidebarContext | undefined>(
-  undefined,
-);
+const SidebarContext = createContext<SidebarContext | undefined>(undefined);
 
 export function useSidebar() {
-  const context = React.useContext(SidebarContext);
+  const context = useContext(SidebarContext);
   if (!context) {
     throw new Error("useSidebarContext must be used within a SidebarProvider");
   }
   return context;
 }
 
-interface SidebarProviderProps {
+export interface SidebarProviderProps {
   readonly children: React.ReactNode;
 }
 
 export function SidebarProvider({ children }: SidebarProviderProps) {
-  const [isSidebarOpen, setSidebarOpen] = React.useState(false);
-  const [isLoading, setLoading] = React.useState(true);
+  const [isSidebarOpen, setSidebarOpen] = useState(false);
+  const [isLoading, setLoading] = useState(true);
 
-  React.useEffect(() => {
+  useEffect(() => {
     const value = localStorage.getItem(LOCAL_STORAGE_KEY);
     if (value) {
       setSidebarOpen(false);
@@ -38,18 +43,20 @@ export function SidebarProvider({ children }: SidebarProviderProps) {
     setLoading(false);
   }, []);
 
-  const toggleSidebar = () => {
+  const toggleSidebar = useCallback(() => {
     setSidebarOpen((value) => {
       const newState = !value;
       localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newState));
       return newState;
     });
-  };
+  }, [setSidebarOpen]);
+
+  const contextValue = useMemo(() => {
+    return { isSidebarOpen, toggleSidebar, isLoading };
+  }, [isSidebarOpen, isLoading, toggleSidebar]);
 
   return (
-    <SidebarContext.Provider
-      value={{ isSidebarOpen, toggleSidebar, isLoading }}
-    >
+    <SidebarContext.Provider value={contextValue}>
       {children}
     </SidebarContext.Provider>
   );

--- a/packages/exports/src/gSuite/docs/populateDoc.ts
+++ b/packages/exports/src/gSuite/docs/populateDoc.ts
@@ -3,7 +3,6 @@ import type { docs_v1 } from "@googleapis/docs";
 import type { Result } from "../../types";
 import type { ValueToString } from "../../utils";
 import { defaultValueToString } from "../../utils";
-import { processImageReplacements } from "./processImagesReplacements";
 import { textReplacements } from "./textReplacements";
 
 /**


### PR DESCRIPTION
## Description

- Addresses a sonar issue complaining that the props of the sidebar provider change each render

