### PR TITLE
fix: sonar minors #5

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
@@ -98,7 +98,6 @@ const createComponents = (
 
     return (
       <CodeBlock
-        key={Math.random()}
         language={match?.[1] ?? ""}
         value={String(children).replace(/\n$/, "")}
         {...restProps}

--- a/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
@@ -20,11 +20,10 @@ import type { PersistedModerationBase } from "@oakai/core/src/utils/ailaModerati
 import type { Moderation } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
 import * as Sentry from "@sentry/nextjs";
-import type { Message } from "ai";
-import { nanoid } from "ai";
-import type { ChatRequestOptions, CreateMessage } from "ai";
+import type { ChatRequestOptions, CreateMessage, Message } from "ai";
 import { useChat } from "ai/react";
 import { useTemporaryLessonPlanWithStreamingEdits } from "hooks/useTemporaryLessonPlanWithStreamingEdits";
+import { nanoid } from "nanoid";
 import { redirect, usePathname, useRouter } from "next/navigation";
 
 import { useLessonPlanTracking } from "@/lib/analytics/lessonPlanTrackingContext";

--- a/apps/nextjs/src/lib/hooks/use-sidebar.tsx
+++ b/apps/nextjs/src/lib/hooks/use-sidebar.tsx
@@ -32,24 +32,24 @@ export interface SidebarProviderProps {
 }
 
 export function SidebarProvider({ children }: SidebarProviderProps) {
-  const [isSidebarOpen, setSidebarOpen] = useState(false);
+  const [isSidebarOpen, setIsSidebarOpen] = useState(false);
   const [isLoading, setLoading] = useState(true);
 
   useEffect(() => {
     const value = localStorage.getItem(LOCAL_STORAGE_KEY);
     if (value) {
-      setSidebarOpen(false);
+      setIsSidebarOpen(false);
     }
     setLoading(false);
   }, []);
 
   const toggleSidebar = useCallback(() => {
-    setSidebarOpen((value) => {
+    setIsSidebarOpen((value) => {
       const newState = !value;
       localStorage.setItem(LOCAL_STORAGE_KEY, JSON.stringify(newState));
       return newState;
     });
-  }, [setSidebarOpen]);
+  }, [setIsSidebarOpen]);
 
   const contextValue = useMemo(() => {
     return { isSidebarOpen, toggleSidebar, isLoading };

--- a/apps/nextjs/src/lib/hooks/use-sidebar.tsx
+++ b/apps/nextjs/src/lib/hooks/use-sidebar.tsx
@@ -33,14 +33,14 @@ export interface SidebarProviderProps {
 
 export function SidebarProvider({ children }: SidebarProviderProps) {
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const [isLoading, setLoading] = useState(true);
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     const value = localStorage.getItem(LOCAL_STORAGE_KEY);
     if (value) {
       setIsSidebarOpen(false);
     }
-    setLoading(false);
+    setIsLoading(false);
   }, []);
 
   const toggleSidebar = useCallback(() => {


### PR DESCRIPTION
## Description

- Minor fixes for Sonar
- nanoid is deprecated in the "ai" package
- When destructuring a useState, the getter and setter should use a consistent naming convention
