### PR TITLE
test: chat quick buttons stories

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-left-hand-side.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-left-hand-side.tsx
@@ -48,14 +48,9 @@ const ChatLeftHandSide = ({
             demo={demo}
           />
         </ChatPanelArea>
-        {!isDemoLocked && (
-          <QuickActionButtons isEmptyScreen={!!messages.length} />
-        )}
+        {!isDemoLocked && <QuickActionButtons />}
       </div>
-      <ChatPanel
-        isEmptyScreen={!!messages.length}
-        isDemoLocked={isDemoLocked}
-      />
+      <ChatPanel isDemoLocked={isDemoLocked} />
       <span className="absolute right-0 top-[-70px] z-10 hidden h-[calc(100vh+100px)] w-3 bg-black sm:block" />
     </Flex>
   );

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-panel.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-panel.tsx
@@ -8,7 +8,6 @@ import useAnalytics from "@/lib/analytics/useAnalytics";
 import ChatPanelDisclaimer from "./chat-panel-disclaimer";
 
 interface ChatPanelProps {
-  isEmptyScreen: boolean;
   isDemoLocked: boolean;
 }
 
@@ -18,13 +17,11 @@ function LockedPromptForm() {
   );
 }
 
-export function ChatPanel({
-  isEmptyScreen,
-  isDemoLocked,
-}: Readonly<ChatPanelProps>) {
+export function ChatPanel({ isDemoLocked }: Readonly<ChatPanelProps>) {
   const chat = useLessonChat();
   const {
     id,
+    messages,
     isLoading,
     input,
     setInput,
@@ -35,11 +32,14 @@ export function ChatPanel({
   } = chat;
 
   const { trackEvent } = useAnalytics();
-  const containerClass = `grid w-full grid-cols-1 ${isEmptyScreen ? "sm:grid-cols-1" : ""} peer-[[data-state=open]]:group-[]:lg:pl-[250px] peer-[[data-state=open]]:group-[]:xl:pl-[300px]`;
+
+  const hasMessages = !!messages.length;
+
+  const containerClass = `grid w-full grid-cols-1 ${hasMessages ? "sm:grid-cols-1" : ""} peer-[[data-state=open]]:group-[]:lg:pl-[250px] peer-[[data-state=open]]:group-[]:xl:pl-[300px]`;
   return (
     <div className={containerClass}>
       <ButtonScrollToBottom />
-      <div className={chatBoxWrap({ isEmptyScreen })}>
+      <div className={chatBoxWrap({ hasMessages })}>
         {!isDemoLocked && (
           <PromptForm
             onSubmit={async (value) => {
@@ -57,7 +57,7 @@ export function ChatPanel({
             input={input}
             setInput={setInput}
             ailaStreamingStatus={ailaStreamingStatus}
-            isEmptyScreen={isEmptyScreen}
+            hasMessages={hasMessages}
             queueUserAction={queueUserAction}
             queuedUserAction={queuedUserAction}
           />
@@ -73,7 +73,7 @@ export function ChatPanel({
 
 const chatBoxWrap = cva(["mx-auto w-full  "], {
   variants: {
-    isEmptyScreen: {
+    hasMessages: {
       false: "max-w-2xl ",
       true: "",
     },

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.stories.tsx
@@ -1,0 +1,133 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import {
+  ChatContext,
+  type ChatContextProps,
+} from "@/components/ContextProviders/ChatProvider";
+import { lessonPlanTrackingContext } from "@/lib/analytics/lessonPlanTrackingContext";
+
+import ChatQuickButtons from "./chat-quick-buttons";
+
+const DummyMessage = {};
+
+const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
+  <ChatContext.Provider
+    value={
+      {
+        messages: [DummyMessage],
+        ...parameters.chatContext,
+      } as unknown as ChatContextProps
+    }
+  >
+    <Story />
+  </ChatContext.Provider>
+);
+
+const LessonPlanTrackingContextDecorator: Story["decorators"] = (Story) => (
+  <lessonPlanTrackingContext.Provider
+    value={{
+      onClickContinue: () => {},
+      onClickRetry: () => {},
+      onClickStartFromExample: () => {},
+      onClickStartFromFreeText: () => {},
+      onStreamFinished: () => {},
+      onSubmitText: () => {},
+    }}
+  >
+    <Story />
+  </lessonPlanTrackingContext.Provider>
+);
+
+const meta: Meta<typeof ChatQuickButtons> = {
+  title: "Components/Chat/ChatQuickButtons",
+  component: ChatQuickButtons,
+  tags: ["autodocs"],
+  decorators: [ChatDecorator, LessonPlanTrackingContextDecorator],
+};
+
+export default meta;
+type Story = StoryObj<typeof ChatQuickButtons>;
+
+export const Idle: Story = {
+  args: {},
+  parameters: {
+    chatContext: {
+      ailaStreamingStatus: "Idle",
+    },
+  },
+};
+
+export const Loading: Story = {
+  args: {},
+  parameters: {
+    chatContext: {
+      ailaStreamingStatus: "Loading",
+    },
+  },
+};
+
+export const LoadingWithoutMessages: Story = {
+  args: {},
+  parameters: {
+    chatContext: {
+      ailaStreamingStatus: "Loading",
+      messages: [],
+    },
+  },
+};
+
+export const RequestMade: Story = {
+  args: {},
+  parameters: {
+    chatContext: {
+      ailaStreamingStatus: "RequestMade",
+    },
+  },
+};
+
+export const StreamingLessonPlan: Story = {
+  args: {},
+  parameters: {
+    chatContext: {
+      ailaStreamingStatus: "StreamingLessonPlan",
+    },
+  },
+};
+
+export const StreamingChatResponse: Story = {
+  args: {},
+  parameters: {
+    chatContext: {
+      ailaStreamingStatus: "StreamingChatResponse",
+    },
+  },
+};
+
+export const Moderating: Story = {
+  args: {},
+  parameters: {
+    chatContext: {
+      ailaStreamingStatus: "Moderating",
+    },
+  },
+};
+
+export const StreamingWithQueuedUserAction: Story = {
+  args: {},
+  parameters: {
+    chatContext: {
+      queuedUserAction: "regenerate",
+      ailaStreamingStatus: "StreamingLessonPlan",
+    },
+  },
+};
+
+export const ModeratingWithQueuedUserAction: Story = {
+  args: {},
+  parameters: {
+    chatContext: {
+      queuedUserAction: "regenerate",
+      ailaStreamingStatus: "Moderating",
+    },
+  },
+};

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.tsx
@@ -12,16 +12,12 @@ import type { AilaStreamingStatus } from "./Chat/hooks/useAilaStreamingStatus";
 import ChatButton from "./ui/chat-button";
 import { IconRefresh, IconStop } from "./ui/icons";
 
-export type QuickActionButtonsProps = Readonly<{
-  isEmptyScreen: boolean;
-}>;
-
 const shouldAllowStop = (
   ailaStreamingStatus: AilaStreamingStatus,
-  isEmptyScreen: boolean,
+  hasMessages: boolean,
   queuedUserAction: string | null,
 ) => {
-  if (!isEmptyScreen) {
+  if (!hasMessages) {
     return false;
   }
 
@@ -43,7 +39,7 @@ const shouldAllowStop = (
   return false;
 };
 
-const QuickActionButtons = ({ isEmptyScreen }: QuickActionButtonsProps) => {
+const QuickActionButtons = () => {
   const chat = useLessonChat();
   const { trackEvent } = useAnalytics();
   const lessonPlanTracking = useLessonPlanTracking();
@@ -56,6 +52,8 @@ const QuickActionButtons = ({ isEmptyScreen }: QuickActionButtonsProps) => {
     queueUserAction,
     queuedUserAction,
   } = chat;
+
+  const hasMessages = !!messages.length;
 
   const shouldAllowUserAction =
     ["Idle", "Moderating"].includes(ailaStreamingStatus) && !queuedUserAction;
@@ -106,7 +104,7 @@ const QuickActionButtons = ({ isEmptyScreen }: QuickActionButtonsProps) => {
 
         {shouldAllowStop(
           ailaStreamingStatus,
-          isEmptyScreen,
+          hasMessages,
           queuedUserAction,
         ) && (
           <ChatButton

--- a/apps/nextjs/src/components/AppComponents/Chat/prompt-form.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/prompt-form.tsx
@@ -17,7 +17,7 @@ import type { AilaStreamingStatus } from "./Chat/hooks/useAilaStreamingStatus";
 export interface PromptFormProps
   extends Pick<UseChatHelpers, "input" | "setInput"> {
   onSubmit: (value: string) => void;
-  isEmptyScreen: boolean;
+  hasMessages: boolean;
   placeholder?: string;
   ailaStreamingStatus: AilaStreamingStatus;
   queuedUserAction?: string | null;
@@ -29,7 +29,7 @@ export function PromptForm({
   onSubmit,
   input,
   setInput,
-  isEmptyScreen,
+  hasMessages,
   placeholder,
   queuedUserAction,
   queueUserAction,
@@ -93,7 +93,7 @@ export function PromptForm({
           value={input}
           onChange={(e) => setInput(e.target.value)}
           placeholder={handlePlaceholder(
-            isEmptyScreen,
+            hasMessages,
             queuedUserAction ?? placeholder,
           )}
           spellCheck={false}
@@ -119,11 +119,11 @@ export function PromptForm({
   );
 }
 
-function handlePlaceholder(isEmptyScreen: boolean, placeholder?: string) {
+function handlePlaceholder(hasMessages: boolean, placeholder?: string) {
   if (placeholder && !["continue", "regenerate"].includes(placeholder)) {
     return placeholder;
   }
-  return !isEmptyScreen
+  return !hasMessages
     ? "Type a subject, key stage and title"
     : "Type your response here";
 }

--- a/apps/nextjs/src/lib/analytics/lessonPlanTrackingContext.tsx
+++ b/apps/nextjs/src/lib/analytics/lessonPlanTrackingContext.tsx
@@ -30,7 +30,7 @@ type LessonPlanTrackingContext = {
   onClickStartFromFreeText: (text: string) => void;
 };
 
-const lessonPlanTrackingContext =
+export const lessonPlanTrackingContext =
   createContext<LessonPlanTrackingContext | null>(null);
 
 export type LessonPlanTrackingProviderProps = Readonly<{


### PR DESCRIPTION
- Rename `isEmptyScreen` to `hasMessages`, as the original name seems to be the opposite of the behaviour?
- Infer `hasMessages` from chat context rather than props
- Add stories for the different quick actions states