### PR TITLE
fix: use TeX for math notation [AI-538]

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -71,6 +71,7 @@
     "archiver": "^7.0.1",
     "axios": "^1.6.8",
     "base64url": "^3.0.1",
+    "better-react-mathjax": "2.0.4-beta1",
     "class-variance-authority": "^0.7.0",
     "cloudinary": "^1.41.1",
     "cohere-ai": "^7.8.0",

--- a/apps/nextjs/src/app/aila/page-contents.tsx
+++ b/apps/nextjs/src/app/aila/page-contents.tsx
@@ -2,6 +2,8 @@
 
 import React from "react";
 
+import { MathJaxContext } from "better-react-mathjax";
+
 import { Chat } from "@/components/AppComponents/Chat/Chat/chat";
 import Layout from "@/components/AppComponents/Layout";
 import { ChatProvider } from "@/components/ContextProviders/ChatProvider";
@@ -10,11 +12,13 @@ import LessonPlanTrackingProvider from "@/lib/analytics/lessonPlanTrackingContex
 const ChatPageContents = ({ id }: { readonly id: string }) => {
   return (
     <Layout>
-      <LessonPlanTrackingProvider chatId={id}>
-        <ChatProvider key={`chat-${id}`} id={id}>
-          <Chat />
-        </ChatProvider>
-      </LessonPlanTrackingProvider>
+      <MathJaxContext>
+        <LessonPlanTrackingProvider chatId={id}>
+          <ChatProvider key={`chat-${id}`} id={id}>
+            <Chat />
+          </ChatProvider>
+        </LessonPlanTrackingProvider>
+      </MathJaxContext>
     </Layout>
   );
 };

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanMapToMarkDown.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanMapToMarkDown.tsx
@@ -2,6 +2,7 @@ import { useRef } from "react";
 
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
 import { sectionToMarkdown } from "@oakai/aila/src/protocol/sectionToMarkdown";
+import { MathJax } from "better-react-mathjax";
 import { lessonSectionTitlesAndMiniDescriptions } from "data/lessonSectionTitlesAndMiniDescriptions";
 
 import { notEmpty } from "./chat-lessonPlanDisplay";
@@ -72,15 +73,19 @@ const ChatSection = ({ sectionRefs, objectKey, value }) => {
   const sectionRef = useRef(null);
   if (sectionRefs) sectionRefs[objectKey] = sectionRef;
 
+  console.log("objectKey", objectKey);
+
   return (
     <div ref={sectionRef}>
-      <MemoizedReactMarkdownWithStyles
-        lessonPlanSectionDescription={
-          lessonSectionTitlesAndMiniDescriptions[objectKey]?.description
-        }
-        markdown={`# ${sectionTitle(objectKey)}
+      <MathJax>
+        <MemoizedReactMarkdownWithStyles
+          lessonPlanSectionDescription={
+            lessonSectionTitlesAndMiniDescriptions[objectKey]?.description
+          }
+          markdown={`# ${sectionTitle(objectKey)}
 ${sectionToMarkdown(objectKey, value)}`}
-      />
+        />
+      </MathJax>
     </div>
   );
 };

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/chat-section.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/chat-section.tsx
@@ -1,5 +1,6 @@
 import { sectionToMarkdown } from "@oakai/aila/src/protocol/sectionToMarkdown";
 import { OakFlex } from "@oaknational/oak-components";
+import { MathJax } from "better-react-mathjax";
 import { lessonSectionTitlesAndMiniDescriptions } from "data/lessonSectionTitlesAndMiniDescriptions";
 
 import { sectionTitle } from ".";
@@ -15,12 +16,14 @@ export type ChatSectionProps = Readonly<{
 const ChatSection = ({ objectKey, value }: ChatSectionProps) => {
   return (
     <OakFlex $flexDirection="column">
-      <MemoizedReactMarkdownWithStyles
-        lessonPlanSectionDescription={
-          lessonSectionTitlesAndMiniDescriptions[objectKey]?.description
-        }
-        markdown={`${sectionToMarkdown(objectKey, value)}`}
-      />
+      <MathJax>
+        <MemoizedReactMarkdownWithStyles
+          lessonPlanSectionDescription={
+            lessonSectionTitlesAndMiniDescriptions[objectKey]?.description
+          }
+          markdown={`${sectionToMarkdown(objectKey, value)}`}
+        />
+      </MathJax>
       <OakFlex
         $gap="all-spacing-3"
         $mt="space-between-s"

--- a/packages/aila/src/protocol/jsonPatchProtocol.ts
+++ b/packages/aila/src/protocol/jsonPatchProtocol.ts
@@ -720,6 +720,7 @@ export function parseMessageRow(row: string, index: number): MessagePart[] {
       return result;
     } catch (e) {
       log.error("LLM Message parsing error", e);
+      log.error(e);
       return [
         {
           type: "message-part",

--- a/packages/core/src/prompts/lesson-assistant/parts/body.ts
+++ b/packages/core/src/prompts/lesson-assistant/parts/body.ts
@@ -394,5 +394,8 @@ If a user asks to add practical instructions for an additional material and the 
 7. Health and safety guidance  - written in voice 5 (EXPERT_TEACHER)
 8. Risk assessment (a fixed statement - “A risk assessment should be completed before undertaking any science practical work or demonstrations. The information outlined in this guidance contains advice for how to work safely in and out of the classroom, however, risk assessments are the responsibility of the individual school. Please contact a local or wider advisory service, such as CLEAPSS, on all aspects of health and safety for further support.
 
-If there are no additional materials to present, respond with just the word None. Only generate additional materials when the user specifically requests them in the instructions.`;
+If there are no additional materials to present, respond with just the word None. Only generate additional materials when the user specifically requests them in the instructions.
+
+MATHEMATICAL NOTATION
+Wherever there is mathematical notation in your response, it's imperative that you use valid LaTeX syntax. This will ensure that the mathematical notation is correctly rendered in the final lesson plan. For example, to write a fraction, you would use the following syntax: \frac{numerator}{denominator}.`;
 };

--- a/packages/core/src/prompts/lesson-assistant/parts/body.ts
+++ b/packages/core/src/prompts/lesson-assistant/parts/body.ts
@@ -397,5 +397,6 @@ If a user asks to add practical instructions for an additional material and the 
 If there are no additional materials to present, respond with just the word None. Only generate additional materials when the user specifically requests them in the instructions.
 
 MATHEMATICAL NOTATION
-Wherever there is mathematical notation in your response, it's imperative that you use valid LaTeX syntax. This will ensure that the mathematical notation is correctly rendered in the final lesson plan. For example, to write a fraction, you would use the following syntax: \frac{numerator}{denominator}.`;
+Wherever there is mathematical notation in your response, it's imperative that you use valid LaTeX syntax, wrapped inline with $$ . This will ensure that the mathematical notation is correctly rendered in the final lesson plan. For example, to write a fraction, you would use the following syntax: $$\frac{numerator}{denominator}$$. Similarly, if a mathematical operation is required, you would use the following syntax: $$a + b = c$$.
+If you see that the current lesson plan contains mathematics which is not written in LaTeX, please convert it to LaTeX syntax. For instance if you see "An equation of the form ax^2 + bx + c = 0.", you should convert it to: "An equation of the form $$ax^2 + bx + c = 0$$."`;
 };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -209,6 +209,9 @@ importers:
       base64url:
         specifier: ^3.0.1
         version: 3.0.1
+      better-react-mathjax:
+        specifier: 2.0.4-beta1
+        version: 2.0.4-beta1(react@18.2.0)
       class-variance-authority:
         specifier: ^0.7.0
         version: 0.7.0
@@ -10860,6 +10863,15 @@ packages:
     dependencies:
       open: 8.4.0
 
+  /better-react-mathjax@2.0.4-beta1(react@18.2.0):
+    resolution: {integrity: sha512-b166Edbt0YsPMsM8Hsdps5csxx0ObI87Ji0Ey2WLMD3yRRlJwwowO79l4/bTUzQmp5C7CUh76fj6drFZjAch4w==}
+    peerDependencies:
+      react: '>=16.8'
+    dependencies:
+      mathjax-full: 3.2.2
+      react: 18.2.0
+    dev: false
+
   /big-integer@1.6.52:
     resolution: {integrity: sha512-QxD8cf2eVqJOOz63z6JIN9BzvVs/dlySa5HGSBH5xtR8dPteIRQnBxxKqkNTiT6jbDTF6jAfrd4oMcND9RGbQg==}
     engines: {node: '>=0.6'}
@@ -11756,6 +11768,11 @@ packages:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
     dev: true
+
+  /commander@9.2.0:
+    resolution: {integrity: sha512-e2i4wANQiSXgnrBlIatyHtP1odfUp0BbV5Y5nEGbxtIrStkEOAAzCUirvLBNXHLr7kwLvJl6V+4V3XV9x7Wd9w==}
+    engines: {node: ^12.20.0 || >=14}
+    dev: false
 
   /common-path-prefix@3.0.0:
     resolution: {integrity: sha512-QE33hToZseCH3jS0qN96O/bSh3kaw/h+Tq7ngyY9eWDUnTlTNUyqfqvCXioLe5Na5jFsL78ra/wuBU4iuEgd4w==}
@@ -13578,6 +13595,11 @@ packages:
       text-table: 0.2.0
     transitivePeerDependencies:
       - supports-color
+
+  /esm@3.2.25:
+    resolution: {integrity: sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==}
+    engines: {node: '>=6'}
+    dev: false
 
   /espree@9.6.1:
     resolution: {integrity: sha512-oruZaFkjorTpF32kDSI5/75ViwGeZginGGy2NoOSg3Q9bnwlnmDm4HLnkl0RE3n+njDXR037aY1+x58Z/zFdwQ==}
@@ -17544,6 +17566,15 @@ packages:
     hasBin: true
     dev: false
 
+  /mathjax-full@3.2.2:
+    resolution: {integrity: sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==}
+    dependencies:
+      esm: 3.2.25
+      mhchemparser: 4.2.1
+      mj-context-menu: 0.6.1
+      speech-rule-engine: 4.0.7
+    dev: false
+
   /md5.js@1.3.5:
     resolution: {integrity: sha512-xitP+WxNPcTTOgnTJcrhM0xvdPepipPSf3I8EIpGKeFLjt3PlJLIDG3u8EX53ZIubkb+5U2+3rELYpEhHhzdkg==}
     dependencies:
@@ -17772,6 +17803,10 @@ packages:
   /methods@1.1.2:
     resolution: {integrity: sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==}
     engines: {node: '>= 0.6'}
+
+  /mhchemparser@4.2.1:
+    resolution: {integrity: sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==}
+    dev: false
 
   /micromark-core-commonmark@2.0.0:
     resolution: {integrity: sha512-jThOz/pVmAYUtkroV3D5c1osFXAMv9e0ypGDOIZuCeAe91/sD6BoE2Sjzt30yuXtwOYUmySOhMas/PVyh02itA==}
@@ -18164,6 +18199,10 @@ packages:
       minipass: 3.3.6
       yallist: 4.0.0
     dev: true
+
+  /mj-context-menu@0.6.1:
+    resolution: {integrity: sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==}
+    dev: false
 
   /mkdirp@0.5.6:
     resolution: {integrity: sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==}
@@ -21554,6 +21593,15 @@ packages:
     resolution: {integrity: sha512-eWN+LnM3GR6gPu35WxNgbGl8rmY1AEmoMDvL/QD6zYmPWgywxWqJWNdLGT+ke8dKNWrcYgYjPpG5gbTfghP8rw==}
     dev: false
 
+  /speech-rule-engine@4.0.7:
+    resolution: {integrity: sha512-sJrL3/wHzNwJRLBdf6CjJWIlxC04iYKkyXvYSVsWVOiC2DSkHmxsqOhEeMsBA9XK+CHuNcsdkbFDnoUfAsmp9g==}
+    hasBin: true
+    dependencies:
+      commander: 9.2.0
+      wicked-good-xpath: 1.3.0
+      xmldom-sre: 0.1.31
+    dev: false
+
   /speedometer@1.0.0:
     resolution: {integrity: sha512-lgxErLl/7A5+vgIIXsh9MbeukOaCb2axgQ+bKCdIE+ibNT4XNYGNCR1qFEGq6F+YDASXK3Fh/c5FgtZchFolxw==}
     dev: false
@@ -23622,6 +23670,10 @@ packages:
     dependencies:
       isexe: 2.0.0
 
+  /wicked-good-xpath@1.3.0:
+    resolution: {integrity: sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==}
+    dev: false
+
   /widest-line@4.0.1:
     resolution: {integrity: sha512-o0cyEG0e8GPzT4iGHphIOh0cJOV8fivsXxddQasHPHfoZf1ZexrfeA21w2NaEN1RHE+fXlfISmOE8R9N3u3Qig==}
     engines: {node: '>=12'}
@@ -23753,6 +23805,11 @@ packages:
 
   /xmlchars@2.2.0:
     resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+    dev: false
+
+  /xmldom-sre@0.1.31:
+    resolution: {integrity: sha512-f9s+fUkX04BxQf+7mMWAp5zk61pciie+fFLC9hX9UVvCeJQfNHRHXpeo5MPcR0EUf57PYLdt+ZO4f3Ipk2oZUw==}
+    engines: {node: '>=0.1'}
     dev: false
 
   /xtend@4.0.2:


### PR DESCRIPTION
## Description

- add lines to prompt to request that math is returned using appropriate syntax
- adds https://github.com/fast-reflexes/better-react-mathjax which OWA uses to render it

## Note

This is a quick spike, not intended to be merged. To solve it properly we also need to look at rendering the notation correctly in exports.

It looks [API math notation isn't available](https://issuetracker.google.com/issues/36761273?pli=1) on Google docs etc

[This plugin might be worth looking into](https://tex.stackexchange.com/questions/173317/is-there-a-latex-wrapper-for-use-in-google-docs)