### PR TITLE
chore: remove stories files from code duplication calculations

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -18,7 +18,9 @@ sonar.exclusions=\
 sonar.cpd.exclusions=\
   **/*.test.ts, \
   **/*.fixture.ts, \
-  **/*.json
+  **/*.json \
+  **/*.stories.ts \
+  **/*.stories.tsx \
 
 sonar.tests=.
 sonar.test.inclusions=**/*.test.ts


### PR DESCRIPTION
## Description

- Currently we get penalised in Sonar for code duplication in storybook files
- This adds .stories.ts{x} to our list of exclusions for duplication calculation
