### PR TITLE
fix: remove key from chat provider

### DIFF
--- a/apps/nextjs/src/app/aila/page-contents.tsx
+++ b/apps/nextjs/src/app/aila/page-contents.tsx
@@ -11,7 +11,7 @@ const ChatPageContents = ({ id }: { readonly id: string }) => {
   return (
     <Layout>
       <LessonPlanTrackingProvider chatId={id}>
-        <ChatProvider key={`chat-${id}`} id={id}>
+        <ChatProvider id={id}>
           <Chat />
         </ChatProvider>
       </LessonPlanTrackingProvider>


### PR DESCRIPTION
## Description

- Removes the key from the chat provider
- This stops it re-rendering when the chat gets an ID for the first time
