### PR TITLE
test: storybook decorators

### DIFF
--- a/apps/nextjs/.storybook/decorators/AnalyticsDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/AnalyticsDecorator.tsx
@@ -1,0 +1,34 @@
+import React from "react";
+
+import type { Decorator } from "@storybook/react";
+
+import {
+  analyticsContext,
+  type AnalyticsContext,
+} from "../../src/components/ContextProviders/AnalyticsProvider";
+
+declare module "@storybook/csf" {
+  interface Parameters {
+    analyticsContext?: Partial<AnalyticsContext>;
+  }
+}
+
+export const AnalyticsDecorator: Decorator = (Story, { parameters }) => {
+  return (
+    <analyticsContext.Provider
+      value={
+        {
+          track: () => {},
+          trackEvent: () => {},
+          identify: () => {},
+          reset: () => {},
+          page: () => {},
+          posthogAiBetaClient: {},
+          ...parameters.analyticsContext,
+        } as unknown as AnalyticsContext
+      }
+    >
+      <Story />
+    </analyticsContext.Provider>
+  );
+};

--- a/apps/nextjs/.storybook/decorators/AnalyticsDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/AnalyticsDecorator.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import type { Decorator } from "@storybook/react";
+import { fn } from "@storybook/test";
 
 import {
   analyticsContext,
@@ -18,11 +19,11 @@ export const AnalyticsDecorator: Decorator = (Story, { parameters }) => {
     <analyticsContext.Provider
       value={
         {
-          track: () => {},
-          trackEvent: () => {},
-          identify: () => {},
-          reset: () => {},
-          page: () => {},
+          track: fn(),
+          trackEvent: fn(),
+          identify: fn(),
+          reset: fn(),
+          page: fn(),
           posthogAiBetaClient: {},
           ...parameters.analyticsContext,
         } as unknown as AnalyticsContext

--- a/apps/nextjs/.storybook/decorators/ChatDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/ChatDecorator.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+import type { Decorator } from "@storybook/react";
+
+import {
+  ChatContext,
+  type ChatContextProps,
+} from "../../src/components/ContextProviders/ChatProvider";
+
+declare module "@storybook/csf" {
+  interface Parameters {
+    chatContext?: Partial<ChatContextProps>;
+  }
+}
+
+export const ChatDecorator: Decorator = (Story, { parameters }) => (
+  <ChatContext.Provider value={parameters.chatContext as ChatContextProps}>
+    <Story />
+  </ChatContext.Provider>
+);

--- a/apps/nextjs/.storybook/decorators/DemoDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/DemoDecorator.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+
+import type { Decorator } from "@storybook/react";
+
+import {
+  DemoContext,
+  type DemoContextProps,
+} from "@/components/ContextProviders/Demo";
+
+declare module "@storybook/csf" {
+  interface Parameters {
+    // DemoContext is a discriminated union, which doesn't work with extensible config
+    // Instead, allow all props together
+    demoContext?: {
+      isDemoUser?: boolean;
+      demo?: Partial<DemoContextProps["demo"]>;
+      isSharingEnabled?: boolean;
+    };
+  }
+}
+
+const demoBase: DemoContextProps["demo"] = {
+  appSessionsRemaining: 2,
+  appSessionsPerMonth: 3,
+  contactHref: "https://share.hsforms.com/1R9ulYSNPQgqElEHde3KdhAbvumd",
+};
+
+export const DemoDecorator: Decorator = (Story, { parameters }) => {
+  const demo = { ...demoBase, ...parameters.demoContext?.demo };
+  const isSharingEnabled = parameters.demoContext?.isSharingEnabled ?? true;
+
+  const isDemo =
+    parameters.demoContext &&
+    "isDemoUser" in parameters.demoContext &&
+    parameters.demoContext.isDemoUser;
+
+  const value = isDemo
+    ? { isDemoUser: true as const, demo, isSharingEnabled }
+    : { isDemoUser: false as const, isSharingEnabled };
+
+  return (
+    <DemoContext.Provider value={value}>
+      <Story />
+    </DemoContext.Provider>
+  );
+};

--- a/apps/nextjs/.storybook/decorators/DemoDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/DemoDecorator.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import type { Decorator } from "@storybook/react";
+import invariant from "tiny-invariant";
 
 import {
   DemoContext,
@@ -9,15 +10,23 @@ import {
 
 declare module "@storybook/csf" {
   interface Parameters {
-    // DemoContext is a discriminated union, which doesn't work with extensible config
-    // Instead, allow all props together
-    demoContext?: {
-      isDemoUser?: boolean;
-      demo?: Partial<DemoContextProps["demo"]>;
-      isSharingEnabled?: boolean;
-    };
+    demoContext?: DemoContextProps;
   }
 }
+
+export const DemoDecorator: Decorator = (Story, { parameters }) => {
+  const value = parameters.demoContext;
+  invariant(
+    value,
+    "DemoDecorator requires a DemoContext. Please call ...demoParams() in the parameters",
+  );
+
+  return (
+    <DemoContext.Provider value={value}>
+      <Story />
+    </DemoContext.Provider>
+  );
+};
 
 const demoBase: DemoContextProps["demo"] = {
   appSessionsRemaining: 2,
@@ -25,22 +34,29 @@ const demoBase: DemoContextProps["demo"] = {
   contactHref: "https://share.hsforms.com/1R9ulYSNPQgqElEHde3KdhAbvumd",
 };
 
-export const DemoDecorator: Decorator = (Story, { parameters }) => {
-  const demo = { ...demoBase, ...parameters.demoContext?.demo };
-  const isSharingEnabled = parameters.demoContext?.isSharingEnabled ?? true;
+type DemoParams = {
+  isDemoUser: boolean;
+  demo?: Partial<DemoContextProps["demo"]>;
+  isSharingEnabled?: boolean;
+};
+export const demoParams = (
+  args: DemoParams,
+): { demoContext: DemoContextProps } => {
+  const isSharingEnabled = args.isSharingEnabled ?? true;
 
-  const isDemo =
-    parameters.demoContext &&
-    "isDemoUser" in parameters.demoContext &&
-    parameters.demoContext.isDemoUser;
+  const context: DemoContextProps = args.isDemoUser
+    ? {
+        isDemoUser: true,
+        demo: { ...demoBase, ...args.demo },
+        isSharingEnabled,
+      }
+    : {
+        isDemoUser: false,
+        demo: undefined,
+        isSharingEnabled,
+      };
 
-  const value = isDemo
-    ? { isDemoUser: true as const, demo, isSharingEnabled }
-    : { isDemoUser: false as const, isSharingEnabled };
-
-  return (
-    <DemoContext.Provider value={value}>
-      <Story />
-    </DemoContext.Provider>
-  );
+  return {
+    demoContext: context,
+  };
 };

--- a/apps/nextjs/.storybook/decorators/DialogContentDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/DialogContentDecorator.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+import type { Decorator } from "@storybook/react";
+
+import type { DialogTypes } from "../../src/components/AppComponents/Chat/Chat/types";
+import { DialogContext } from "../../src/components/AppComponents/DialogContext";
+
+declare module "@storybook/csf" {
+  interface Parameters {
+    dialogWindow?: DialogTypes;
+  }
+}
+
+export const DialogContentDecorator: Decorator = (Story, { parameters }) => {
+  return (
+    <DialogContext.Provider
+      value={{
+        dialogWindow: parameters.dialogWindow ?? "",
+        setDialogWindow: () => {},
+        dialogProps: {},
+        setDialogProps: () => {},
+        openSidebar: false,
+        setOpenSidebar: () => {},
+      }}
+    >
+      <Story />
+    </DialogContext.Provider>
+  );
+};

--- a/apps/nextjs/.storybook/decorators/DialogContentDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/DialogContentDecorator.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import type { Decorator } from "@storybook/react";
+import { fn } from "@storybook/test";
 
 import type { DialogTypes } from "../../src/components/AppComponents/Chat/Chat/types";
 import { DialogContext } from "../../src/components/AppComponents/DialogContext";
@@ -16,11 +17,11 @@ export const DialogContentDecorator: Decorator = (Story, { parameters }) => {
     <DialogContext.Provider
       value={{
         dialogWindow: parameters.dialogWindow ?? "",
-        setDialogWindow: () => {},
+        setDialogWindow: fn(),
         dialogProps: {},
-        setDialogProps: () => {},
+        setDialogProps: fn(),
         openSidebar: false,
-        setOpenSidebar: () => {},
+        setOpenSidebar: fn(),
       }}
     >
       <Story />

--- a/apps/nextjs/.storybook/decorators/LessonPlanTrackingDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/LessonPlanTrackingDecorator.tsx
@@ -1,0 +1,20 @@
+import React from "react";
+
+import type { Decorator } from "@storybook/react";
+
+import { lessonPlanTrackingContext } from "../../src/lib/analytics/lessonPlanTrackingContext";
+
+export const LessonPlanTrackingDecorator: Decorator = (Story) => (
+  <lessonPlanTrackingContext.Provider
+    value={{
+      onClickContinue: () => {},
+      onClickRetry: () => {},
+      onClickStartFromExample: () => {},
+      onClickStartFromFreeText: () => {},
+      onStreamFinished: () => {},
+      onSubmitText: () => {},
+    }}
+  >
+    <Story />
+  </lessonPlanTrackingContext.Provider>
+);

--- a/apps/nextjs/.storybook/decorators/LessonPlanTrackingDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/LessonPlanTrackingDecorator.tsx
@@ -1,18 +1,19 @@
 import React from "react";
 
 import type { Decorator } from "@storybook/react";
+import { fn } from "@storybook/test";
 
 import { LessonPlanTrackingContext } from "../../src/lib/analytics/lessonPlanTrackingContext";
 
 export const LessonPlanTrackingDecorator: Decorator = (Story) => (
   <LessonPlanTrackingContext.Provider
     value={{
-      onClickContinue: () => {},
-      onClickRetry: () => {},
-      onClickStartFromExample: () => {},
-      onClickStartFromFreeText: () => {},
-      onStreamFinished: () => {},
-      onSubmitText: () => {},
+      onClickContinue: fn(),
+      onClickRetry: fn(),
+      onClickStartFromExample: fn(),
+      onClickStartFromFreeText: fn(),
+      onStreamFinished: fn(),
+      onSubmitText: fn(),
     }}
   >
     <Story />

--- a/apps/nextjs/.storybook/decorators/LessonPlanTrackingDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/LessonPlanTrackingDecorator.tsx
@@ -2,10 +2,10 @@ import React from "react";
 
 import type { Decorator } from "@storybook/react";
 
-import { lessonPlanTrackingContext } from "../../src/lib/analytics/lessonPlanTrackingContext";
+import { LessonPlanTrackingContext } from "../../src/lib/analytics/lessonPlanTrackingContext";
 
 export const LessonPlanTrackingDecorator: Decorator = (Story) => (
-  <lessonPlanTrackingContext.Provider
+  <LessonPlanTrackingContext.Provider
     value={{
       onClickContinue: () => {},
       onClickRetry: () => {},
@@ -16,5 +16,5 @@ export const LessonPlanTrackingDecorator: Decorator = (Story) => (
     }}
   >
     <Story />
-  </lessonPlanTrackingContext.Provider>
+  </LessonPlanTrackingContext.Provider>
 );

--- a/apps/nextjs/.storybook/decorators/RadixThemeDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/RadixThemeDecorator.tsx
@@ -1,8 +1,9 @@
 import React from "react";
 
 import { Theme } from "@radix-ui/themes";
+import { Decorator } from "@storybook/react";
 
-export const RadixThemeDecorator = (Story: React.ComponentType) => (
+export const RadixThemeDecorator: Decorator = (Story) => (
   <Theme>
     <Story />
   </Theme>

--- a/apps/nextjs/.storybook/decorators/SidebarDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/SidebarDecorator.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import type { Decorator } from "@storybook/react";
+import { fn } from "@storybook/test";
 
 import { SidebarContext } from "../../src/lib/hooks/use-sidebar";
 
@@ -14,7 +15,7 @@ declare module "@storybook/csf" {
 export const SidebarDecorator: Decorator = (Story) => (
   <SidebarContext.Provider
     value={{
-      toggleSidebar: () => {},
+      toggleSidebar: fn(),
       isLoading: false,
       isSidebarOpen: false,
     }}

--- a/apps/nextjs/.storybook/decorators/SidebarDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/SidebarDecorator.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+import type { Decorator } from "@storybook/react";
+
+import { SidebarContext } from "../../src/lib/hooks/use-sidebar";
+
+declare module "@storybook/csf" {
+  interface Parameters {
+    // Please fill out as we add configuration
+    sidebarContext?: {};
+  }
+}
+
+export const SidebarDecorator: Decorator = (Story) => (
+  <SidebarContext.Provider
+    value={{
+      toggleSidebar: () => {},
+      isLoading: false,
+      isSidebarOpen: false,
+    }}
+  >
+    <Story />
+  </SidebarContext.Provider>
+);

--- a/apps/nextjs/.storybook/preview.tsx
+++ b/apps/nextjs/.storybook/preview.tsx
@@ -54,13 +54,7 @@ const preview: Preview = {
   loaders: [mswLoader],
 };
 
-// Providers not currently used
-// - CookieConsentProvider
-// - DemoProvider
-// - LessonPlanTrackingProvider
-// - DialogProvider
-// - SidebarProvider
-// - ChatModerationProvider
+// NOTE: See ./decorators for more decorators available to use in stories
 
 export const decorators: Decorator[] = [
   RadixThemeDecorator,

--- a/apps/nextjs/src/app/aila/[id]/download/DownloadView.stories.tsx
+++ b/apps/nextjs/src/app/aila/[id]/download/DownloadView.stories.tsx
@@ -1,7 +1,8 @@
 import type { AilaPersistedChat } from "@oakai/aila/src/protocol/schema";
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { chromaticParams } from "../../../../../.storybook/chromatic";
+import { chromaticParams } from "@/storybook/chromatic";
+
 import { DemoProvider } from "../../../../../src/components/ContextProviders/Demo";
 import { DownloadContent } from "./DownloadView";
 

--- a/apps/nextjs/src/app/aila/[id]/share/index.stories.tsx
+++ b/apps/nextjs/src/app/aila/[id]/share/index.stories.tsx
@@ -1,7 +1,8 @@
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { chromaticParams } from "../../../../../.storybook/chromatic";
+import { chromaticParams } from "@/storybook/chromatic";
+
 import ShareChat from "./";
 
 const meta: Meta<typeof ShareChat> = {

--- a/apps/nextjs/src/app/aila/help/index.stories.tsx
+++ b/apps/nextjs/src/app/aila/help/index.stories.tsx
@@ -1,9 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { DemoProvider } from "@/components/ContextProviders/Demo";
+import { chromaticParams } from "@/storybook/chromatic";
 
 import { HelpContent } from ".";
-import { chromaticParams } from "../../../../.storybook/chromatic";
 
 const meta: Meta<typeof HelpContent> = {
   title: "Pages/Chat/Help",

--- a/apps/nextjs/src/app/faqs/index.stories.tsx
+++ b/apps/nextjs/src/app/faqs/index.stories.tsx
@@ -1,7 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { chromaticParams } from "@/storybook/chromatic";
+
 import { FAQPageContent } from ".";
-import { chromaticParams } from "../../../.storybook/chromatic";
 
 const meta: Meta<typeof FAQPageContent> = {
   title: "Pages/FAQs",

--- a/apps/nextjs/src/app/home-page.stories.tsx
+++ b/apps/nextjs/src/app/home-page.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { chromaticParams } from "../../.storybook/chromatic";
+import { chromaticParams } from "@/storybook/chromatic";
+
 import { HomePageContent } from "./home-page";
 
 const meta: Meta<typeof HomePageContent> = {

--- a/apps/nextjs/src/app/legal/[slug]/legal.stories.tsx
+++ b/apps/nextjs/src/app/legal/[slug]/legal.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { chromaticParams } from "../../../../.storybook/chromatic";
+import { chromaticParams } from "@/storybook/chromatic";
+
 import { LegalContent } from "./legal";
 
 const meta: Meta<typeof LegalContent> = {

--- a/apps/nextjs/src/app/legal/account-locked/account-locked.stories.tsx
+++ b/apps/nextjs/src/app/legal/account-locked/account-locked.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { chromaticParams } from "../../../../.storybook/chromatic";
+import { chromaticParams } from "@/storybook/chromatic";
+
 import { AccountLocked } from "./account-locked";
 
 const meta: Meta<typeof AccountLocked> = {

--- a/apps/nextjs/src/app/prompts/prompts.stories.tsx
+++ b/apps/nextjs/src/app/prompts/prompts.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { chromaticParams } from "../../../.storybook/chromatic";
+import { chromaticParams } from "@/storybook/chromatic";
+
 import { PromptsContent } from "./prompts";
 
 const meta: Meta<typeof PromptsContent> = {

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.stories.tsx
@@ -1,34 +1,25 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import type { ChatContextProps } from "@/components/ContextProviders/ChatProvider";
-import { ChatContext } from "@/components/ContextProviders/ChatProvider";
+import { ChatDecorator } from "@/storybook/decorators/ChatDecorator";
 
 import LessonPlanDisplay from "./chat-lessonPlanDisplay";
 
-const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
-  <ChatContext.Provider
-    value={
-      {
-        id: "123",
-        lastModeration: null,
-        messages: [],
-        lessonPlan: {
-          title: "About Frogs",
-          keyStage: "Key Stage 2",
-          subject: "Science",
-          topic: "Amphibians",
-          basedOn: "Frogs in Modern Britain",
-          learningOutcome:
-            "To understand the importance of frogs in British society and culture",
-        },
-        ailaStreamingStatus: "Idle",
-        ...parameters.chatContext,
-      } as unknown as ChatContextProps
-    }
-  >
-    <Story />
-  </ChatContext.Provider>
-);
+const chatContext: Partial<ChatContextProps> = {
+  id: "123",
+  lastModeration: null,
+  messages: [],
+  lessonPlan: {
+    title: "About Frogs",
+    keyStage: "Key Stage 2",
+    subject: "Science",
+    topic: "Amphibians",
+    basedOn: { title: "Frogs in Modern Britain" },
+    learningOutcome:
+      "To understand the importance of frogs in British society and culture",
+  },
+  ailaStreamingStatus: "Idle",
+};
 
 const meta: Meta<typeof LessonPlanDisplay> = {
   title: "Components/LessonPlan/LessonPlanDisplay",
@@ -47,7 +38,7 @@ type Story = StoryObj<typeof LessonPlanDisplay>;
 export const Default: Story = {
   args: {},
   parameters: {
-    chatContext: {},
+    chatContext,
   },
 };
 
@@ -55,6 +46,7 @@ export const Loading: Story = {
   args: {},
   parameters: {
     chatContext: {
+      ...chatContext,
       lessonPlan: {},
     },
   },
@@ -64,7 +56,9 @@ export const WithModeration: Story = {
   args: {},
   parameters: {
     chatContext: {
+      ...chatContext,
       lastModeration: {
+        id: "123",
         categories: ["l/strong-language"],
       },
     },

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-lhs-header.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-lhs-header.stories.tsx
@@ -1,24 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import {
-  ChatContext,
-  type ChatContextProps,
-} from "@/components/ContextProviders/ChatProvider";
+import { ChatDecorator } from "@/storybook/decorators/ChatDecorator";
 
 import ChatLhsHeader from "./chat-lhs-header";
-
-const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
-  <ChatContext.Provider
-    value={
-      {
-        ailaStreamingStatus: "Idle",
-        ...parameters.chatContext,
-      } as unknown as ChatContextProps
-    }
-  >
-    <Story />
-  </ChatContext.Provider>
-);
 
 const meta: Meta<typeof ChatLhsHeader> = {
   title: "Components/Chat/ChatLhsHeader",
@@ -27,6 +11,11 @@ const meta: Meta<typeof ChatLhsHeader> = {
   decorators: [ChatDecorator],
   args: {
     showStreamingStatus: false,
+  },
+  parameters: {
+    chatContext: {
+      ailaStreamingStatus: "Idle",
+    },
   },
 };
 

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-list/in-chat-download-buttons.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-list/in-chat-download-buttons.stories.tsx
@@ -1,6 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { DemoDecorator } from "@/storybook/decorators/DemoDecorator";
+import {
+  DemoDecorator,
+  demoParams,
+} from "@/storybook/decorators/DemoDecorator";
 
 import { InChatDownloadButtons } from "./in-chat-download-buttons";
 
@@ -12,6 +15,9 @@ const meta: Meta<typeof InChatDownloadButtons> = {
     id: "test-chat-id",
   },
   decorators: [DemoDecorator],
+  parameters: {
+    ...demoParams({ isDemoUser: true }),
+  },
 };
 
 export default meta;
@@ -21,8 +27,6 @@ export const Default: Story = {};
 
 export const SharingDisabled: Story = {
   parameters: {
-    demoContext: {
-      isSharingEnabled: false,
-    },
+    ...demoParams({ isDemoUser: true, isSharingEnabled: false }),
   },
 };

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-list/in-chat-download-buttons.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-list/in-chat-download-buttons.stories.tsx
@@ -1,20 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { DemoContext } from "@/components/ContextProviders/Demo";
+import { DemoDecorator } from "@/storybook/decorators/DemoDecorator";
 
 import { InChatDownloadButtons } from "./in-chat-download-buttons";
-
-const DemoDecorator: Story["decorators"] = (Story, { parameters }) => (
-  <DemoContext.Provider
-    value={{
-      isDemoUser: false,
-      isSharingEnabled: true,
-      ...parameters.demoContext,
-    }}
-  >
-    <Story />
-  </DemoContext.Provider>
-);
 
 const meta: Meta<typeof InChatDownloadButtons> = {
   title: "Components/Chat/InChatDownloadButtons",

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-panel.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-panel.stories.tsx
@@ -5,7 +5,7 @@ import {
   type ChatContextProps,
 } from "@/components/ContextProviders/ChatProvider";
 import { LessonPlanTrackingDecorator } from "@/storybook/decorators/LessonPlanTrackingDecorator";
-import { SidebarContextDecorator } from "@/storybook/decorators/SidebarDecorator";
+import { SidebarDecorator } from "@/storybook/decorators/SidebarDecorator";
 
 import { ChatPanel } from "./chat-panel";
 
@@ -28,11 +28,7 @@ const meta: Meta<typeof ChatPanel> = {
   title: "Components/Chat/ChatPanel",
   component: ChatPanel,
   tags: ["autodocs"],
-  decorators: [
-    ChatDecorator,
-    LessonPlanTrackingDecorator,
-    SidebarContextDecorator,
-  ],
+  decorators: [ChatDecorator, LessonPlanTrackingDecorator, SidebarDecorator],
   args: {
     isDemoLocked: false,
   },

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-panel.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-panel.stories.tsx
@@ -1,28 +1,17 @@
+import type { Message } from "@oakai/aila/src/core/chat";
 import type { Meta, StoryObj } from "@storybook/react";
 
-import {
-  ChatContext,
-  type ChatContextProps,
-} from "@/components/ContextProviders/ChatProvider";
+import { ChatDecorator } from "@/storybook/decorators/ChatDecorator";
 import { LessonPlanTrackingDecorator } from "@/storybook/decorators/LessonPlanTrackingDecorator";
 import { SidebarDecorator } from "@/storybook/decorators/SidebarDecorator";
 
 import { ChatPanel } from "./chat-panel";
 
-const DummyMessage = {};
-
-const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
-  <ChatContext.Provider
-    value={
-      {
-        messages: [DummyMessage],
-        ...parameters.chatContext,
-      } as unknown as ChatContextProps
-    }
-  >
-    <Story />
-  </ChatContext.Provider>
-);
+const DummyMessage: Message = {
+  content: "Dummy message",
+  id: "123",
+  role: "user",
+};
 
 const meta: Meta<typeof ChatPanel> = {
   title: "Components/Chat/ChatPanel",
@@ -31,6 +20,11 @@ const meta: Meta<typeof ChatPanel> = {
   decorators: [ChatDecorator, LessonPlanTrackingDecorator, SidebarDecorator],
   args: {
     isDemoLocked: false,
+  },
+  parameters: {
+    chatContext: {
+      messages: [DummyMessage],
+    },
   },
 };
 

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-panel.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-panel.stories.tsx
@@ -4,8 +4,8 @@ import {
   ChatContext,
   type ChatContextProps,
 } from "@/components/ContextProviders/ChatProvider";
-import { lessonPlanTrackingContext } from "@/lib/analytics/lessonPlanTrackingContext";
-import { SidebarContext } from "@/lib/hooks/use-sidebar";
+import { LessonPlanTrackingDecorator } from "@/storybook/decorators/LessonPlanTrackingDecorator";
+import { SidebarContextDecorator } from "@/storybook/decorators/SidebarDecorator";
 
 import { ChatPanel } from "./chat-panel";
 
@@ -24,40 +24,13 @@ const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
   </ChatContext.Provider>
 );
 
-const LessonPlanTrackingContextDecorator: Story["decorators"] = (Story) => (
-  <lessonPlanTrackingContext.Provider
-    value={{
-      onClickContinue: () => {},
-      onClickRetry: () => {},
-      onClickStartFromExample: () => {},
-      onClickStartFromFreeText: () => {},
-      onStreamFinished: () => {},
-      onSubmitText: () => {},
-    }}
-  >
-    <Story />
-  </lessonPlanTrackingContext.Provider>
-);
-
-const SidebarContextDecorator: Story["decorators"] = (Story) => (
-  <SidebarContext.Provider
-    value={{
-      toggleSidebar: () => {},
-      isLoading: false,
-      isSidebarOpen: false,
-    }}
-  >
-    <Story />
-  </SidebarContext.Provider>
-);
-
 const meta: Meta<typeof ChatPanel> = {
   title: "Components/Chat/ChatPanel",
   component: ChatPanel,
   tags: ["autodocs"],
   decorators: [
     ChatDecorator,
-    LessonPlanTrackingContextDecorator,
+    LessonPlanTrackingDecorator,
     SidebarContextDecorator,
   ],
   args: {

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.stories.tsx
@@ -1,33 +1,27 @@
+import type { Message } from "@oakai/aila/src/core/chat";
 import type { Meta, StoryObj } from "@storybook/react";
 
-import {
-  ChatContext,
-  type ChatContextProps,
-} from "@/components/ContextProviders/ChatProvider";
+import { ChatDecorator } from "@/storybook/decorators/ChatDecorator";
 import { LessonPlanTrackingDecorator } from "@/storybook/decorators/LessonPlanTrackingDecorator";
 
 import ChatQuickButtons from "./chat-quick-buttons";
 
-const DummyMessage = {};
-
-const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
-  <ChatContext.Provider
-    value={
-      {
-        messages: [DummyMessage],
-        ...parameters.chatContext,
-      } as unknown as ChatContextProps
-    }
-  >
-    <Story />
-  </ChatContext.Provider>
-);
+const DummyMessage: Message = {
+  content: "Dummy message",
+  id: "123",
+  role: "user",
+};
 
 const meta: Meta<typeof ChatQuickButtons> = {
   title: "Components/Chat/ChatQuickButtons",
   component: ChatQuickButtons,
   tags: ["autodocs"],
   decorators: [ChatDecorator, LessonPlanTrackingDecorator],
+  parameters: {
+    chatContext: {
+      messages: [DummyMessage],
+    },
+  },
 };
 
 export default meta;

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.stories.tsx
@@ -4,7 +4,7 @@ import {
   ChatContext,
   type ChatContextProps,
 } from "@/components/ContextProviders/ChatProvider";
-import { lessonPlanTrackingContext } from "@/lib/analytics/lessonPlanTrackingContext";
+import { LessonPlanTrackingDecorator } from "@/storybook/decorators/LessonPlanTrackingDecorator";
 
 import ChatQuickButtons from "./chat-quick-buttons";
 
@@ -23,26 +23,11 @@ const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
   </ChatContext.Provider>
 );
 
-const LessonPlanTrackingContextDecorator: Story["decorators"] = (Story) => (
-  <lessonPlanTrackingContext.Provider
-    value={{
-      onClickContinue: () => {},
-      onClickRetry: () => {},
-      onClickStartFromExample: () => {},
-      onClickStartFromFreeText: () => {},
-      onStreamFinished: () => {},
-      onSubmitText: () => {},
-    }}
-  >
-    <Story />
-  </lessonPlanTrackingContext.Provider>
-);
-
 const meta: Meta<typeof ChatQuickButtons> = {
   title: "Components/Chat/ChatQuickButtons",
   component: ChatQuickButtons,
   tags: ["autodocs"],
-  decorators: [ChatDecorator, LessonPlanTrackingContextDecorator],
+  decorators: [ChatDecorator, LessonPlanTrackingDecorator],
 };
 
 export default meta;

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-start.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-start.stories.tsx
@@ -1,8 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { DemoProvider } from "@/components/ContextProviders/Demo";
+import { chromaticParams } from "@/storybook/chromatic";
 
-import { chromaticParams } from "../../../../.storybook/chromatic";
 import { DialogProvider } from "../DialogContext";
 import { ChatStart } from "./chat-start";
 

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/index.stories.tsx
@@ -1,39 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/test";
 
-import type { ChatContextProps } from "@/components/ContextProviders/ChatProvider";
-import { ChatContext } from "@/components/ContextProviders/ChatProvider";
+import { ChatDecorator } from "@/storybook/decorators/ChatDecorator";
 
 import DropDownSection from "./";
 
 const MAX_INT32 = 2 ** 31 - 1;
 
 const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
-
-const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
-  <ChatContext.Provider
-    value={
-      {
-        id: "123",
-        lastModeration: null,
-        messages: [],
-        lessonPlan: {
-          title: "About Frogs",
-          keyStage: "Key Stage 2",
-          subject: "Science",
-          topic: "Amphibians",
-          basedOn: "Frogs in Modern Britain",
-          learningOutcome:
-            "To understand the importance of frogs in British society and culture",
-        },
-        ailaStreamingStatus: "Idle",
-        ...parameters.chatContext,
-      } as unknown as ChatContextProps
-    }
-  >
-    <Story />
-  </ChatContext.Provider>
-);
 
 const meta: Meta<typeof DropDownSection> = {
   title: "Components/LessonPlan/DropDownSection",
@@ -47,6 +21,23 @@ const meta: Meta<typeof DropDownSection> = {
     streamingTimeout: 0,
   },
   decorators: [ChatDecorator],
+  parameters: {
+    chatContext: {
+      id: "123",
+      lastModeration: null,
+      messages: [],
+      lessonPlan: {
+        title: "About Frogs",
+        keyStage: "Key Stage 2",
+        subject: "Science",
+        topic: "Amphibians",
+        basedOn: { id: "testId", title: "Frogs in Modern Britain" },
+        learningOutcome:
+          "To understand the importance of frogs in British society and culture",
+      },
+      ailaStreamingStatus: "Idle",
+    },
+  },
 };
 
 export default meta;

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.stories.tsx
@@ -2,7 +2,6 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import type { ChatContextProps } from "@/components/ContextProviders/ChatProvider";
 import { ChatContext } from "@/components/ContextProviders/ChatProvider";
-import { DemoContext } from "@/components/ContextProviders/Demo";
 
 import { chromaticParams } from "../../../../../.storybook/chromatic";
 import { MobileExportButtons } from "./MobileExportButtons";
@@ -18,18 +17,6 @@ const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
   >
     <Story />
   </ChatContext.Provider>
-);
-
-const DemoDecorator: Story["decorators"] = (Story, { parameters }) => (
-  <DemoContext.Provider
-    value={{
-      isDemoUser: false,
-      isSharingEnabled: true,
-      ...parameters.demoContext,
-    }}
-  >
-    <Story />
-  </DemoContext.Provider>
 );
 
 const meta: Meta<typeof MobileExportButtons> = {

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.stories.tsx
@@ -1,24 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import type { ChatContextProps } from "@/components/ContextProviders/ChatProvider";
-import { ChatContext } from "@/components/ContextProviders/ChatProvider";
 import { chromaticParams } from "@/storybook/chromatic";
+import { ChatDecorator } from "@/storybook/decorators/ChatDecorator";
 import { DemoDecorator } from "@/storybook/decorators/DemoDecorator";
 
 import { MobileExportButtons } from "./MobileExportButtons";
-
-const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
-  <ChatContext.Provider
-    value={
-      {
-        id: "123",
-        ...parameters.chatContext,
-      } as unknown as ChatContextProps
-    }
-  >
-    <Story />
-  </ChatContext.Provider>
-);
 
 const meta: Meta<typeof MobileExportButtons> = {
   title: "Components/LessonPlan/MobileExportButtons",
@@ -30,6 +16,9 @@ const meta: Meta<typeof MobileExportButtons> = {
       defaultViewport: "mobile1",
     },
     ...chromaticParams(["mobile"]),
+    chatContext: {
+      id: "123",
+    },
   },
   args: {
     closeMobileLessonPullOut: () => {},

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.stories.tsx
@@ -3,6 +3,7 @@ import type { Meta, StoryObj } from "@storybook/react";
 import type { ChatContextProps } from "@/components/ContextProviders/ChatProvider";
 import { ChatContext } from "@/components/ContextProviders/ChatProvider";
 import { chromaticParams } from "@/storybook/chromatic";
+import { DemoDecorator } from "@/storybook/decorators/DemoDecorator";
 
 import { MobileExportButtons } from "./MobileExportButtons";
 

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.stories.tsx
@@ -2,7 +2,10 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import { chromaticParams } from "@/storybook/chromatic";
 import { ChatDecorator } from "@/storybook/decorators/ChatDecorator";
-import { DemoDecorator } from "@/storybook/decorators/DemoDecorator";
+import {
+  DemoDecorator,
+  demoParams,
+} from "@/storybook/decorators/DemoDecorator";
 
 import { MobileExportButtons } from "./MobileExportButtons";
 
@@ -16,6 +19,7 @@ const meta: Meta<typeof MobileExportButtons> = {
       defaultViewport: "mobile1",
     },
     ...chromaticParams(["mobile"]),
+    ...demoParams({ isDemoUser: false }),
     chatContext: {
       id: "123",
     },
@@ -32,9 +36,6 @@ export const Default: Story = {};
 
 export const SharingDisabled: Story = {
   parameters: {
-    demoContext: {
-      isDemoUser: true,
-      isSharingEnabled: false,
-    },
+    ...demoParams({ isDemoUser: true, isSharingEnabled: false }),
   },
 };

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.stories.tsx
@@ -2,8 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import type { ChatContextProps } from "@/components/ContextProviders/ChatProvider";
 import { ChatContext } from "@/components/ContextProviders/ChatProvider";
+import { chromaticParams } from "@/storybook/chromatic";
 
-import { chromaticParams } from "../../../../../.storybook/chromatic";
 import { MobileExportButtons } from "./MobileExportButtons";
 
 const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/index.stories.tsx
@@ -1,25 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import type { ChatContextProps } from "@/components/ContextProviders/ChatProvider";
-import { ChatContext } from "@/components/ContextProviders/ChatProvider";
+import { ChatDecorator } from "@/storybook/decorators/ChatDecorator";
 import { DemoDecorator } from "@/storybook/decorators/DemoDecorator";
 
 import ExportButtons from "./";
-
-const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
-  <ChatContext.Provider
-    value={
-      {
-        id: "123",
-        isStreaming: false,
-        lessonPlan: {},
-        ...parameters.chatContext,
-      } as unknown as ChatContextProps
-    }
-  >
-    <Story />
-  </ChatContext.Provider>
-);
 
 const meta: Meta<typeof ExportButtons> = {
   title: "Components/LessonPlan/ExportButtons",
@@ -29,6 +13,13 @@ const meta: Meta<typeof ExportButtons> = {
   args: {
     sectionRefs: {},
     documentContainerRef: { current: null },
+  },
+  parameters: {
+    chatContext: {
+      id: "123",
+      isStreaming: false,
+      lessonPlan: {},
+    },
   },
 };
 

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/index.stories.tsx
@@ -2,9 +2,8 @@ import type { Meta, StoryObj } from "@storybook/react";
 
 import type { ChatContextProps } from "@/components/ContextProviders/ChatProvider";
 import { ChatContext } from "@/components/ContextProviders/ChatProvider";
-import { DemoContext } from "@/components/ContextProviders/Demo";
+import { DemoDecorator } from "@/storybook/decorators/DemoDecorator";
 
-import { chromaticParams } from "../../../../../.storybook/chromatic";
 import ExportButtons from "./";
 
 const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
@@ -20,18 +19,6 @@ const ChatDecorator: Story["decorators"] = (Story, { parameters }) => (
   >
     <Story />
   </ChatContext.Provider>
-);
-
-const DemoDecorator: Story["decorators"] = (Story, { parameters }) => (
-  <DemoContext.Provider
-    value={{
-      isDemoUser: false,
-      isSharingEnabled: true,
-      ...parameters.demoContext,
-    }}
-  >
-    <Story />
-  </DemoContext.Provider>
 );
 
 const meta: Meta<typeof ExportButtons> = {

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/index.stories.tsx
@@ -1,7 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { ChatDecorator } from "@/storybook/decorators/ChatDecorator";
-import { DemoDecorator } from "@/storybook/decorators/DemoDecorator";
+import {
+  DemoDecorator,
+  demoParams,
+} from "@/storybook/decorators/DemoDecorator";
 
 import ExportButtons from "./";
 
@@ -20,6 +23,7 @@ const meta: Meta<typeof ExportButtons> = {
       isStreaming: false,
       lessonPlan: {},
     },
+    ...demoParams({ isDemoUser: false }),
   },
 };
 
@@ -38,9 +42,6 @@ export const IsStreaming: Story = {
 
 export const SharingDisabled: Story = {
   parameters: {
-    demoContext: {
-      isDemoUser: true,
-      isSharingEnabled: false,
-    },
+    ...demoParams({ isDemoUser: true, isSharingEnabled: false }),
   },
 };

--- a/apps/nextjs/src/components/AppComponents/Chat/header.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/header.stories.tsx
@@ -1,21 +1,9 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { DemoContext } from "@/components/ContextProviders/Demo";
+import { chromaticParams } from "@/storybook/chromatic";
+import { DemoDecorator } from "@/storybook/decorators/DemoDecorator";
 
-import { chromaticParams } from "../../../../.storybook/chromatic";
 import { Header } from "./header";
-
-const DemoDecorator: Story["decorators"] = (Story, { parameters }) => (
-  <DemoContext.Provider
-    value={{
-      isDemoUser: false,
-      isSharingEnabled: true,
-      ...parameters.demoContext,
-    }}
-  >
-    <Story />
-  </DemoContext.Provider>
-);
 
 const meta: Meta<typeof Header> = {
   title: "Components/Layout/ChatHeader",
@@ -44,8 +32,10 @@ export const DemoUser: Story = {
   parameters: {
     demoContext: {
       isDemoUser: true,
-      appSessionsPerMonth: 3,
-      appSessionsRemaining: 2,
+      demo: {
+        appSessionsPerMonth: 3,
+        appSessionsRemaining: 2,
+      },
     },
     ...chromaticParams(["desktop", "desktop-wide"]),
   },
@@ -56,8 +46,10 @@ export const DemoLoading: Story = {
   parameters: {
     demoContext: {
       isDemoUser: true,
-      appSessionsPerMonth: 3,
-      appSessionsRemaining: undefined,
+      demo: {
+        appSessionsPerMonth: 3,
+        appSessionsRemaining: undefined,
+      },
     },
   },
 };

--- a/apps/nextjs/src/components/AppComponents/Chat/header.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/header.stories.tsx
@@ -1,7 +1,10 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { chromaticParams } from "@/storybook/chromatic";
-import { DemoDecorator } from "@/storybook/decorators/DemoDecorator";
+import {
+  DemoDecorator,
+  demoParams,
+} from "@/storybook/decorators/DemoDecorator";
 
 import { Header } from "./header";
 
@@ -17,6 +20,7 @@ const meta: Meta<typeof Header> = {
         height: "150px",
       },
     },
+    ...demoParams({ isDemoUser: false }),
   },
 };
 
@@ -30,13 +34,13 @@ export const Default: Story = {
 export const DemoUser: Story = {
   args: {},
   parameters: {
-    demoContext: {
+    ...demoParams({
       isDemoUser: true,
       demo: {
         appSessionsPerMonth: 3,
         appSessionsRemaining: 2,
       },
-    },
+    }),
     ...chromaticParams(["desktop", "desktop-wide"]),
   },
 };
@@ -44,12 +48,12 @@ export const DemoUser: Story = {
 export const DemoLoading: Story = {
   args: {},
   parameters: {
-    demoContext: {
+    ...demoParams({
       isDemoUser: true,
       demo: {
         appSessionsPerMonth: 3,
         appSessionsRemaining: undefined,
       },
-    },
+    }),
   },
 };

--- a/apps/nextjs/src/components/AppComponents/Chat/header.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/header.tsx
@@ -22,7 +22,7 @@ import { OpenSideBarButton } from "./open-side-bar-button";
 import { UserOrLogin } from "./user-or-login";
 
 export function Header() {
-  const demo = useDemoUser();
+  const { isDemoUser, demo } = useDemoUser();
 
   // Check whether clerk metadata has loaded to prevent the banner from flashing
   const clerkMetadata = useClerkDemoMetadata();
@@ -36,7 +36,7 @@ export function Header() {
       $zIndex={"banner"}
       $width={"100%"}
     >
-      {clerkMetadata.isSet && demo.isDemoUser && (
+      {clerkMetadata.isSet && isDemoUser && (
         <OakFlex
           $alignItems={"center"}
           $bb={"border-solid-m"}

--- a/apps/nextjs/src/components/ContextProviders/Demo.tsx
+++ b/apps/nextjs/src/components/ContextProviders/Demo.tsx
@@ -14,18 +14,16 @@ const DEMO_APP_SESSIONS_PER_30D = parseInt(
   10,
 );
 
-export type DemoContextProps =
-  | {
-      isDemoUser: true;
-      appSessionsRemaining: number | undefined;
-      appSessionsPerMonth: number;
-      contactHref: string;
-      isSharingEnabled: boolean;
-    }
-  | {
-      isDemoUser: false;
-      isSharingEnabled: boolean;
-    };
+type Demo = {
+  appSessionsRemaining: number | undefined;
+  appSessionsPerMonth: number;
+  contactHref: string;
+};
+
+export type DemoContextProps = { isSharingEnabled: boolean } & (
+  | { isDemoUser: true; demo: Demo }
+  | { isDemoUser: false; demo: undefined }
+);
 
 export const DemoContext = createContext<DemoContextProps | null>(null);
 
@@ -52,14 +50,17 @@ export function DemoProvider({ children }: Readonly<DemoProviderProps>) {
       isDemoUser
         ? {
             isDemoUser,
-            appSessionsRemaining,
-            appSessionsPerMonth: DEMO_APP_SESSIONS_PER_30D,
-            contactHref:
-              "https://share.hsforms.com/1R9ulYSNPQgqElEHde3KdhAbvumd",
+            demo: {
+              appSessionsRemaining,
+              appSessionsPerMonth: DEMO_APP_SESSIONS_PER_30D,
+              contactHref:
+                "https://share.hsforms.com/1R9ulYSNPQgqElEHde3KdhAbvumd",
+            },
             isSharingEnabled,
           }
         : {
             isDemoUser,
+            demo: undefined,
             isSharingEnabled,
           },
     [isDemoUser, appSessionsRemaining, isSharingEnabled],

--- a/apps/nextjs/src/components/DialogControl/ContentOptions/DemoInterstitialDialog.tsx
+++ b/apps/nextjs/src/components/DialogControl/ContentOptions/DemoInterstitialDialog.tsx
@@ -46,15 +46,15 @@ const CreatingChatDialog = ({
   submit,
   closeDialog,
 }: CreatingChatDialogProps) => {
-  const demo = useDemoUser();
+  const { isDemoUser, demo } = useDemoUser();
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [appSessionsRemaining, setAppSessionsRemaining] = useState<
     number | undefined
-  >(demo.isDemoUser ? demo.appSessionsRemaining : undefined);
+  >(isDemoUser ? demo.appSessionsRemaining : undefined);
 
   // Don't update the remaining count while submitting as the mutation will change it
   useEffect(() => {
-    if (demo.isDemoUser && !isSubmitting) {
+    if (isDemoUser && !isSubmitting) {
       setAppSessionsRemaining(demo.appSessionsRemaining);
     }
   }, [isSubmitting, demo]);
@@ -74,7 +74,7 @@ const CreatingChatDialog = ({
     }
   }, [submit]);
 
-  if (!demo.isDemoUser) {
+  if (!isDemoUser) {
     return null;
   }
 

--- a/apps/nextjs/src/components/DialogControl/ContentOptions/DemoInterstitialDialog.tsx
+++ b/apps/nextjs/src/components/DialogControl/ContentOptions/DemoInterstitialDialog.tsx
@@ -57,7 +57,7 @@ const CreatingChatDialog = ({
     if (isDemoUser && !isSubmitting) {
       setAppSessionsRemaining(demo.appSessionsRemaining);
     }
-  }, [isSubmitting, demo]);
+  }, [isSubmitting, isDemoUser, demo]);
 
   const createAppSession = useCallback(() => {
     if (!submit) {

--- a/apps/nextjs/src/components/DialogControl/ContentOptions/DemoShareLockedDialog.tsx
+++ b/apps/nextjs/src/components/DialogControl/ContentOptions/DemoShareLockedDialog.tsx
@@ -29,9 +29,9 @@ const DemoShareLockedDialog = ({
 }: {
   readonly closeDialog: () => void;
 }) => {
-  const demo = useDemoUser();
+  const { isDemoUser, demo } = useDemoUser();
 
-  if (!demo.isDemoUser) {
+  if (!isDemoUser) {
     return null;
   }
 

--- a/apps/nextjs/src/components/DialogControl/DialogContents.stories.tsx
+++ b/apps/nextjs/src/components/DialogControl/DialogContents.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { fn } from "@storybook/test";
 import { http, HttpResponse } from "msw";
 import { SurveyQuestionType, SurveyType } from "posthog-js";
 import type { PostHog } from "posthog-js";
@@ -106,7 +107,7 @@ export const Feedback: Story = {
     dialogWindow: "feedback",
     analyticsContext: {
       posthogAiBetaClient: {
-        capture: () => {},
+        capture: fn(),
         getSurveys: (fn) => {
           fn([
             {

--- a/apps/nextjs/src/components/DialogControl/DialogContents.stories.tsx
+++ b/apps/nextjs/src/components/DialogControl/DialogContents.stories.tsx
@@ -1,18 +1,18 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { http, HttpResponse } from "msw";
+import { SurveyQuestionType, SurveyType } from "posthog-js";
+import type { PostHog } from "posthog-js";
 
-import type { AnalyticsContext } from "@/components/ContextProviders/AnalyticsProvider";
-import { analyticsContext } from "@/components/ContextProviders/AnalyticsProvider";
+import { AnalyticsDecorator } from "@/storybook/decorators/AnalyticsDecorator";
+import { DialogContentDecorator } from "@/storybook/decorators/DialogContentDecorator";
 
 import { DemoProvider } from "../ContextProviders/Demo";
 import DialogContents from "./DialogContents";
-import { DialogContentDecorator } from "@/storybook/decorators/DialogContentDecorator";
 
 const meta: Meta<typeof DialogContents> = {
   title: "Components/Dialogs/DialogContents",
   component: DialogContents,
-  decorators: [DialogContentDecorator]
-  },
+  decorators: [DialogContentDecorator],
 };
 
 export default meta;
@@ -101,53 +101,39 @@ export const DemoInterstitialLimited: Story = {
 
 export const Feedback: Story = {
   args: {},
+  decorators: [AnalyticsDecorator],
   parameters: {
     dialogWindow: "feedback",
-  },
-  decorators: (Story) => {
-    return (
-      <analyticsContext.Provider
-        value={
-          {
-            track: () => {},
-            trackEvent: () => {},
-            identify: () => {},
-            reset: () => {},
-            page: () => {},
-            posthogAiBetaClient: {
-              capture: () => {},
-              getSurveys: (fn) => {
-                fn([
-                  {
-                    id: "01917ac7-e417-0000-0c86-99ef890e6807",
-                    name: "End of Aila generation survey launch aug24",
-                    type: "api",
-                    questions: [
-                      {
-                        type: "rating",
-                        question:
-                          "How would you rate the structure and content of this lesson plan?",
-                      },
-                      {
-                        type: "rating",
-                        question:
-                          "How would you rate the ease of creating this lesson with Aila?",
-                      },
-                      {
-                        type: "open",
-                        question:
-                          "What suggestions do you have to improve the lesson planning experience with Aila?",
-                      },
-                    ],
-                  },
-                ]);
-              },
+    analyticsContext: {
+      posthogAiBetaClient: {
+        capture: () => {},
+        getSurveys: (fn) => {
+          fn([
+            {
+              id: "01917ac7-e417-0000-0c86-99ef890e6807",
+              name: "End of Aila generation survey launch aug24",
+              type: SurveyType.API,
+              questions: [
+                {
+                  type: SurveyQuestionType.Rating,
+                  question:
+                    "How would you rate the structure and content of this lesson plan?",
+                },
+                {
+                  type: SurveyQuestionType.Rating,
+                  question:
+                    "How would you rate the ease of creating this lesson with Aila?",
+                },
+                {
+                  type: SurveyQuestionType.Open,
+                  question:
+                    "What suggestions do you have to improve the lesson planning experience with Aila?",
+                },
+              ],
             },
-          } as unknown as AnalyticsContext
-        }
-      >
-        <Story />
-      </analyticsContext.Provider>
-    );
+          ]);
+        },
+      } as unknown as PostHog,
+    },
   },
 };

--- a/apps/nextjs/src/components/DialogControl/DialogContents.stories.tsx
+++ b/apps/nextjs/src/components/DialogControl/DialogContents.stories.tsx
@@ -4,28 +4,14 @@ import { http, HttpResponse } from "msw";
 import type { AnalyticsContext } from "@/components/ContextProviders/AnalyticsProvider";
 import { analyticsContext } from "@/components/ContextProviders/AnalyticsProvider";
 
-import { DialogContext } from "../AppComponents/DialogContext";
 import { DemoProvider } from "../ContextProviders/Demo";
 import DialogContents from "./DialogContents";
+import { DialogContentDecorator } from "@/storybook/decorators/DialogContentDecorator";
 
 const meta: Meta<typeof DialogContents> = {
   title: "Components/Dialogs/DialogContents",
   component: DialogContents,
-  decorators: (Story, { parameters }) => {
-    return (
-      <DialogContext.Provider
-        value={{
-          dialogWindow: parameters.dialogWindow,
-          setDialogWindow: () => {},
-          dialogProps: {},
-          setDialogProps: () => {},
-          openSidebar: false,
-          setOpenSidebar: () => {},
-        }}
-      >
-        <Story />
-      </DialogContext.Provider>
-    );
+  decorators: [DialogContentDecorator]
   },
 };
 

--- a/apps/nextjs/src/components/Onboarding/AcceptTermsForm.stories.tsx
+++ b/apps/nextjs/src/components/Onboarding/AcceptTermsForm.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { chromaticParams } from "../../../.storybook/chromatic";
+import { chromaticParams } from "@/storybook/chromatic";
+
 import { AcceptTermsForm } from "./AcceptTermsForm";
 
 const meta: Meta<typeof AcceptTermsForm> = {

--- a/apps/nextjs/src/components/Onboarding/LegacyUpgradeNotice.stories.tsx
+++ b/apps/nextjs/src/components/Onboarding/LegacyUpgradeNotice.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
-import { chromaticParams } from "../../../.storybook/chromatic";
+import { chromaticParams } from "@/storybook/chromatic";
+
 import { LegacyUpgradeNotice } from "./LegacyUpgradeNotice";
 
 const meta: Meta<typeof LegacyUpgradeNotice> = {

--- a/apps/nextjs/src/lib/analytics/lessonPlanTrackingContext.tsx
+++ b/apps/nextjs/src/lib/analytics/lessonPlanTrackingContext.tsx
@@ -21,7 +21,7 @@ type OnStreamFinishedProps = {
   nextLesson: LooseLessonPlan;
   messages: Message[];
 };
-type LessonPlanTrackingContext = {
+type LessonPlanTrackingContextProps = {
   onStreamFinished: (props: OnStreamFinishedProps) => void;
   onSubmitText: (text: string) => void;
   onClickContinue: () => void;
@@ -30,8 +30,8 @@ type LessonPlanTrackingContext = {
   onClickStartFromFreeText: (text: string) => void;
 };
 
-export const lessonPlanTrackingContext =
-  createContext<LessonPlanTrackingContext | null>(null);
+export const LessonPlanTrackingContext =
+  createContext<LessonPlanTrackingContextProps | null>(null);
 
 export type LessonPlanTrackingProviderProps = Readonly<{
   readonly children?: React.ReactNode;
@@ -91,7 +91,7 @@ const LessonPlanTrackingProvider: FC<LessonPlanTrackingProviderProps> = ({
     setUserMessageContent(text);
   }, []);
 
-  const value: LessonPlanTrackingContext = useMemo(
+  const value: LessonPlanTrackingContextProps = useMemo(
     () => ({
       onStreamFinished,
       onSubmitText,
@@ -111,14 +111,14 @@ const LessonPlanTrackingProvider: FC<LessonPlanTrackingProviderProps> = ({
   );
 
   return (
-    <lessonPlanTrackingContext.Provider value={value}>
+    <LessonPlanTrackingContext.Provider value={value}>
       {children}
-    </lessonPlanTrackingContext.Provider>
+    </LessonPlanTrackingContext.Provider>
   );
 };
 
 export const useLessonPlanTracking = () => {
-  const context = useContext(lessonPlanTrackingContext);
+  const context = useContext(LessonPlanTrackingContext);
   if (!context) {
     throw new Error(
       "useLessonPlanTracking must be used within a LessonPlanTrackingProvider",

--- a/apps/nextjs/src/mocks/clerk/ClerkDecorator.tsx
+++ b/apps/nextjs/src/mocks/clerk/ClerkDecorator.tsx
@@ -2,6 +2,12 @@ import type { Decorator } from "@storybook/react";
 
 import { ClerkProvider } from "./nextjsComponents";
 
+declare module "@storybook/csf" {
+  interface Parameters {
+    auth?: "loading" | "signedIn" | "signedInDemo" | "signedOut";
+  }
+}
+
 export const ClerkDecorator: Decorator = (Story, { parameters }) => {
   return (
     <ClerkProvider state={parameters.auth ?? "signedIn"}>

--- a/apps/nextjs/tsconfig.json
+++ b/apps/nextjs/tsconfig.json
@@ -23,7 +23,8 @@
       "@/app/*": ["app/*"],
       "@/lib/*": ["lib/*"],
       "@/utils/*": ["utils/*"],
-      "@/assets/*": ["assets/*"]
+      "@/assets/*": ["assets/*"],
+      "@/storybook/*": ["../.storybook/*"]
     },
     "plugins": [
       {


### PR DESCRIPTION
## Description

Storybook and chromatic will only be useful for us if we can build them into a good habit. This means having easy to use helpers for things like context providers. So far, I've been adding custom decorators into each story file as we need them. Now we're ready to make these reusable

A decorator

- Add the following story decorators to .storybook/decorators:
  - SidebarDecorator
  - AnalyticsDecorator
  - ChatDecorator
  - LessonPlanTrackingDecorator
  - DemoDecorator
  - DialogContentDecorator
- Update stories using context to use these decorators
- Specify types for the story parameters supported by each decorator
- DemoContext used to have a union which varied the keys available. This was hard tow ork with in TS, so I've moved the optional keys to a `demo` object in the context

I wasn't able to import from `@/components` in the .storybook folder, so I've used relative imports for now. I've dabbled with the storybook typescript config and I found that the `tsconfig.storybook.json` file in the project isn't being used - so that work should come in a new PR

## How to test

Testing this is actually a bit blocked while we talk to Chromatic about our usage quota