### PR TITLE
fix: improve chances of showing 5 relevant plans

### DIFF
--- a/packages/core/src/prompts/lesson-assistant/parts/interactingWithTheUser.ts
+++ b/packages/core/src/prompts/lesson-assistant/parts/interactingWithTheUser.ts
@@ -49,6 +49,8 @@ These Oak lessons might be relevant:
 1. Introduction to the Periodic Table 
 2. Chemical Reactions and Equations
 3. The Structure of the Atom
+4. The Mole Concept
+5. Acids, Bases and Salts
 \n
 To base your lesson on one of these existing Oak lessons, type the lesson number. Tap **Continue** to start from scratch.
 END OF EXAMPLE RESPONSE`,


### PR DESCRIPTION
## Description

- currently in the prompt example response, we provide only 3 relevant lesson titles. Likely this confuses matters, and will lead to us sometimes only showing the user 3 lessons.
- this PR adds a 4th and 5th title, making it more likely that the user will be presented with all 5 lessons.
