### PR TITLE
fix: show previously shared lessons in history

### DIFF
--- a/packages/api/src/router/appSessions.ts
+++ b/packages/api/src/router/appSessions.ts
@@ -201,7 +201,7 @@ export const appSessionsRouter = router({
         id,
         "updated_at" as "updatedAt",
         output->>'title' as title,
-        output->>'isShared' as "isShared"
+        output->'isShared' as "isShared"
       FROM
         "app_sessions"
       WHERE


### PR DESCRIPTION
## Description

There was a raw query which uses `->>` to access `isShared` ... but it coerces it to a string. I've changed it to `->` which should now stop us getting these errors.

The impact was minimal, I think it would have hidden shared lesson plans from your 'history' sidebar.