### PR TITLE
fix: rename LessonPlanKeys to LessonPlanKey

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/Chat/hooks/useProgressForDownloads.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/Chat/hooks/useProgressForDownloads.ts
@@ -1,7 +1,7 @@
 import { useMemo } from "react";
 
 import type {
-  LessonPlanKeys,
+  LessonPlanKey,
   LooseLessonPlan,
 } from "@oakai/aila/src/protocol/schema";
 import { lessonPlanSectionsSchema } from "@oakai/exports/src/schema/input.schema";
@@ -15,7 +15,7 @@ export type ProgressForDownloads = {
 
 export type ProgressSection = {
   label: string;
-  key: LessonPlanKeys;
+  key: LessonPlanKey;
   complete: boolean;
 };
 

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.tsx
@@ -1,6 +1,6 @@
 import React, { useRef, useState } from "react";
 
-import type { LessonPlanKeys } from "@oakai/aila/src/protocol/schema";
+import type { LessonPlanKey } from "@oakai/aila/src/protocol/schema";
 
 import { useLessonChat } from "@/components/ContextProviders/ChatProvider";
 
@@ -33,7 +33,7 @@ const ChatRightHandSideLesson = ({
 
   // This retains this existing bug, but is fixed on subsequent PRs
   const sectionRefs: Partial<
-    Record<LessonPlanKeys, React.MutableRefObject<HTMLDivElement | null>>
+    Record<LessonPlanKey, React.MutableRefObject<HTMLDivElement | null>>
   > = {};
 
   const scrollToBottom = () => {

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/chat-section.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/chat-section.tsx
@@ -1,5 +1,5 @@
 import type {
-  LessonPlanKeys,
+  LessonPlanKey,
   LessonPlanSectionWhileStreaming,
 } from "@oakai/aila/src/protocol/schema";
 import { sectionToMarkdown } from "@oakai/aila/src/protocol/sectionToMarkdown";
@@ -13,7 +13,7 @@ import FlagButton from "./flag-button";
 import ModifyButton from "./modify-button";
 
 export type ChatSectionProps = Readonly<{
-  section: LessonPlanKeys;
+  section: LessonPlanKey;
   value: LessonPlanSectionWhileStreaming;
 }>;
 

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/index.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import type { LessonPlanKeys } from "@oakai/aila/src/protocol/schema";
+import type { LessonPlanKey } from "@oakai/aila/src/protocol/schema";
 import { camelCaseToSentenceCase } from "@oakai/core/src/utils/camelCaseConversion";
 import { OakBox, OakFlex, OakP } from "@oaknational/oak-components";
 import { equals } from "ramda";
@@ -16,7 +16,7 @@ import ChatSection from "./chat-section";
 const HALF_SECOND = 500;
 
 export type DropDownSectionProps = Readonly<{
-  section: LessonPlanKeys;
+  section: LessonPlanKey;
   sectionRefs: Record<string, React.MutableRefObject<HTMLDivElement | null>>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   value: any;

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/LessonPlanProgressDropdown.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/LessonPlanProgressDropdown.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from "react";
 
 import type {
-  LessonPlanKeys,
+  LessonPlanKey,
   LooseLessonPlan,
 } from "@oakai/aila/src/protocol/schema";
 import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
@@ -16,7 +16,7 @@ export type LessonPlanProgressDropdownProps = Readonly<{
   lessonPlan: LooseLessonPlan;
   isStreaming: boolean;
   sectionRefs: Partial<
-    Record<LessonPlanKeys, React.MutableRefObject<HTMLDivElement | null>>
+    Record<LessonPlanKey, React.MutableRefObject<HTMLDivElement | null>>
   >;
   documentContainerRef: React.MutableRefObject<HTMLDivElement | null>;
 }>;

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import type { LessonPlanKeys } from "@oakai/aila/src/protocol/schema";
+import type { LessonPlanKey } from "@oakai/aila/src/protocol/schema";
 import { OakSmallSecondaryButton } from "@oaknational/oak-components";
 import Link from "next/link";
 
@@ -13,7 +13,7 @@ import { LessonPlanProgressDropdown } from "./LessonPlanProgressDropdown";
 
 export type ExportButtonsProps = Readonly<{
   sectionRefs: Partial<
-    Record<LessonPlanKeys, React.MutableRefObject<HTMLDivElement | null>>
+    Record<LessonPlanKey, React.MutableRefObject<HTMLDivElement | null>>
   >;
   documentContainerRef: React.MutableRefObject<HTMLDivElement | null>;
 }>;

--- a/apps/nextjs/src/data/lessonSectionTitlesAndMiniDescriptions.ts
+++ b/apps/nextjs/src/data/lessonSectionTitlesAndMiniDescriptions.ts
@@ -1,7 +1,7 @@
-import type { LessonPlanKeys } from "@oakai/aila/src/protocol/schema";
+import type { LessonPlanKey } from "@oakai/aila/src/protocol/schema";
 
 export const lessonSectionTitlesAndMiniDescriptions: Record<
-  LessonPlanKeys,
+  LessonPlanKey,
   { description: string }
 > = {
   title: {

--- a/apps/nextjs/src/hooks/useDemoLocking.ts
+++ b/apps/nextjs/src/hooks/useDemoLocking.ts
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 
-import type { LessonPlanKeys } from "@oakai/aila/src/protocol/schema";
+import type { LessonPlanKey } from "@oakai/aila/src/protocol/schema";
 import type { Message } from "ai";
 
 import { useDemoUser } from "@/components/ContextProviders/Demo";
@@ -20,7 +20,7 @@ const KEYS_TO_COMPLETE = [
   "cycle2",
   "cycle3",
   "exitQuiz",
-] satisfies LessonPlanKeys[];
+] satisfies LessonPlanKey[];
 
 if (!process.env.NEXT_PUBLIC_DEMO_MESSAGES_AFTER_COMPLETE) {
   throw new Error("NEXT_PUBLIC_DEMO_MESSAGES_AFTER_COMPLETE is not set");

--- a/apps/nextjs/src/lib/lessonPlan/organiseSections.ts
+++ b/apps/nextjs/src/lib/lessonPlan/organiseSections.ts
@@ -1,8 +1,8 @@
-import type { LessonPlanKeys } from "@oakai/aila/src/protocol/schema";
+import type { LessonPlanKey } from "@oakai/aila/src/protocol/schema";
 
 export const organiseSections: {
-  trigger: LessonPlanKeys;
-  dependants: LessonPlanKeys[];
+  trigger: LessonPlanKey;
+  dependants: LessonPlanKey[];
 }[] = [
   {
     trigger: "learningOutcome",

--- a/apps/nextjs/src/lib/lessonPlan/sectionsInOrder.ts
+++ b/apps/nextjs/src/lib/lessonPlan/sectionsInOrder.ts
@@ -1,6 +1,6 @@
-import type { LessonPlanKeys } from "@oakai/aila/src/protocol/schema";
+import type { LessonPlanKey } from "@oakai/aila/src/protocol/schema";
 
-export const allSectionsInOrder: LessonPlanKeys[] = [
+export const allSectionsInOrder: LessonPlanKey[] = [
   "learningOutcome",
   "learningCycles",
   "priorKnowledge",
@@ -15,7 +15,7 @@ export const allSectionsInOrder: LessonPlanKeys[] = [
   "additionalMaterials",
 ];
 
-export const groupedSectionsInOrder: LessonPlanKeys[][] = [
+export const groupedSectionsInOrder: LessonPlanKey[][] = [
   ["learningOutcome", "learningCycles"],
   ["priorKnowledge", "keyLearningPoints", "misconceptions", "keywords"],
   ["starterQuiz", "cycle1", "cycle2", "cycle3", "exitQuiz"],

--- a/packages/aila/src/features/americanisms/AilaAmericanisms.ts
+++ b/packages/aila/src/features/americanisms/AilaAmericanisms.ts
@@ -8,7 +8,7 @@ import type {
   AmericanismIssue,
   AmericanismIssueBySection,
 } from "../../features/americanisms";
-import type { LessonPlanKeys, LooseLessonPlan } from "../../protocol/schema";
+import type { LessonPlanKey, LooseLessonPlan } from "../../protocol/schema";
 
 export type TranslationResult = Record<
   string,
@@ -17,7 +17,7 @@ export type TranslationResult = Record<
 
 export class AilaAmericanisms implements AilaAmericanismsFeature {
   private findSectionAmericanisms(
-    section: LessonPlanKeys,
+    section: LessonPlanKey,
     lessonPlan: LooseLessonPlan,
   ): AmericanismIssueBySection | undefined {
     const filterOutPhrases = new Set([
@@ -58,7 +58,7 @@ export class AilaAmericanisms implements AilaAmericanismsFeature {
   public findAmericanisms(lessonPlan: LooseLessonPlan) {
     return Object.keys(lessonPlan).flatMap((section) => {
       const sectionIssues = this.findSectionAmericanisms(
-        section as LessonPlanKeys,
+        section as LessonPlanKey,
         lessonPlan,
       );
       return sectionIssues && sectionIssues.issues.length > 0

--- a/packages/aila/src/features/persistence/adaptors/prisma/index.ts
+++ b/packages/aila/src/features/persistence/adaptors/prisma/index.ts
@@ -10,7 +10,7 @@ import type {
 } from "../../../../core/AilaServices";
 import type {
   AilaPersistedChat,
-  LessonPlanKeys,
+  LessonPlanKey,
 } from "../../../../protocol/schema";
 import { chatSchema } from "../../../../protocol/schema";
 import type { AilaGeneration } from "../../../generation/AilaGeneration";
@@ -59,7 +59,7 @@ export class AilaPrismaPersistence extends AilaPersistence {
   async upsertChat(): Promise<void> {
     const currentIteration = this._chat.iteration;
     const payload = this.createChatPayload();
-    const keys = (Object.keys(payload.lessonPlan) as LessonPlanKeys[]).filter(
+    const keys = (Object.keys(payload.lessonPlan) as LessonPlanKey[]).filter(
       (k) => payload.lessonPlan[k],
     );
 

--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -403,7 +403,7 @@ export const LessonPlanSchemaWhilstStreaming = LessonPlanSchema;
 
 export type LooseLessonPlan = z.infer<typeof LessonPlanSchemaWhilstStreaming>;
 
-export type LessonPlanKeys = keyof typeof CompletedLessonPlanSchema.shape;
+export type LessonPlanKey = keyof typeof CompletedLessonPlanSchema.shape;
 
 export const LessonPlanJsonSchema = zodToJsonSchema(
   CompletedLessonPlanSchema,

--- a/packages/core/src/prompts/lesson-assistant/parts/interactingWithTheUser.ts
+++ b/packages/core/src/prompts/lesson-assistant/parts/interactingWithTheUser.ts
@@ -3,14 +3,14 @@ import { aiLogger } from "@oakai/logger";
 import type { TemplateProps } from "..";
 import { allSectionsInOrder } from "../../../../../../apps/nextjs/src/lib/lessonPlan/sectionsInOrder";
 import type {
-  LessonPlanKeys,
+  LessonPlanKey,
   LooseLessonPlan,
 } from "../../../../../aila/src/protocol/schema";
 
 interface LessonConstructionStep {
   title: string;
   content: string;
-  sections?: LessonPlanKeys[];
+  sections?: LessonPlanKey[];
 }
 
 const log = aiLogger("chat");
@@ -19,8 +19,8 @@ const lessonConstructionSteps = (
   lessonPlan: LooseLessonPlan,
   relevantLessonPlans: string | undefined,
 ): LessonConstructionStep[] => {
-  const presentLessonPlanKeys = (
-    Object.keys(lessonPlan) as LessonPlanKeys[]
+  const presentLessonPlanKey = (
+    Object.keys(lessonPlan) as LessonPlanKey[]
   ).filter((k) => lessonPlan[k]);
   const hasRelevantLessons =
     relevantLessonPlans && relevantLessonPlans.length > 3; // TODO This is a string, not an array!
@@ -58,7 +58,7 @@ END OF EXAMPLE RESPONSE`,
       : undefined,
     !hasRelevantLessons
       ? {
-          sections: ["learningOutcome", "learningCycles"] as LessonPlanKeys[],
+          sections: ["learningOutcome", "learningCycles"] as LessonPlanKey[],
           title: "GENERATE SECTION GROUP [learningOutcome, learningCycles]",
           content: `Generate learning outcomes and the learning cycles overview.
 Generate both of these sections together in one interaction with the user.
@@ -66,7 +66,7 @@ Do not add any additional explanation about the content you have generated.
 In some cases it is possible for the user to base their lesson on existing ones, but that is not the case here. Ensure you start your reply to the user with this: "There are no existing Oak lessons for this topic, so I've started a new lesson from scratch." Ensure you ALWAYS generate the learning outcomes and learning cycles together in your response.`,
         }
       : {
-          sections: ["learningOutcome", "learningCycles"] as LessonPlanKeys[],
+          sections: ["learningOutcome", "learningCycles"] as LessonPlanKey[],
           title:
             "GENERATE SECTION GROUP [basedOn, learningOutcome, learningCycles]",
           content: `You need to generate three sections in one interaction with the user. Do these all in one interaction.
@@ -148,7 +148,7 @@ END OF EXAMPLE RESPONSE`,
     if (step.sections) {
       // If the step has sections defined, check if all of them are already present in the lesson plan
       const allSectionsPresent = step.sections.every((section) =>
-        presentLessonPlanKeys.includes(section),
+        presentLessonPlanKey.includes(section),
       );
 
       // Exclude the step if all its sections are already present


### PR DESCRIPTION
## Description

- LessonPlanKeys plural should be LessonPlanKey singular, based on the principle of least surpriste
- Renames this globally 
- Type-only update, no UX changes
