### PR TITLE
test: don't force desktop chromatic mode for all stories

### DIFF
--- a/apps/nextjs/.storybook/chromatic.ts
+++ b/apps/nextjs/.storybook/chromatic.ts
@@ -10,7 +10,7 @@ export function chromaticParams(modes: ChromaticModes[]) {
           mobile: { viewport: "mobile" },
         }),
         ...(modes.includes("mobile-wide") && {
-          mobile: { viewport: "mobile-wide" },
+          "mobile-wide": { viewport: "mobile-wide" },
         }),
         ...(modes.includes("desktop") && {
           desktop: { viewport: "desktop" },

--- a/apps/nextjs/.storybook/decorators/ChromaticValidationDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/ChromaticValidationDecorator.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+
+import { Decorator } from "@storybook/react";
+
+export const ChromaticValidationDecorator: Decorator = (
+  Story,
+  { parameters },
+) => {
+  if (
+    !parameters.chromatic?.modes ||
+    Object.keys(parameters.chromatic.modes).length === 0
+  ) {
+    throw new Error("No chromatic parameters set");
+  }
+  return <Story />;
+};

--- a/apps/nextjs/.storybook/preview.tsx
+++ b/apps/nextjs/.storybook/preview.tsx
@@ -19,7 +19,7 @@ import { DialogProvider } from "../src/components/AppComponents/DialogContext";
 import { AnalyticsProvider } from "../src/mocks/analytics/provider";
 import { ClerkDecorator } from "../src/mocks/clerk/ClerkDecorator";
 import { TRPCReactProvider } from "../src/utils/trpc";
-import { chromaticParams } from "./chromatic";
+import { ChromaticValidationDecorator } from "./decorators/ChromaticValidationDecorator";
 import { RadixThemeDecorator } from "./decorators/RadixThemeDecorator";
 import "./preview.css";
 
@@ -59,7 +59,6 @@ const preview: Preview = {
         },
       },
     },
-    ...chromaticParams(["desktop"]),
   },
   loaders: [mswLoader],
 };
@@ -69,6 +68,7 @@ const preview: Preview = {
 export const decorators: Decorator[] = [
   RadixThemeDecorator,
   ClerkDecorator,
+  ChromaticValidationDecorator,
   (Story) => (
     <>
       <TRPCReactProvider>

--- a/apps/nextjs/jest.config.mjs
+++ b/apps/nextjs/jest.config.mjs
@@ -27,6 +27,7 @@ const config = {
     "^(\\.{1,2}/.*)\\.js$": "$1",
     "^@/components/(.*)$": "<rootDir>/src/components/$1",
     "^@/assets/(.*)$": "<rootDir>/src/assets/$1",
+    "^@/storybook/(.*)$": "<rootDir>/.storybook/$1",
   },
   extensionsToTreatAsEsm: [".ts", ".tsx"],
   testMatch: ["**/*.test.ts", "**/*.test.tsx"],

--- a/apps/nextjs/src/components/AppComponents/Chat/Chat/ChatModerationDisplay.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/Chat/ChatModerationDisplay.stories.tsx
@@ -1,6 +1,8 @@
 import type { PersistedModerationBase } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { chromaticParams } from "@/storybook/chromatic";
+
 import { ChatModerationDisplay } from "./ChatModerationDisplay";
 
 const meta = {
@@ -14,6 +16,9 @@ const meta = {
       </div>
     ),
   ],
+  parameters: {
+    ...chromaticParams(["desktop"]),
+  },
 } satisfies Meta<typeof ChatModerationDisplay>;
 
 export default meta;

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-history.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-history.stories.tsx
@@ -1,6 +1,8 @@
 import * as Dialog from "@radix-ui/react-dialog";
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { chromaticParams } from "@/storybook/chromatic";
+
 import { ChatHistory } from "./chat-history";
 
 const meta = {
@@ -8,6 +10,7 @@ const meta = {
   component: ChatHistory,
   parameters: {
     layout: "centered",
+    ...chromaticParams(["desktop"]),
   },
   tags: ["autodocs"],
   decorators: [

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import type { ChatContextProps } from "@/components/ContextProviders/ChatProvider";
+import { chromaticParams } from "@/storybook/chromatic";
 import { ChatDecorator } from "@/storybook/decorators/ChatDecorator";
 
 import LessonPlanDisplay from "./chat-lessonPlanDisplay";
@@ -31,6 +32,9 @@ const meta = {
     chatEndRef: undefined,
     sectionRefs: {},
     showLessonMobile: false,
+  },
+  parameters: {
+    ...chromaticParams(["desktop"]),
   },
 } satisfies Meta<typeof LessonPlanDisplay>;
 

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-lhs-header.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-lhs-header.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
 
+import { chromaticParams } from "@/storybook/chromatic";
 import { ChatDecorator } from "@/storybook/decorators/ChatDecorator";
 
 import ChatLhsHeader from "./chat-lhs-header";
@@ -17,6 +18,7 @@ const meta = {
     isDemoUser: false,
   },
   parameters: {
+    ...chromaticParams(["desktop"]),
     chatContext: {
       ailaStreamingStatus: "Idle",
     },

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-list/demo-limit-message.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-list/demo-limit-message.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { ChatModerationProvider } from "@/components/ContextProviders/ChatModerationContext";
+import { chromaticParams } from "@/storybook/chromatic";
 
 import { DemoLimitMessage } from "./demo-limit-message";
 
@@ -17,6 +18,9 @@ const meta = {
   ],
   args: {
     id: "test-chat-id",
+  },
+  parameters: {
+    ...chromaticParams(["desktop"]),
   },
 } satisfies Meta<typeof DemoLimitMessage>;
 

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-list/in-chat-download-buttons.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-list/in-chat-download-buttons.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { chromaticParams } from "@/storybook/chromatic";
 import {
   DemoDecorator,
   demoParams,
@@ -16,6 +17,7 @@ const meta = {
   },
   decorators: [DemoDecorator],
   parameters: {
+    ...chromaticParams(["desktop"]),
     ...demoParams({ isDemoUser: true }),
   },
 } satisfies Meta<typeof InChatDownloadButtons>;

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-message/ChatMessagePart.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-message/ChatMessagePart.stories.tsx
@@ -1,6 +1,8 @@
 import type { MessagePart } from "@oakai/aila/src/protocol/jsonPatchProtocol";
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { chromaticParams } from "@/storybook/chromatic";
+
 import { ChatMessagePart } from "./ChatMessagePart";
 
 const meta = {
@@ -9,6 +11,9 @@ const meta = {
   tags: ["autodocs"],
   args: {
     inspect: false,
+  },
+  parameters: {
+    ...chromaticParams(["desktop"]),
   },
 } satisfies Meta<typeof ChatMessagePart>;
 

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-message/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-message/index.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { ChatModerationProvider } from "@/components/ContextProviders/ChatModerationContext";
+import { chromaticParams } from "@/storybook/chromatic";
 
 import { ChatMessage } from "./";
 
@@ -19,6 +20,9 @@ const meta = {
     chatId: "test-chat-id",
     persistedModerations: [],
     ailaStreamingStatus: "Idle",
+  },
+  parameters: {
+    ...chromaticParams(["mobile", "desktop"]),
   },
 } satisfies Meta<typeof ChatMessage>;
 

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-message/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-message/index.stories.tsx
@@ -22,7 +22,7 @@ const meta = {
     ailaStreamingStatus: "Idle",
   },
   parameters: {
-    ...chromaticParams(["mobile", "desktop"]),
+    ...chromaticParams(["desktop"]),
   },
 } satisfies Meta<typeof ChatMessage>;
 

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-panel.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-panel.stories.tsx
@@ -1,6 +1,7 @@
 import type { Message } from "@oakai/aila/src/core/chat";
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { chromaticParams } from "@/storybook/chromatic";
 import { ChatDecorator } from "@/storybook/decorators/ChatDecorator";
 import { LessonPlanTrackingDecorator } from "@/storybook/decorators/LessonPlanTrackingDecorator";
 import { SidebarDecorator } from "@/storybook/decorators/SidebarDecorator";
@@ -22,6 +23,7 @@ const meta = {
     isDemoLocked: false,
   },
   parameters: {
+    ...chromaticParams(["desktop"]),
     chatContext: {
       messages: [DummyMessage],
     },

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.stories.tsx
@@ -1,6 +1,7 @@
 import type { Message } from "@oakai/aila/src/core/chat";
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { chromaticParams } from "@/storybook/chromatic";
 import { ChatDecorator } from "@/storybook/decorators/ChatDecorator";
 import { LessonPlanTrackingDecorator } from "@/storybook/decorators/LessonPlanTrackingDecorator";
 
@@ -18,6 +19,7 @@ const meta = {
   tags: ["autodocs"],
   decorators: [ChatDecorator, LessonPlanTrackingDecorator],
   parameters: {
+    ...chromaticParams(["desktop"]),
     chatContext: {
       messages: [DummyMessage],
     },

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.tsx
@@ -24,6 +24,8 @@ const ChatRightHandSideLesson = ({
   demo,
 }: Readonly<ChatRightHandSideLessonProps>) => {
   const { messages } = useLessonChat();
+  console.log({ messages, showLessonMobile });
+  console.log(messages.length);
 
   const chatEndRef = useRef<HTMLDivElement>(null);
 

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-start-form.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-start-form.stories.tsx
@@ -1,11 +1,16 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { chromaticParams } from "@/storybook/chromatic";
+
 import { ChatStartForm } from "./chat-start-form";
 
 const meta = {
   title: "Components/Chat Start/ChatStartForm",
   component: ChatStartForm,
   tags: ["autodocs"],
+  parameters: {
+    ...chromaticParams(["desktop"]),
+  },
 } satisfies Meta<typeof ChatStartForm>;
 
 export default meta;

--- a/apps/nextjs/src/components/AppComponents/Chat/clear-history.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/clear-history.stories.tsx
@@ -1,5 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { chromaticParams } from "@/storybook/chromatic";
+
 import { ClearHistory } from "./clear-history";
 
 const meta = {
@@ -8,6 +10,9 @@ const meta = {
   tags: ["autodocs"],
   argTypes: {
     isEnabled: { control: "boolean" },
+  },
+  parameters: {
+    ...chromaticParams(["desktop"]),
   },
   decorators: [
     (Story) => {

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/index.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { userEvent, within } from "@storybook/test";
 
+import { chromaticParams } from "@/storybook/chromatic";
 import { ChatDecorator } from "@/storybook/decorators/ChatDecorator";
 
 import DropDownSection from "./";
@@ -25,6 +26,7 @@ const meta = {
   },
   decorators: [ChatDecorator],
   parameters: {
+    ...chromaticParams(["desktop"]),
     chatContext: {
       id: "123",
       lastModeration: null,

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/LessonPlanProgressDropdown.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/LessonPlanProgressDropdown.stories.tsx
@@ -6,12 +6,17 @@ import type {
 } from "@oakai/aila/src/protocol/schema";
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { chromaticParams } from "@/storybook/chromatic";
+
 import { LessonPlanProgressDropdown } from "./LessonPlanProgressDropdown";
 
 const meta = {
   title: "Components/LessonPlan/LessonPlanProgressDropdown",
   component: LessonPlanProgressDropdown,
   tags: ["autodocs"],
+  parameters: {
+    ...chromaticParams(["desktop"]),
+  },
 } satisfies Meta<typeof LessonPlanProgressDropdown>;
 
 export default meta;

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/LessonPlanProgressDropdown.test.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/LessonPlanProgressDropdown.test.tsx
@@ -19,27 +19,6 @@ const { Default, PartiallyCompleted, FullyCompleted, PartialCycles } =
   composeStories(stories);
 
 describe("LessonPlanProgressDropdown", () => {
-  it("renders the Default story with correct closed state", () => {
-    render(<Default />);
-    expect(screen.getByText("4 of 10 sections complete")).toBeInTheDocument();
-    expect(screen.queryByText("Cycles")).not.toBeInTheDocument();
-  });
-
-  it("renders the PartiallyCompleted story with correct closed state", () => {
-    render(<PartiallyCompleted />);
-    expect(screen.getByText("7 of 10 sections complete")).toBeInTheDocument();
-  });
-
-  it("renders the FullyCompleted story with correct closed state", () => {
-    render(<FullyCompleted />);
-    expect(screen.getByText("10 of 10 sections complete")).toBeInTheDocument();
-  });
-
-  it("renders the PartialCycles story with correct closed state", () => {
-    render(<PartialCycles />);
-    expect(screen.getByText("5 of 10 sections complete")).toBeInTheDocument();
-  });
-
   it("displays the dropdown menu when clicked and shows correct completed sections", async () => {
     render(<PartiallyCompleted />);
 

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/index.stories.tsx
@@ -1,5 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { chromaticParams } from "@/storybook/chromatic";
 import { ChatDecorator } from "@/storybook/decorators/ChatDecorator";
 import {
   DemoDecorator,
@@ -8,7 +9,7 @@ import {
 
 import ExportButtons from "./";
 
-const meta: Meta<typeof ExportButtons> = {
+const meta = {
   title: "Components/LessonPlan/ExportButtons",
   component: ExportButtons,
   tags: ["autodocs"],
@@ -18,6 +19,7 @@ const meta: Meta<typeof ExportButtons> = {
     documentContainerRef: { current: null },
   },
   parameters: {
+    ...chromaticParams(["desktop"]),
     chatContext: {
       id: "123",
       isStreaming: false,
@@ -25,7 +27,7 @@ const meta: Meta<typeof ExportButtons> = {
     },
     ...demoParams({ isDemoUser: false }),
   },
-};
+} satisfies Meta<typeof ExportButtons>;
 
 export default meta;
 type Story = StoryObj<typeof meta>;

--- a/apps/nextjs/src/components/AppComponents/Chat/guidance-required.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/guidance-required.stories.tsx
@@ -1,12 +1,17 @@
 import type { PersistedModerationBase } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { chromaticParams } from "@/storybook/chromatic";
+
 import { GuidanceRequired } from "./guidance-required";
 
 const meta = {
   title: "Components/Chat/GuidanceRequired",
   component: GuidanceRequired,
   tags: ["autodocs"],
+  parameters: {
+    ...chromaticParams(["desktop"]),
+  },
 } satisfies Meta<typeof GuidanceRequired>;
 
 export default meta;

--- a/apps/nextjs/src/components/AppComponents/Chat/header.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/header.stories.tsx
@@ -21,6 +21,7 @@ const meta = {
       },
     },
     ...demoParams({ isDemoUser: false }),
+    ...chromaticParams(["desktop"]),
   },
 } satisfies Meta<typeof Header>;
 

--- a/apps/nextjs/src/components/AppComponents/Chat/sidebar-actions.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/sidebar-actions.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { within } from "@storybook/test";
 
+import { chromaticParams } from "@/storybook/chromatic";
+
 import { SidebarActions } from "./sidebar-actions";
 
 const meta = {
@@ -8,6 +10,7 @@ const meta = {
   component: SidebarActions,
   parameters: {
     layout: "centered",
+    ...chromaticParams(["desktop"]),
   },
   tags: ["autodocs"],
 } satisfies Meta<typeof SidebarActions>;

--- a/apps/nextjs/src/components/DialogControl/DialogContents.stories.tsx
+++ b/apps/nextjs/src/components/DialogControl/DialogContents.stories.tsx
@@ -4,6 +4,7 @@ import { http, HttpResponse } from "msw";
 import { SurveyQuestionType, SurveyType } from "posthog-js";
 import type { PostHog } from "posthog-js";
 
+import { chromaticParams } from "@/storybook/chromatic";
 import { AnalyticsDecorator } from "@/storybook/decorators/AnalyticsDecorator";
 import { DialogContentDecorator } from "@/storybook/decorators/DialogContentDecorator";
 
@@ -17,6 +18,9 @@ const meta = {
   args: {
     lesson: {},
     chatId: "example-chat-id",
+  },
+  parameters: {
+    ...chromaticParams(["desktop"]),
   },
 } satisfies Meta<typeof DialogContents>;
 

--- a/apps/nextjs/src/components/Footer.stories.tsx
+++ b/apps/nextjs/src/components/Footer.stories.tsx
@@ -1,11 +1,16 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { chromaticParams } from "@/storybook/chromatic";
+
 import Footer from "./Footer";
 
 const meta = {
   title: "Components/Layout/Footer",
   component: Footer,
   tags: ["autodocs"],
+  parameters: {
+    ...chromaticParams(["desktop"]),
+  },
 } satisfies Meta<typeof Footer>;
 
 export default meta;

--- a/apps/nextjs/src/components/Header.stories.tsx
+++ b/apps/nextjs/src/components/Header.stories.tsx
@@ -1,6 +1,8 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
 
+import { chromaticParams } from "@/storybook/chromatic";
+
 import Header from "./Header";
 
 const meta = {
@@ -14,6 +16,7 @@ const meta = {
         height: "80px",
       },
     },
+    ...chromaticParams(["desktop"]),
   },
   args: {
     menuOpen: false,

--- a/apps/nextjs/src/components/Onboarding/TermsContent.stories.tsx
+++ b/apps/nextjs/src/components/Onboarding/TermsContent.stories.tsx
@@ -1,10 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { chromaticParams } from "@/storybook/chromatic";
+
 import TermsContent from "./TermsContent";
 
 const meta = {
   title: "Components/Onboarding/TermsContent",
   component: TermsContent,
+  parameters: {
+    ...chromaticParams(["mobile", "desktop"]),
+  },
 } satisfies Meta<typeof TermsContent>;
 
 export default meta;

--- a/apps/nextjs/src/components/Onboarding/TermsContent.stories.tsx
+++ b/apps/nextjs/src/components/Onboarding/TermsContent.stories.tsx
@@ -8,7 +8,7 @@ const meta = {
   title: "Components/Onboarding/TermsContent",
   component: TermsContent,
   parameters: {
-    ...chromaticParams(["mobile", "desktop"]),
+    ...chromaticParams(["desktop"]),
   },
 } satisfies Meta<typeof TermsContent>;
 

--- a/apps/nextjs/src/components/SignUpSignInLayout.stories.tsx
+++ b/apps/nextjs/src/components/SignUpSignInLayout.stories.tsx
@@ -1,10 +1,15 @@
 import type { Meta, StoryObj } from "@storybook/react";
 
+import { chromaticParams } from "@/storybook/chromatic";
+
 import SignUpSignInLayout from "./SignUpSignInLayout";
 
 const meta = {
   title: "Components/Layout/SignUpSignInLayout",
   component: SignUpSignInLayout,
+  parameters: {
+    ...chromaticParams(["desktop"]),
+  },
 } satisfies Meta<typeof SignUpSignInLayout>;
 
 export default meta;


### PR DESCRIPTION
## Description

In storybook, Chromatic is configured through the parameters object:

```
      modes: {
          desktop: { viewport: "desktop" },
      },
```

We provide a default with just the desktop mode, and then stories can add their own modes to the parameters object. The problem is that Storybook merges values in parameters, which means that there's no way for us to remove the desktop mode for a component which is only relevant on mobile

- Remove default chromatic mode from preview.tsx
- Add explicit chromatic viewport config to each story file
- Add ChromaticValidationDecorator to ensure that chromatic config is set
- Fix config for mobile-wide chromatic mode
