### PR TITLE
test: increase modify-lesson test timeout

### DIFF
--- a/apps/nextjs/tests-e2e/tests/modifiy-lesson.test.ts
+++ b/apps/nextjs/tests-e2e/tests/modifiy-lesson.test.ts
@@ -22,6 +22,7 @@ test.describe("Modify a lesson plan", () => {
   });
 
   test("Modify a lesson resource", async ({ page }) => {
+    test.setTimeout(generationTimeout * 3);
     const { setFixture } = await applyLlmFixtures(page, "replay");
 
     await test.step("Modify a lesson", async () => {


### PR DESCRIPTION
This test has slowed a bit. It first became flaky and then has recently begun to time out (on PRs and main)

In #472 I tried to speed up test LLM fixtures, but it didn't solve the problem. The quick fix to unblock is to extend the timeout