### PR TITLE
fix: async data prep functions should use Promise.resolve

### DIFF
--- a/packages/exports/src/dataHelpers/prepLessonForSlides.ts
+++ b/packages/exports/src/dataHelpers/prepLessonForSlides.ts
@@ -181,7 +181,7 @@ export async function prepLessonForSlides(
     learning_cycle_3_practise: data.cycle3?.practice ?? "",
     learning_cycle_3_feedback: data.cycle3?.feedback ?? "",
   };
-  return newData;
+  return Promise.resolve(newData);
 }
 
 type QuizDesignerSlidesTemplateData = {
@@ -601,7 +601,7 @@ export async function prepQuizDesignerForSlides(
         data.questions[19]?.distractors,
       )[2] ?? "",
   };
-  return newData;
+  return Promise.resolve(newData);
 }
 
 export async function prepLessonForAdditionalMaterialsDoc(
@@ -611,5 +611,5 @@ export async function prepLessonForAdditionalMaterialsDoc(
     lesson_title: data.title,
     content: data.additionalMaterials ?? "",
   };
-  return newData;
+  return Promise.resolve(newData);
 }

--- a/packages/exports/src/dataHelpers/prepLessonPlanForDocs.ts
+++ b/packages/exports/src/dataHelpers/prepLessonPlanForDocs.ts
@@ -24,7 +24,7 @@ function processQuizAnswersForLessonPlanDoc(
 export async function prepLessonPlanForDocs(
   lessonPlan: LessonPlanDocInputData,
 ): Promise<LessonPlanDocsTemplateData> {
-  return {
+  return Promise.resolve({
     lesson_title: lessonPlan.title,
     subject: lessonPlan.subject,
     key_stage: camelCaseToTitleCase(lessonPlan.keyStage) ?? "",
@@ -400,5 +400,5 @@ export async function prepLessonPlanForDocs(
       )[2] ?? "",
     cycle_3_practice: lessonPlan.cycle3?.practice ?? " ",
     cycle_3_feedback: lessonPlan.cycle3?.feedback ?? " ",
-  };
+  });
 }

--- a/packages/exports/src/dataHelpers/prepQuizForDocs.ts
+++ b/packages/exports/src/dataHelpers/prepQuizForDocs.ts
@@ -30,7 +30,7 @@ export async function prepQuizForDocs({
 }) {
   const quizTypeText = quizType === "exit" ? "Exit quiz" : "Starter quiz";
 
-  return {
+  return Promise.resolve({
     lesson_title: title,
     quiz_type: quizTypeText,
     question_1: processQuizQuestionText(quiz[0]?.question, 0),
@@ -96,5 +96,5 @@ export async function prepQuizForDocs({
     question_6_answer_c:
       processQuizAnswersForQuiz(quiz[5]?.answers, quiz[5]?.distractors)[2] ??
       " ",
-  };
+  });
 }

--- a/packages/exports/src/dataHelpers/prepWorksheetForSlides.ts
+++ b/packages/exports/src/dataHelpers/prepWorksheetForSlides.ts
@@ -6,7 +6,7 @@ export async function prepWorksheetForSlides(
     "title" | "cycle1" | "cycle2" | "cycle3"
   >,
 ) {
-  return {
+  return Promise.resolve({
     lesson_title: lessonPlan.title,
     learning_cycle_title_1: lessonPlan.cycle1.title ?? " ",
     practice_task_1: lessonPlan.cycle1.practice ?? " ",
@@ -14,5 +14,5 @@ export async function prepWorksheetForSlides(
     practice_task_2: lessonPlan?.cycle2?.practice ?? " ",
     learning_cycle_title_3: lessonPlan?.cycle3?.title ?? " ",
     practice_task_3: lessonPlan?.cycle3?.practice ?? " ",
-  };
+  });
 }


### PR DESCRIPTION
## Description

- These data prep functions for exports are marked as async
- Use Promise.resolve to retain the expected async behaviour without changing the signature of each function
- Not user-facing