### PR TITLE
feat: decouple aila engine stream reader

### DIFF
--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -94,8 +94,14 @@ export class AilaStreamHandler {
 
     const AILA_ENGINE_STREAM_URL = process.env.AILA_ENGINE_STREAM_URL;
 
-    const lastUserMessage = this._chat.messages.slice(-1)[0];
     if (AILA_ENGINE_STREAM_URL) {
+      /**
+       * If the AILA_ENGINE_STREAM_URL is defined, we will use it to stream the
+       * engine's response rather than using an AilaPromptBuilder with OpenAI's API.
+       *
+       * It allows us to experinent with different paradigms in a safe and unobtrusive way.
+       */
+      const lastUserMessage = this._chat.messages.slice(-1)[0];
       this._streamReader = await createStreamReaderFromURL(
         `${AILA_ENGINE_STREAM_URL}?prompt=${JSON.stringify(currentLessonPlan)}\n\n${lastUserMessage?.content}`,
       );

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -102,7 +102,7 @@ export class AilaStreamHandler {
        * It allows us to experinent with different paradigms in a safe and unobtrusive way.
        *
        * NOTE
-       * In order to use this in production, we'll need
+       * In order to use this in a non-local environment, we'll need
        * - authentication to the engine
        * - deeper changes in order to record that the source of the response is the engine and not OpenAI.
        */

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -100,6 +100,10 @@ export class AilaStreamHandler {
        * engine's response rather than using an AilaPromptBuilder with OpenAI's API.
        *
        * It allows us to experinent with different paradigms in a safe and unobtrusive way.
+       *
+       * NOTE
+       * In order to use this in production, we'll need deeper changes in order
+       * to record that the source of the response is the engine and not OpenAI.
        */
       const lastUserMessage = this._chat.messages.slice(-1)[0];
       this._streamReader = await createStreamReaderFromURL(

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -102,8 +102,9 @@ export class AilaStreamHandler {
        * It allows us to experinent with different paradigms in a safe and unobtrusive way.
        *
        * NOTE
-       * In order to use this in production, we'll need deeper changes in order
-       * to record that the source of the response is the engine and not OpenAI.
+       * In order to use this in production, we'll need
+       * - authentication to the engine
+       * - deeper changes in order to record that the source of the response is the engine and not OpenAI.
        */
       const lastUserMessage = this._chat.messages.slice(-1)[0];
       this._streamReader = await createStreamReaderFromURL(

--- a/packages/aila/src/core/chat/createStreamReaderFromURL.ts
+++ b/packages/aila/src/core/chat/createStreamReaderFromURL.ts
@@ -1,0 +1,47 @@
+export async function createStreamReaderFromURL(
+  apiUrl: string,
+): Promise<ReadableStreamDefaultReader<string>> {
+  const response = await fetch(apiUrl, {
+    method: "GET",
+    headers: {
+      Accept: "application/json",
+    },
+  });
+
+  if (!response.ok || !response.body) {
+    throw new Error(`Failed to fetch stream from API: ${response.statusText}`);
+  }
+
+  const textDecoder = new TextDecoder();
+  const streamReader = response.body.getReader();
+
+  return new ReadableStream<string>({
+    async start(controller) {
+      const readChunk = async () => {
+        try {
+          const { done, value } = await streamReader.read();
+          if (done) {
+            controller.close();
+            return;
+          }
+
+          const decoded = textDecoder.decode(value, { stream: true });
+          const lines = decoded.split("\n");
+          for (const line of lines) {
+            if (line.trim()) {
+              controller.enqueue(line.trim());
+            }
+          }
+          await readChunk();
+        } catch (error) {
+          controller.error(error);
+        }
+      };
+
+      await readChunk();
+    },
+    async cancel() {
+      await streamReader.cancel();
+    },
+  }).getReader();
+}

--- a/packages/aila/src/core/chat/createStreamReaderFromURL.ts
+++ b/packages/aila/src/core/chat/createStreamReaderFromURL.ts
@@ -1,3 +1,7 @@
+/**
+ * This function takes an API endpoint for an Aila compatible engine and returns a
+ * ReadableStreamDefaultReader, allowing it to be used in place of the OpenAI API.
+ */
 export async function createStreamReaderFromURL(
   apiUrl: string,
 ): Promise<ReadableStreamDefaultReader<string>> {


### PR DESCRIPTION
## Description

- in as simple way as possible, allow Aila to use a different 'engine'
- only routes traffic away _after_ lesson is initialised with (title,subject,key_stage,topic)
- it doesn't concern itself with any persistence or moderation currently. It would act as a drop in replacement for **the combination of the Prompt Builder and OpenAI**.
- due to improvements in streaming objects, a lot of the 'chunk' parsing will become redundant, however as I'm not wanting to delve into that part of the codebase (and risk jeopardising backward compatibility).