### PR TITLE
refactor: add zustand mirror for parsed chat messages

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -124,7 +124,8 @@
     "untruncate-json": "^0.0.1",
     "usehooks-ts": "^2.9.1",
     "zod": "3.23.8",
-    "zod-to-json-schema": "^3.23.0"
+    "zod-to-json-schema": "^3.23.0",
+    "zustand": "^5.0.3"
   },
   "devDependencies": {
     "@chromatic-com/storybook": "^1.6.1",

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.tsx
@@ -24,8 +24,6 @@ const ChatRightHandSideLesson = ({
   demo,
 }: Readonly<ChatRightHandSideLessonProps>) => {
   const { messages } = useLessonChat();
-  console.log({ messages, showLessonMobile });
-  console.log(messages.length);
 
   const chatEndRef = useRef<HTMLDivElement>(null);
 

--- a/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
@@ -24,6 +24,7 @@ import type { ChatRequestOptions, CreateMessage, Message } from "ai";
 import { useChat } from "ai/react";
 import { nanoid } from "nanoid";
 import { redirect, usePathname, useRouter } from "next/navigation";
+import { useChatStoreMirror } from "src/stores/chatStore/hooks";
 
 import { useTemporaryLessonPlanWithStreamingEdits } from "@/hooks/useTemporaryLessonPlanWithStreamingEdits";
 import { useLessonPlanTracking } from "@/lib/analytics/lessonPlanTrackingContext";
@@ -248,6 +249,9 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
       chatAreaRef.current?.scrollTo(0, chatAreaRef.current?.scrollHeight);
     },
   });
+
+  // Hooks to update the Zustand chat store mirror
+  useChatStoreMirror(messages, isLoading);
 
   useEffect(() => {
     /**

--- a/apps/nextjs/src/stores/chatStore/hooks.ts
+++ b/apps/nextjs/src/stores/chatStore/hooks.ts
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+
+import type { Message as AiMessage } from "ai";
+
+import { useChatStore } from "./index";
+
+// Hooks to update the Zustand chat store mirror from the AI SDK outputs
+export const useChatStoreMirror = (
+  messages: AiMessage[],
+  isLoading: boolean,
+) => {
+  const setMessages = useChatStore((state) => state.setMessages);
+
+  useEffect(() => {
+    setMessages(messages, isLoading);
+  }, [messages, isLoading, setMessages]);
+};

--- a/apps/nextjs/src/stores/chatStore/index.ts
+++ b/apps/nextjs/src/stores/chatStore/index.ts
@@ -1,0 +1,69 @@
+import { aiLogger } from "@oakai/logger";
+import invariant from "tiny-invariant";
+import { create } from "zustand";
+
+import { getNextStableMessages, parseStreamingMessage } from "./parsing";
+import type { AiMessage, ParsedMessage } from "./types";
+
+const log = aiLogger("chat:store");
+
+type ChatStore = {
+  // From AI SDK
+  isLoading: boolean;
+  stableMessages: ParsedMessage[];
+  streamingMessage: ParsedMessage | null;
+
+  // Actions
+  setMessages: (messages: AiMessage[], isLoading: boolean) => void;
+  setIsLoading: (isLoading: boolean) => void;
+};
+
+export const useChatStore = create<ChatStore>((set, get) => ({
+  // From AI SDK
+  isLoading: false,
+  stableMessages: [],
+  streamingMessage: null,
+
+  // Actions
+  setMessages: (messages, isLoading) => {
+    if (!isLoading) {
+      // All messages are stable
+      const nextStableMessages = getNextStableMessages(
+        messages,
+        get().stableMessages,
+      );
+      set({
+        ...(nextStableMessages && {
+          stableMessages: nextStableMessages,
+        }),
+        streamingMessage: null,
+      });
+    } else {
+      // The latest message is streaming, previous messages are stable
+      const currentMessageData = messages[messages.length - 1];
+      invariant(currentMessageData, "Should have at least one message");
+      const streamingMessage = parseStreamingMessage(
+        currentMessageData,
+        get().streamingMessage,
+      );
+
+      const stableMessageData = messages.slice(0, messages.length - 1);
+      const nextStableMessages = getNextStableMessages(
+        stableMessageData,
+        get().stableMessages,
+      );
+
+      set({
+        streamingMessage,
+        ...(nextStableMessages && {
+          stableMessages: nextStableMessages,
+        }),
+      });
+    }
+  },
+  setIsLoading: (isLoading) => set({ isLoading }),
+}));
+
+useChatStore.subscribe((state) => {
+  log.info("Chat store updated", state);
+});

--- a/apps/nextjs/src/stores/chatStore/parsing.ts
+++ b/apps/nextjs/src/stores/chatStore/parsing.ts
@@ -1,0 +1,65 @@
+import { parseMessageParts } from "@oakai/aila/src/protocol/jsonPatchProtocol";
+import { aiLogger } from "@oakai/logger";
+
+import type { AiMessage, ParsedMessage } from "./types";
+
+const log = aiLogger("chat:store");
+
+const stableMessagesMatch = (
+  messages: AiMessage[],
+  stableMessages: AiMessage[],
+) => {
+  const idHash = (messages: AiMessage[]) => messages.map((m) => m.id).join(",");
+  return idHash(messages) === idHash(stableMessages);
+};
+
+export const getNextStableMessages = (
+  messages: AiMessage[],
+  currentMessages: ParsedMessage[],
+): ParsedMessage[] | null => {
+  if (stableMessagesMatch(messages, currentMessages)) {
+    log.info("Stable messages unchanged, not updating");
+    return null;
+  }
+  return messages.map((m) => parseMessage(m));
+};
+
+export const parseStableMessages = (messages: AiMessage[]): ParsedMessage[] => {
+  return messages.map((m) => parseMessage(m));
+};
+
+export const parseStreamingMessage = (
+  message: AiMessage,
+  previousIteration: ParsedMessage | null,
+): ParsedMessage => {
+  try {
+    return parseMessage(message);
+  } catch (e) {
+    if (message.id === previousIteration?.id) {
+      log.warn(
+        "Failed to parse streaming message. Falling back to previous iteration",
+        e,
+      );
+      return previousIteration;
+    }
+    throw e;
+  }
+};
+
+export const parseMessage = (message: AiMessage): ParsedMessage => {
+  const parts = parseMessageParts(message.content);
+
+  return {
+    ...message,
+    parts,
+
+    // Calculated fields
+    hasError: parts.some((part) => part.document.type === "error"),
+    isEditing:
+      // TODO: this used to look at ailaStreamingStatus.
+      // Our equivalent would be to only add it to a currentMessage
+      parts.some((part) => part.isPartial) ||
+      parts.filter((part) => ["bad", "text", "prompt"].includes(part.type))
+        .length === 0,
+  };
+};

--- a/apps/nextjs/src/stores/chatStore/parsing.ts
+++ b/apps/nextjs/src/stores/chatStore/parsing.ts
@@ -1,4 +1,7 @@
-import { parseMessageParts } from "@oakai/aila/src/protocol/jsonPatchProtocol";
+import {
+  type MessagePart,
+  parseMessageParts,
+} from "@oakai/aila/src/protocol/jsonPatchProtocol";
 import { aiLogger } from "@oakai/logger";
 
 import type { AiMessage, ParsedMessage } from "./types";
@@ -12,6 +15,9 @@ const stableMessagesMatch = (
   const idHash = (messages: AiMessage[]) => messages.map((m) => m.id).join(",");
   return idHash(messages) === idHash(stableMessages);
 };
+
+const isContentPart = (part: MessagePart): boolean =>
+  ["text", "bad", "prompt"].includes(part.type);
 
 export const getNextStableMessages = (
   messages: AiMessage[],
@@ -56,10 +62,6 @@ export const parseMessage = (message: AiMessage): ParsedMessage => {
     // Calculated fields
     hasError: parts.some((part) => part.document.type === "error"),
     isEditing:
-      // TODO: this used to look at ailaStreamingStatus.
-      // Our equivalent would be to only add it to a currentMessage
-      parts.some((part) => part.isPartial) ||
-      parts.filter((part) => ["bad", "text", "prompt"].includes(part.type))
-        .length === 0,
+      parts.some((part) => part.isPartial) || !parts.some(isContentPart),
   };
 };

--- a/apps/nextjs/src/stores/chatStore/types.ts
+++ b/apps/nextjs/src/stores/chatStore/types.ts
@@ -1,0 +1,11 @@
+import type { MessagePart } from "@oakai/aila/src/protocol/jsonPatchProtocol";
+import type { Message as AiMessage } from "ai";
+
+export { AiMessage };
+
+// NOTE: The shape of this type is still in flux
+export type ParsedMessage = AiMessage & {
+  parts: MessagePart[];
+  hasError: boolean;
+  isEditing: boolean;
+};

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -36,6 +36,7 @@ type ChildKey =
   | "app"
   | "auth"
   | "chat"
+  | "chat:store"
   | "cloudinary"
   | "consent"
   | "core"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,6 +359,9 @@ importers:
       zod-to-json-schema:
         specifier: ^3.23.0
         version: 3.23.0(zod@3.23.8)
+      zustand:
+        specifier: ^5.0.3
+        version: 5.0.3(@types/react@18.2.57)(react@18.2.0)
     devDependencies:
       '@chromatic-com/storybook':
         specifier: ^1.6.1
@@ -24779,6 +24782,28 @@ packages:
 
   /zod@3.23.8:
     resolution: {integrity: sha512-XBx9AXhXktjUqnepgTiE5flcKIYWi/rme0Eaj+5Y0lftuGBq+jyRu/md4WnuxqgP1ubdpNCsYEYPxrzVHD8d6g==}
+
+  /zustand@5.0.3(@types/react@18.2.57)(react@18.2.0):
+    resolution: {integrity: sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==}
+    engines: {node: '>=12.20.0'}
+    peerDependencies:
+      '@types/react': '>=18.0.0'
+      immer: '>=9.0.6'
+      react: '>=18.0.0'
+      use-sync-external-store: '>=1.2.0'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+      use-sync-external-store:
+        optional: true
+    dependencies:
+      '@types/react': 18.2.57
+      react: 18.2.0
+    dev: false
 
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}


### PR DESCRIPTION
## Description

- We're trying out [Zustand](https://zustand.docs.pmnd.rs/getting-started/introduction) for state management. We don't have a good pattern for centralised or component-local state at the moment
- With Zustand we can
  - Gain control over data changes like chat messages streaming from the backend
  - Subscribe to slices of the state tree to only re-render components that need to change
  - Avoid challenges of chained useEffect/useState/useMemo for complex behaviour
  - Make logic (global or component-specific) easily testable without rendering components
  - Modularise the behaviours in this project to help with other AI projects across Oak

This pr:
- Adds the "chat" store using zustand
- Syncs chat data into the chat store
- Parses messages to useful structures when adding to the store, not at render time
- Gives us a base to incrementally migrate UI and logic to the new store

Here's an example screenshot of the frontend log while streaming a chat, showing `stableMessages` and `streamingMessage`
![CleanShot 2025-01-16 at 17 29 07@2x](https://github.com/user-attachments/assets/ce5e6f07-16fe-4336-bf58-f5a74e2ba4ac)

## Issue(s)

Fixes #

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
