### PR TITLE
fix: use stable initialMessages for useChat

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.tsx
@@ -24,8 +24,6 @@ const ChatRightHandSideLesson = ({
   demo,
 }: Readonly<ChatRightHandSideLessonProps>) => {
   const { messages } = useLessonChat();
-  console.log({ messages, showLessonMobile });
-  console.log(messages.length);
 
   const chatEndRef = useRef<HTMLDivElement>(null);
 

--- a/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
@@ -174,6 +174,11 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
   const { invokeActionMessages } = useActionMessages();
 
   /******************* Streaming of all chat starts from messages here *******************/
+  const initialMessages = useMemo(() => {
+    return chat?.messages?.filter((m) =>
+      isValidMessageRole(m.role),
+    ) as Message[];
+  }, [chat?.messages]);
 
   const {
     messages,
@@ -186,9 +191,7 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
     setMessages,
   } = useChat({
     sendExtraMessageFields: true,
-    initialMessages: (chat?.messages ?? []).filter((m) =>
-      isValidMessageRole(m.role),
-    ) as Message[],
+    initialMessages,
     generateId: () => generateMessageId({ role: "user" }),
     id,
     body: {


### PR DESCRIPTION
## Description

I've been finding that the frontend has been getting in a render loop that calls `getChat` constantly. @JBR90 worked out that #459 was probably the PR that introduced it

![CleanShot 2025-01-16 at 15 02 48@2x](https://github.com/user-attachments/assets/7b98a9e1-72bf-4216-b870-84c72b5f4a44)


I've found that `initialMessages` was different on each render, which might cause useChat to reload and trigger another tRPC request

I've also been finding that the AI SDK calls like `append` aren't stable. This doesn't seem to completely fix that, though changing `initialMessages` could be the cause

## Issue(s)

Fixes #

## How to test

1. Open the chat page for an existing lesson plan
2. Look at the console



