### PR TITLE
fix: use stable initialMessages for useChat (#493)

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.tsx
@@ -24,8 +24,6 @@ const ChatRightHandSideLesson = ({
   demo,
 }: Readonly<ChatRightHandSideLessonProps>) => {
   const { messages } = useLessonChat();
-  console.log({ messages, showLessonMobile });
-  console.log(messages.length);
 
   const chatEndRef = useRef<HTMLDivElement>(null);
 

--- a/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
@@ -174,6 +174,11 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
   const { invokeActionMessages } = useActionMessages();
 
   /******************* Streaming of all chat starts from messages here *******************/
+  const initialMessages = useMemo(() => {
+    return chat?.messages?.filter((m) =>
+      isValidMessageRole(m.role),
+    ) as Message[];
+  }, [chat?.messages]);
 
   const {
     messages,
@@ -186,9 +191,7 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
     setMessages,
   } = useChat({
     sendExtraMessageFields: true,
-    initialMessages: (chat?.messages ?? []).filter((m) =>
-      isValidMessageRole(m.role),
-    ) as Message[],
+    initialMessages,
     generateId: () => generateMessageId({ role: "user" }),
     id,
     body: {


### PR DESCRIPTION
## Description

- Hotfix for this bug fix - https://github.com/oaknational/oak-ai-lesson-assistant/pull/493

## Issue(s)

Fixes #

## How to test

1. Go to https://oak-ai-lesson-assistant-ny7hx7ow3.vercel-preview.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
