### PR TITLE
chore: maths quiz tighter types

### DIFF
--- a/packages/aila/src/core/quiz/apiCallingUtils.ts
+++ b/packages/aila/src/core/quiz/apiCallingUtils.ts
@@ -5,12 +5,13 @@
 // Beta chat.
 
 // Decorates (without experimental decorators) to add a random delay to a function.
-export function withRandomDelay(
-  fn: (...args: any[]) => Promise<any>,
+// Adds a random delay to a function
+export function withRandomDelay<TArgs extends unknown[], TResult>(
+  fn: (...args: TArgs) => Promise<TResult>,
   minDelay: number,
   maxDelay: number,
-) {
-  return async function (...args: any[]): Promise<any> {
+): (...args: TArgs) => Promise<TResult> {
+  return async function (...args: TArgs): Promise<TResult> {
     const delay = Math.floor(
       Math.random() * (maxDelay - minDelay + 1) + minDelay,
     );
@@ -20,12 +21,13 @@ export function withRandomDelay(
   };
 }
 
+// Example usage:
 // const delayedFetchData = withRandomDelay(fetchData, 1000, 5000);
 
-export async function processArray<T>(
+export async function processArray<T, TResult>(
   array: T[],
-  asyncFunction: (item: T) => Promise<any>,
-): Promise<any[]> {
+  asyncFunction: (item: T) => Promise<TResult>,
+): Promise<TResult[]> {
   const promises = array.map((item) => asyncFunction(item));
   return Promise.all(promises);
 }

--- a/packages/aila/src/core/quiz/rerankers/AilaQuizReranker.ts
+++ b/packages/aila/src/core/quiz/rerankers/AilaQuizReranker.ts
@@ -1,5 +1,6 @@
 import { aiLogger } from "@oakai/logger";
 import { kv } from "@vercel/kv";
+import { pick } from "remeda";
 import { Md5 } from "ts-md5";
 
 import type {
@@ -49,21 +50,14 @@ export abstract class BasedOnRagAilaQuizReranker<T extends typeof BaseSchema>
     quizType: QuizPath,
   ): Promise<T[]> {
     const keyPrefix = "aila:quiz:openai:reranker";
-    const lessonPlanRerankerFields: string[] = [
+    const lessonPlanRerankerFields = [
       "title",
       "topic",
       "learningOutcome",
       "keyLearningPoints",
-    ];
+    ] as const;
 
-    // Extract only the relevant fields from lesson plan
-    const relevantLessonPlanData = lessonPlanRerankerFields.reduce(
-      (acc, field) => {
-        acc[field] = lessonPlan[field as keyof LooseLessonPlan];
-        return acc;
-      },
-      {} as Record<string, unknown>,
-    );
+    const relevantLessonPlanData = pick(lessonPlan, lessonPlanRerankerFields);
 
     // Create hash from relevant data
     const hash = Md5.hashStr(


### PR DESCRIPTION
## Description

- use remeda `pick` to get lesson plan subset
- improve types on `apiCallingUtils` (though curerntly this isn't called anywhere so haven't checked that the new types align with what the caller expects)