### PR TITLE
Chore/abstract lookup table

### DIFF
--- a/packages/aila/src/core/quiz/LessonSlugQuizMapping.test.ts
+++ b/packages/aila/src/core/quiz/LessonSlugQuizMapping.test.ts
@@ -1,0 +1,98 @@
+import type { PrismaClientWithAccelerate } from "@oakai/db";
+
+import {
+  DBLessonQuizLookup,
+  InMemoryLessonQuizLookup,
+} from "./LessonSlugQuizMapping";
+import type { LessonSlugQuizMapping } from "./interfaces";
+
+describe("InMemoryLessonQuizLookup", () => {
+  const mockQuizMap: LessonSlugQuizMapping = {
+    "lesson-1": {
+      starterQuiz: ["q1", "q2"],
+      exitQuiz: ["q3", "q4"],
+    },
+    "lesson-2": {
+      starterQuiz: ["q5"],
+      exitQuiz: ["q6"],
+    },
+  };
+
+  const lookup = new InMemoryLessonQuizLookup(mockQuizMap);
+
+  describe("getStarterQuiz", () => {
+    it("should return starter quiz questions for valid lesson slug", () => {
+      const result = lookup.getStarterQuiz("lesson-1");
+      expect(result).toEqual(["q1", "q2"]);
+    });
+
+    it("should throw error for invalid lesson slug", () => {
+      expect(() => lookup.getStarterQuiz("non-existent")).toThrow(
+        "No starter quiz found for lesson slug: non-existent",
+      );
+    });
+  });
+
+  describe("getExitQuiz", () => {
+    it("should return exit quiz questions for valid lesson slug", () => {
+      const result = lookup.getExitQuiz("lesson-1");
+      expect(result).toEqual(["q3", "q4"]);
+    });
+
+    it("should throw error for invalid lesson slug", () => {
+      expect(() => lookup.getExitQuiz("non-existent")).toThrow(
+        "No exit quiz found for lesson slug: non-existent",
+      );
+    });
+  });
+
+  describe("hasStarterQuiz", () => {
+    it("should return true when starter quiz exists", () => {
+      expect(lookup.hasStarterQuiz("lesson-1")).toBe(true);
+    });
+
+    it("should return false when starter quiz doesn't exist", () => {
+      expect(lookup.hasStarterQuiz("non-existent")).toBe(false);
+    });
+  });
+
+  describe("hasExitQuiz", () => {
+    it("should return true when exit quiz exists", () => {
+      expect(lookup.hasExitQuiz("lesson-1")).toBe(true);
+    });
+
+    it("should return false when exit quiz doesn't exist", () => {
+      expect(lookup.hasExitQuiz("non-existent")).toBe(false);
+    });
+  });
+});
+
+describe("DBLessonQuizLookup", () => {
+  const mockPrisma = {
+    // Add mock methods as needed
+  } as unknown as PrismaClientWithAccelerate;
+
+  const dbLookup = new DBLessonQuizLookup(mockPrisma);
+
+  describe("unimplemented methods", () => {
+    it("getStarterQuiz should throw not implemented error", () => {
+      expect(() => dbLookup.getStarterQuiz("any-slug")).toThrow(
+        "Not implemented",
+      );
+    });
+
+    it("getExitQuiz should throw not implemented error", () => {
+      expect(() => dbLookup.getExitQuiz("any-slug")).toThrow("Not implemented");
+    });
+
+    it("hasStarterQuiz should throw not implemented error", () => {
+      expect(() => dbLookup.hasStarterQuiz("any-slug")).toThrow(
+        "Not implemented",
+      );
+    });
+
+    it("hasExitQuiz should throw not implemented error", () => {
+      expect(() => dbLookup.hasExitQuiz("any-slug")).toThrow("Not implemented");
+    });
+  });
+});

--- a/packages/aila/src/core/quiz/LessonSlugQuizMapping.ts
+++ b/packages/aila/src/core/quiz/LessonSlugQuizMapping.ts
@@ -1,0 +1,71 @@
+import type { PrismaClientWithAccelerate } from "@oakai/db";
+import { aiLogger } from "@oakai/logger";
+
+import type { LessonSlugQuizLookup, LessonSlugQuizMapping } from "./interfaces";
+
+const log = aiLogger("aila:quiz");
+
+export abstract class BaseLesssonQuizLookup implements LessonSlugQuizLookup {
+  abstract getStarterQuiz(lessonSlug: string): string[];
+  abstract getExitQuiz(lessonSlug: string): string[];
+  abstract hasStarterQuiz(lessonSlug: string): boolean;
+  abstract hasExitQuiz(lessonSlug: string): boolean;
+}
+
+export class InMemoryLessonQuizLookup extends BaseLesssonQuizLookup {
+  private readonly quizMap: LessonSlugQuizMapping;
+  constructor(quizMap: LessonSlugQuizMapping) {
+    super();
+    this.quizMap = quizMap;
+  }
+
+  // These are errors as currently we expect a quiz for every lesson slug. Where these are not available in legacy lessons, we have filled with a placeholder quiz with empty quizzes.
+  getStarterQuiz(lessonSlug: string): string[] {
+    const starterQuiz = this.quizMap[lessonSlug]?.starterQuiz;
+    if (!starterQuiz) {
+      log.error(`No starter quiz found for lesson slug: ${lessonSlug}`);
+      throw new Error(`No starter quiz found for lesson slug: ${lessonSlug}`);
+    }
+    return starterQuiz;
+  }
+
+  getExitQuiz(lessonSlug: string): string[] {
+    const exitQuiz = this.quizMap[lessonSlug]?.exitQuiz;
+    if (!exitQuiz) {
+      log.error(`No exit quiz found for lesson slug: ${lessonSlug}`);
+      throw new Error(`No exit quiz found for lesson slug: ${lessonSlug}`);
+    }
+    return exitQuiz;
+  }
+
+  hasStarterQuiz(lessonSlug: string): boolean {
+    return this.quizMap[lessonSlug]?.starterQuiz !== undefined;
+  }
+
+  hasExitQuiz(lessonSlug: string): boolean {
+    return this.quizMap[lessonSlug]?.exitQuiz !== undefined;
+  }
+}
+
+export class DBLessonQuizLookup extends BaseLesssonQuizLookup {
+  constructor(private readonly prisma: PrismaClientWithAccelerate) {
+    super();
+    this.prisma = prisma;
+  }
+
+  getStarterQuiz(lessonSlug: string): string[] {
+    throw new Error("Not implemented");
+  }
+
+  getExitQuiz(lessonSlug: string): string[] {
+    throw new Error("Not implemented");
+  }
+
+  hasStarterQuiz(lessonSlug: string): boolean {
+    throw new Error("Not implemented");
+  }
+
+  hasExitQuiz(lessonSlug: string): boolean {
+    throw new Error("Not implemented");
+  }
+}

--- a/packages/aila/src/core/quiz/LessonSlugQuizMapping.ts
+++ b/packages/aila/src/core/quiz/LessonSlugQuizMapping.ts
@@ -5,14 +5,14 @@ import type { LessonSlugQuizLookup, LessonSlugQuizMapping } from "./interfaces";
 
 const log = aiLogger("aila:quiz");
 
-export abstract class BaseLesssonQuizLookup implements LessonSlugQuizLookup {
+export abstract class BaseLessonQuizLookup implements LessonSlugQuizLookup {
   abstract getStarterQuiz(lessonSlug: string): string[];
   abstract getExitQuiz(lessonSlug: string): string[];
   abstract hasStarterQuiz(lessonSlug: string): boolean;
   abstract hasExitQuiz(lessonSlug: string): boolean;
 }
 
-export class InMemoryLessonQuizLookup extends BaseLesssonQuizLookup {
+export class InMemoryLessonQuizLookup extends BaseLessonQuizLookup {
   private readonly quizMap: LessonSlugQuizMapping;
   constructor(quizMap: LessonSlugQuizMapping) {
     super();
@@ -47,7 +47,8 @@ export class InMemoryLessonQuizLookup extends BaseLesssonQuizLookup {
   }
 }
 
-export class DBLessonQuizLookup extends BaseLesssonQuizLookup {
+// To be implemented later. No factories ect as this will become only implementation.
+export class DBLessonQuizLookup extends BaseLessonQuizLookup {
   constructor(private readonly prisma: PrismaClientWithAccelerate) {
     super();
     this.prisma = prisma;

--- a/packages/aila/src/core/quiz/interfaces.ts
+++ b/packages/aila/src/core/quiz/interfaces.ts
@@ -157,6 +157,7 @@ export interface LessonSlugQuizLookup {
   hasStarterQuiz(lessonSlug: string): boolean;
   hasExitQuiz(lessonSlug: string): boolean;
 }
+
 // FACTORIES BELOW
 export interface FullServiceFactory {
   create(settings: QuizServiceSettings): FullQuizService;

--- a/packages/aila/src/core/quiz/interfaces.ts
+++ b/packages/aila/src/core/quiz/interfaces.ts
@@ -151,6 +151,12 @@ export interface LessonSlugQuizMapping {
   [lessonSlug: string]: QuizSet;
 }
 
+export interface LessonSlugQuizLookup {
+  getStarterQuiz(lessonSlug: string): string[];
+  getExitQuiz(lessonSlug: string): string[];
+  hasStarterQuiz(lessonSlug: string): boolean;
+  hasExitQuiz(lessonSlug: string): boolean;
+}
 // FACTORIES BELOW
 export interface FullServiceFactory {
   create(settings: QuizServiceSettings): FullQuizService;

--- a/packages/aila/src/core/quiz/rerankers/ReturnFirstReranker.test.ts
+++ b/packages/aila/src/core/quiz/rerankers/ReturnFirstReranker.test.ts
@@ -1,7 +1,7 @@
 import type { z } from "zod";
 
 import type { QuizQuestion } from "../../../protocol/schema";
-import { cachedQuiz } from "../fixtures/fixtures_for_matt";
+import { cachedQuiz } from "../fixtures/CachedImageQuiz";
 import { testRatingSchema } from "./RerankerStructuredOutputSchema";
 import { ReturnFirstReranker } from "./ReturnFirstReranker";
 


### PR DESCRIPTION
## Description

- Abstracts lesson lookup table behind LessonLookup Class for refactoring of ingest in `LessonSlugQuizMapping.ts`

## Issue(s)

Fixes #

## How to test

1. Go to https://oak-ai-lesson-assistant-bc1adwcbj.vercel-preview.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
