### PR TITLE
chore: run cron job twice

### DIFF
--- a/apps/nextjs/vercel.json
+++ b/apps/nextjs/vercel.json
@@ -15,8 +15,12 @@
       "schedule": "0 3 * * *"
     },
     {
-      "path": "/api/cron-jobs/google-drive-size-quota",
+      "path": "/api/cron-jobs/expired-exports",
       "schedule": "0 4 * * *"
+    },
+    {
+      "path": "/api/cron-jobs/google-drive-size-quota",
+      "schedule": "0 5 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Description

- Cron job is timing out before it has deleted all the expired exports. We might need to look at another solution for this but for now lets run it twice. 3am and 4am and a check at 5am for % used


## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
