### PR TITLE
refactor: log store changes by key

### DIFF
--- a/apps/nextjs/src/stores/chatStore/index.ts
+++ b/apps/nextjs/src/stores/chatStore/index.ts
@@ -3,6 +3,7 @@ import { aiLogger } from "@oakai/logger";
 import type { ChatRequestOptions, CreateMessage, Message } from "ai";
 import { create } from "zustand";
 
+import { logStoreUpdates } from "../zustandHelpers";
 import { handleExecuteQueuedAction } from "./stateActionFunctions/handleExecuteQueuedAction";
 import { handleQueueUserAction } from "./stateActionFunctions/handleQueueUserAction";
 import { handleSetMessages } from "./stateActionFunctions/handleSetMessages";
@@ -95,6 +96,4 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   },
 }));
 
-useChatStore.subscribe((state) => {
-  log.info("Chat store updated", state);
-});
+logStoreUpdates(useChatStore, "chat:store");

--- a/apps/nextjs/src/stores/zustandHelpers.ts
+++ b/apps/nextjs/src/stores/zustandHelpers.ts
@@ -1,0 +1,29 @@
+import { aiLogger, type LoggerKey } from "@oakai/logger";
+import type { StoreApi } from "zustand";
+
+export const logStoreUpdates = <T extends object>(
+  store: StoreApi<T>,
+  loggerKey: LoggerKey,
+) => {
+  const log = aiLogger(loggerKey);
+  store.subscribe((state, prevState) => {
+    const changedKeys = Object.keys(state)
+      .filter((key) => state[key] !== prevState[key])
+      .map((key) => {
+        const value = state[key];
+        if (value && typeof value === "object") {
+          const prevValue = prevState[key] || {};
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          const changedKeys = Object.keys(value).filter(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            (key) => value[key] !== prevValue[key],
+          );
+          return `/${key}/{${changedKeys.join(",")}}`;
+        }
+
+        return `/${key}`;
+      });
+    // .map((key) => `/${key}`);
+    log.info(`State updated: ${changedKeys.join(", ")}`);
+  });
+};

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -14,7 +14,7 @@ const debugBase = debug("ai");
 // By default debug logs to stderr, we want to use stdout
 debugBase.log = console.log.bind(console);
 
-type ChildKey =
+export type LoggerKey =
   | "admin"
   | "aila"
   | "aila:analytics"
@@ -88,7 +88,7 @@ const errorLogger =
  * const log = aiLogger("db");
  * log.info("Hello world");
  */
-export function aiLogger(childKey: ChildKey) {
+export function aiLogger(childKey: LoggerKey) {
   const debugLogger = debugBase.extend(childKey);
 
   const tableLogger = (tabularData: unknown[], columns?: string[]) => {


### PR DESCRIPTION
A small change taken from the lesson plan store PR

I think that logging the full store contents could be keeping objects in memory after they're no longer needed. I also found that it was difficult to tell which values had changed in each update