### PR TITLE
refactor: reset chat store state

### DIFF
--- a/apps/nextjs/.storybook/decorators/ChatStoreDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/ChatStoreDecorator.tsx
@@ -3,30 +3,24 @@ import React, { useEffect } from "react";
 import type { Decorator } from "@storybook/react";
 
 import {
+  ChatStore,
   useChatStore,
   type AilaStreamingStatus,
 } from "../../src/stores/chatStore";
 
 declare module "@storybook/csf" {
   interface Parameters {
-    chatStoreState?: {
-      ailaStreamingStatus: AilaStreamingStatus;
-      queuedUserAction?: string | null;
-    };
+    chatStoreState?: Partial<ChatStore>;
   }
 }
 
 export const ChatStoreDecorator: Decorator = (Story, { parameters }) => {
-  const reset = useChatStore((state) => state.reset);
-
   useEffect(() => {
     if (!parameters.chatStoreState) {
       return;
     }
-    reset({
-      ...parameters.chatStoreState,
-    });
-  }, [reset]);
+    useChatStore.setState(parameters.chatStoreState);
+  }, [parameters.chatStoreState]);
 
   return <Story />;
 };

--- a/apps/nextjs/src/app/aila/page-contents.tsx
+++ b/apps/nextjs/src/app/aila/page-contents.tsx
@@ -8,9 +8,11 @@ import Layout from "@/components/AppComponents/Layout";
 import { ChatProvider } from "@/components/ContextProviders/ChatProvider";
 import { useReactScan } from "@/hooks/useReactScan";
 import LessonPlanTrackingProvider from "@/lib/analytics/lessonPlanTrackingContext";
+import { useChatStoreReset } from "@/stores/chatStore/hooks/useChatStoreReset";
 
 const ChatPageContents = ({ id }: { readonly id: string }) => {
   useReactScan({ component: LessonPlanDisplay, interval: 10000 });
+  useChatStoreReset({ id });
 
   return (
     <Layout>

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-start.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-start.tsx
@@ -14,6 +14,7 @@ import { useDemoUser } from "@/components/ContextProviders/Demo";
 import DialogContents from "@/components/DialogControl/DialogContents";
 import { DialogRoot } from "@/components/DialogControl/DialogRoot";
 import useAnalytics from "@/lib/analytics/useAnalytics";
+import { useChatStoreReset } from "@/stores/chatStore/hooks/useChatStoreReset";
 import { trpc } from "@/utils/trpc";
 
 import { useDialog } from "../DialogContext";
@@ -120,6 +121,8 @@ export function ChatStart({
     },
     [create, setDialogWindow, demo.isDemoUser, setIsSubmitting],
   );
+
+  useChatStoreReset({ id: null });
 
   const interstitialSubmit = useCallback(() => {
     create(input).catch((error) => {

--- a/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
@@ -24,7 +24,7 @@ import type { ChatRequestOptions, CreateMessage, Message } from "ai";
 import { useChat } from "ai/react";
 import { nanoid } from "nanoid";
 import { redirect, usePathname, useRouter } from "next/navigation";
-import { useChatStoreMirror } from "src/stores/chatStore/hooks/useChatStoreMirror";
+import { useChatStoreAiSdkSync } from "src/stores/chatStore/hooks/useChatStoreAiSdkSync";
 
 import { useTemporaryLessonPlanWithStreamingEdits } from "@/hooks/useTemporaryLessonPlanWithStreamingEdits";
 import { useLessonPlanTracking } from "@/lib/analytics/lessonPlanTrackingContext";
@@ -301,8 +301,14 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
     });
   }, [reload]);
 
-  // Hooks to update the Zustand chat store mirror
-  useChatStoreMirror(messages, isLoading, stopStreaming, append, handleReload);
+  // Hooks to update the Zustand chat store
+  useChatStoreAiSdkSync(
+    messages,
+    isLoading,
+    stopStreaming,
+    append,
+    handleReload,
+  );
 
   /**
    *  If the state is being restored from a previous lesson plan, set the lesson plan

--- a/apps/nextjs/src/stores/chatStore/hooks/useChatStoreAiSdkSync.ts
+++ b/apps/nextjs/src/stores/chatStore/hooks/useChatStoreAiSdkSync.ts
@@ -9,7 +9,7 @@ import type {
 
 import { useChatStore } from "../index";
 
-export const useChatStoreMirror = (
+export const useChatStoreAiSdkSync = (
   messages: AiMessage[],
   isLoading: boolean,
   stop: () => void,

--- a/apps/nextjs/src/stores/chatStore/hooks/useChatStoreReset.ts
+++ b/apps/nextjs/src/stores/chatStore/hooks/useChatStoreReset.ts
@@ -1,0 +1,17 @@
+import { useEffect } from "react";
+
+import { useChatStore } from "..";
+
+// The chat store is instantiated globally, so can leak state between pages
+// Use this hook to reset the store when changing page
+// NOTE: If this causes problems, we can try instantiating the store in a context
+export const useChatStoreReset = ({ id }: { id: string | null }) => {
+  const reset = useChatStore((state) => state.reset);
+
+  useEffect(() => {
+    reset(id);
+    return () => {
+      reset(null);
+    };
+  }, [id, reset]);
+};

--- a/apps/nextjs/src/stores/chatStore/index.ts
+++ b/apps/nextjs/src/stores/chatStore/index.ts
@@ -32,6 +32,7 @@ export type AilaStreamingStatus =
   | "Idle";
 
 export type ChatStore = {
+  id: string | null;
   ailaStreamingStatus: AilaStreamingStatus;
 
   stableMessages: ParsedMessage[];
@@ -53,14 +54,11 @@ export type ChatStore = {
   stop: () => void;
   streamingFinished: () => void;
 
-  reset: (
-    params: Pick<ChatStore, "ailaStreamingStatus"> & {
-      queuedUserAction?: ChatStore["queuedUserAction"];
-    },
-  ) => void;
+  reset: (id: string | null) => void;
 };
 
-export const useChatStore = create<ChatStore>((set, get) => ({
+const initialState = {
+  id: null,
   ailaStreamingStatus: "Idle",
   stableMessages: [],
   streamingMessage: null,
@@ -73,6 +71,10 @@ export const useChatStore = create<ChatStore>((set, get) => ({
     reload: () => {},
     append: async () => Promise.resolve(""),
   },
+} satisfies Partial<ChatStore>;
+
+export const useChatStore = create<ChatStore>((set, get) => ({
+  ...initialState,
 
   // Setters
   setAiSdkActions: (aiSdkActions) => set({ aiSdkActions }),
@@ -85,11 +87,12 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   setMessages: handleSetMessages(set, get),
   streamingFinished: handleStreamingFinished(set, get),
 
-  // reset
-  reset: ({ ailaStreamingStatus = "Idle", queuedUserAction }) => {
+  // Reset function
+  reset: (id) => {
+    log.info(`Resetting to ${id ?? "null"}`);
     set({
-      ailaStreamingStatus: ailaStreamingStatus,
-      queuedUserAction: queuedUserAction,
+      ...initialState,
+      id,
     });
   },
 }));


### PR DESCRIPTION
Pulling some parts from #511 

## Description

- Reset chat store state when navigating between pages
- Update chat store storybook decorator
