### PR TITLE
chore: update the SonarQube action in GitHub workflows

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -45,7 +45,7 @@ jobs:
           echo "version=$APP_VERSION" >> $GITHUB_OUTPUT
 
       - name: SonarCloud scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ steps.doppler.outputs.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       # Run only on production branch
       - name: Report coverage to SonarCloud
         if: ${{ github.event.pull_request.merged == true && github.base_ref == 'production' }}
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}


### PR DESCRIPTION
## Update the SonarQube action in GitHub workflows

The `SonarSource/sonarcloud-github-action` is deprecated. The newer, drop in replacement, `SonarSource/sonarqube-scan-action` is available.

- Moved from `sonarcloud-github-action` to `sonarqube-scan-action`
- Moved from using `master` as a version to a specific version (to stop any breaking changes immediately impacting project workflows)

## Issue(s)

Fixes ENG-1129

## How to test

1. Check SonarQube scans are running successfully.