### PR TITLE
chore: update prisma to 6.3.1

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -51,7 +51,7 @@
     "@oaknational/oak-components": "^1.68.1",
     "@oaknational/oak-consent-client": "^2.1.0",
     "@portabletext/react": "^3.1.0",
-    "@prisma/client": "^5.16.1",
+    "@prisma/client": "^6.3.1",
     "@prisma/extension-accelerate": "^1.2.1",
     "@radix-ui/react-accordion": "^1.1.2",
     "@radix-ui/react-icons": "^1.3.0",

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -70,7 +70,7 @@
   "prettier": "@oakai/prettier-config",
   "dependencies": {
     "@oakai/logger": "*",
-    "@prisma/client": "^5.16.1",
+    "@prisma/client": "^6.3.1",
     "@prisma/extension-accelerate": "^1.2.1",
     "@types/chunk-text": "^1.0.0",
     "cheerio": "1.0.0-rc.12",
@@ -87,7 +87,7 @@
     "@oakai/eslint-config": "*",
     "@oakai/prettier-config": "*",
     "dotenv-cli": "^6.0.0",
-    "prisma": "5.16.1",
+    "prisma": "6.3.1",
     "typescript": "5.7.2",
     "zod-prisma": "^0.5.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -138,11 +138,11 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0(react@18.2.0)
       '@prisma/client':
-        specifier: ^5.16.1
-        version: 5.16.1(prisma@5.16.1)
+        specifier: ^6.3.1
+        version: 6.3.1(prisma@6.3.1)(typescript@5.7.2)
       '@prisma/extension-accelerate':
         specifier: ^1.2.1
-        version: 1.2.1(@prisma/client@5.16.1)
+        version: 1.2.1(@prisma/client@6.3.1)
       '@radix-ui/react-accordion':
         specifier: ^1.1.2
         version: 1.1.2(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
@@ -739,11 +739,11 @@ importers:
         specifier: '*'
         version: link:../logger
       '@prisma/client':
-        specifier: ^5.16.1
-        version: 5.16.1(prisma@5.16.1)
+        specifier: ^6.3.1
+        version: 6.3.1(prisma@6.3.1)(typescript@5.7.2)
       '@prisma/extension-accelerate':
         specifier: ^1.2.1
-        version: 1.2.1(@prisma/client@5.16.1)
+        version: 1.2.1(@prisma/client@6.3.1)
       '@types/chunk-text':
         specifier: ^1.0.0
         version: 1.0.0
@@ -785,14 +785,14 @@ importers:
         specifier: ^6.0.0
         version: 6.0.0
       prisma:
-        specifier: 5.16.1
-        version: 5.16.1
+        specifier: 6.3.1
+        version: 6.3.1(typescript@5.7.2)
       typescript:
         specifier: 5.7.2
         version: 5.7.2
       zod-prisma:
         specifier: ^0.5.4
-        version: 0.5.4(prisma@5.16.1)(zod@3.23.8)
+        version: 0.5.4(prisma@6.3.1)(zod@3.23.8)
 
   packages/eslint-config:
     devDependencies:
@@ -6633,17 +6633,21 @@ packages:
       preact: 10.25.1
     dev: false
 
-  /@prisma/client@5.16.1(prisma@5.16.1):
-    resolution: {integrity: sha512-wM9SKQjF0qLxdnOZIVAIMKiz6Hu7vDt4FFAih85K1dk/Rr2mdahy6d3QP41K62N9O0DJJA//gUDA3Mp49xsKIg==}
-    engines: {node: '>=16.13'}
+  /@prisma/client@6.3.1(prisma@6.3.1)(typescript@5.7.2):
+    resolution: {integrity: sha512-ARAJaPs+eBkemdky/XU3cvGRl+mIPHCN2lCXsl5Vlb0E2gV+R6IN7aCI8CisRGszEZondwIsW9Iz8EJkTdykyA==}
+    engines: {node: '>=18.18'}
     requiresBuild: true
     peerDependencies:
       prisma: '*'
+      typescript: '>=5.1.0'
     peerDependenciesMeta:
       prisma:
         optional: true
+      typescript:
+        optional: true
     dependencies:
-      prisma: 5.16.1
+      prisma: 6.3.1(typescript@5.7.2)
+      typescript: 5.7.2
     dev: false
 
   /@prisma/debug@3.8.1:
@@ -6654,36 +6658,36 @@ packages:
       strip-ansi: 6.0.1
     dev: true
 
-  /@prisma/debug@5.16.1:
-    resolution: {integrity: sha512-JsNgZAg6BD9RInLSrg7ZYzo11N7cVvYArq3fHGSD89HSgtN0VDdjV6bib7YddbcO6snzjchTiLfjeTqBjtArVQ==}
+  /@prisma/debug@6.3.1:
+    resolution: {integrity: sha512-RrEBkd+HLZx+ydfmYT0jUj7wjLiS95wfTOSQ+8FQbvb6vHh5AeKfEPt/XUQ5+Buljj8hltEfOslEW57/wQIVeA==}
 
-  /@prisma/engines-version@5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303:
-    resolution: {integrity: sha512-HkT2WbfmFZ9WUPyuJHhkiADxazHg8Y4gByrTSVeb3OikP6tjQ7txtSUGu9OBOBH0C13dPKN2qqH12xKtHu/Hiw==}
+  /@prisma/engines-version@6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0:
+    resolution: {integrity: sha512-R/ZcMuaWZT2UBmgX3Ko6PAV3f8//ZzsjRIG1eKqp3f2rqEqVtCv+mtzuH2rBPUC9ujJ5kCb9wwpxeyCkLcHVyA==}
 
-  /@prisma/engines@5.16.1:
-    resolution: {integrity: sha512-KkyF3eIUtBIyp5A/rJHCtwQO18OjpGgx18PzjyGcJDY/+vNgaVyuVd+TgwBgeq6NLdd1XMwRCI+58vinHsAdfA==}
+  /@prisma/engines@6.3.1:
+    resolution: {integrity: sha512-sXdqEVLyGAJ5/iUoG/Ea5AdHMN71m6PzMBWRQnLmhhOejzqAaEr8rUd623ql6OJpED4s/U4vIn4dg1qkF7vGag==}
     requiresBuild: true
     dependencies:
-      '@prisma/debug': 5.16.1
-      '@prisma/engines-version': 5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303
-      '@prisma/fetch-engine': 5.16.1
-      '@prisma/get-platform': 5.16.1
+      '@prisma/debug': 6.3.1
+      '@prisma/engines-version': 6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0
+      '@prisma/fetch-engine': 6.3.1
+      '@prisma/get-platform': 6.3.1
 
-  /@prisma/extension-accelerate@1.2.1(@prisma/client@5.16.1):
+  /@prisma/extension-accelerate@1.2.1(@prisma/client@6.3.1):
     resolution: {integrity: sha512-QicnMeyqL226ilT3vvRsFAqPeIdqHGKR4c25CoK5zZ1tNIv8egfgpD1gCKqOGmfAz0pIKQnMuJU3eNg9KItC7A==}
     engines: {node: '>=16'}
     peerDependencies:
       '@prisma/client': '>=4.16.1'
     dependencies:
-      '@prisma/client': 5.16.1(prisma@5.16.1)
+      '@prisma/client': 6.3.1(prisma@6.3.1)(typescript@5.7.2)
     dev: false
 
-  /@prisma/fetch-engine@5.16.1:
-    resolution: {integrity: sha512-oOkjaPU1lhcA/Rvr4GVfd1NLJBwExgNBE36Ueq7dr71kTMwy++a3U3oLd2ZwrV9dj9xoP6LjCcky799D9nEt4w==}
+  /@prisma/fetch-engine@6.3.1:
+    resolution: {integrity: sha512-HOf/0umOgt+/S2xtZze+FHKoxpVg4YpVxROr6g2YG09VsI3Ipyb+rGvD6QGbCqkq5NTWAAZoOGNL+oy7t+IhaQ==}
     dependencies:
-      '@prisma/debug': 5.16.1
-      '@prisma/engines-version': 5.16.0-24.34ace0eb2704183d2c05b60b52fba5c43c13f303
-      '@prisma/get-platform': 5.16.1
+      '@prisma/debug': 6.3.1
+      '@prisma/engines-version': 6.3.0-17.acc0b9dd43eb689cbd20c9470515d719db10d0b0
+      '@prisma/get-platform': 6.3.1
 
   /@prisma/generator-helper@3.8.1:
     resolution: {integrity: sha512-3zSy+XTEjmjLj6NO+/YPN1Cu7or3xA11TOoOnLRJ9G4pTT67RJXjK0L9Xy5n+3I0Xlb7xrWCgo8MvQQLMWzxPA==}
@@ -6694,10 +6698,10 @@ packages:
       cross-spawn: 7.0.3
     dev: true
 
-  /@prisma/get-platform@5.16.1:
-    resolution: {integrity: sha512-R4IKnWnMkR2nUAbU5gjrPehdQYUUd7RENFD2/D+xXTNhcqczp0N+WEGQ3ViyI3+6mtVcjjNIMdnUTNyu3GxIgA==}
+  /@prisma/get-platform@6.3.1:
+    resolution: {integrity: sha512-AYLq6Hk9xG73JdLWJ3Ip9Wg/vlP7xPvftGBalsPzKDOHr/ImhwJ09eS8xC2vNT12DlzGxhfk8BkL0ve2OriNhQ==}
     dependencies:
-      '@prisma/debug': 5.16.1
+      '@prisma/debug': 6.3.1
 
   /@prisma/instrumentation@5.19.1:
     resolution: {integrity: sha512-VLnzMQq7CWroL5AeaW0Py2huiNKeoMfCH3SUxstdzPrlWQi6UQ9UrfcbUkNHlVFqOMacqy8X/8YtE0kuKDpD9w==}
@@ -20740,13 +20744,21 @@ packages:
       minimist: 1.2.8
     dev: false
 
-  /prisma@5.16.1:
-    resolution: {integrity: sha512-Z1Uqodk44diztImxALgJJfNl2Uisl9xDRvqybMKEBYJLNKNhDfAHf+ZIJbZyYiBhLMbKU9cYGdDVG5IIXEnL2Q==}
-    engines: {node: '>=16.13'}
+  /prisma@6.3.1(typescript@5.7.2):
+    resolution: {integrity: sha512-JKCZWvBC3enxk51tY4TWzS4b5iRt4sSU1uHn2I183giZTvonXaQonzVtjLzpOHE7qu9MxY510kAtFGJwryKe3Q==}
+    engines: {node: '>=18.18'}
     hasBin: true
     requiresBuild: true
+    peerDependencies:
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
     dependencies:
-      '@prisma/engines': 5.16.1
+      '@prisma/engines': 6.3.1
+      typescript: 5.7.2
+    optionalDependencies:
+      fsevents: 2.3.3
 
   /prismjs@1.27.0:
     resolution: {integrity: sha512-t13BGPUlFDR7wRB5kQDG4jjl7XeuH6jbJGt11JHPL96qwsEHNX2+68tFXqc1/k+/jALsbSWJKUOT/hcYAZ5LkA==}
@@ -24800,7 +24812,7 @@ packages:
       readable-stream: 4.4.2
     dev: false
 
-  /zod-prisma@0.5.4(prisma@5.16.1)(zod@3.23.8):
+  /zod-prisma@0.5.4(prisma@6.3.1)(zod@3.23.8):
     resolution: {integrity: sha512-5Ca4Qd1a1jy1T/NqCEpbr0c+EsbjJfJ/7euEHob3zDvtUK2rTuD1Rc/vfzH8q8PtaR2TZbysD88NHmrLwpv3Xg==}
     engines: {node: '>=14'}
     hasBin: true
@@ -24814,7 +24826,7 @@ packages:
     dependencies:
       '@prisma/generator-helper': 3.8.1
       parenthesis: 3.1.8
-      prisma: 5.16.1
+      prisma: 6.3.1(typescript@5.7.2)
       ts-morph: 13.0.3
       zod: 3.23.8
     dev: true


### PR DESCRIPTION
## Description

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to https://oak-ai-lesson-assistant-3nwnobny5.vercel-preview.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
