### PR TITLE
feat: refetch lesson plan when streaming completes

### DIFF
--- a/apps/nextjs/.storybook/decorators/ChatStoreDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/ChatStoreDecorator.tsx
@@ -8,7 +8,7 @@ import {
   createLessonPlanStore,
   type LessonPlanStore,
 } from "@/stores/lessonPlanStore";
-import { trpc } from "@/utils/trpc";
+import { trpc, TrpcUtils } from "@/utils/trpc";
 
 declare module "@storybook/csf" {
   interface Parameters {
@@ -20,7 +20,7 @@ declare module "@storybook/csf" {
 export const ChatStoreDecorator: Decorator = (Story, { parameters }) => {
   const value = useMemo(() => {
     const id = "dummy-chat-id";
-    const trpcUtils = trpc.useUtils();
+    const trpcUtils = {} as TrpcUtils;
 
     return {
       chat: createChatStore(parameters.chatStoreState),

--- a/apps/nextjs/.storybook/decorators/ChatStoreDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/ChatStoreDecorator.tsx
@@ -8,6 +8,7 @@ import {
   createLessonPlanStore,
   type LessonPlanStore,
 } from "@/stores/lessonPlanStore";
+import { trpc } from "@/utils/trpc";
 
 declare module "@storybook/csf" {
   interface Parameters {
@@ -18,9 +19,16 @@ declare module "@storybook/csf" {
 
 export const ChatStoreDecorator: Decorator = (Story, { parameters }) => {
   const value = useMemo(() => {
+    const id = "dummy-chat-id";
+    const trpcUtils = trpc.useUtils();
+
     return {
       chat: createChatStore(parameters.chatStoreState),
-      lessonPlan: createLessonPlanStore(parameters.lessonPlanStoreState),
+      lessonPlan: createLessonPlanStore(
+        id,
+        trpcUtils,
+        parameters.lessonPlanStoreState,
+      ),
     };
   }, [parameters.chatStoreState]);
 

--- a/apps/nextjs/src/app/aila/page-contents.tsx
+++ b/apps/nextjs/src/app/aila/page-contents.tsx
@@ -16,7 +16,7 @@ const ChatPageContents = ({ id }: { readonly id: string }) => {
   return (
     <Layout>
       <LessonPlanTrackingProvider chatId={id}>
-        <AilaStoresProvider>
+        <AilaStoresProvider id={id}>
           <ChatProvider id={id}>
             <Chat />
           </ChatProvider>

--- a/apps/nextjs/src/stores/AilaStoresProvider.tsx
+++ b/apps/nextjs/src/stores/AilaStoresProvider.tsx
@@ -1,8 +1,9 @@
-import { useState, createContext, useContext } from "react";
+import { useState, createContext, useContext, useEffect } from "react";
 
 import { useStore, type StoreApi } from "zustand";
 
 import { type ChatStore, createChatStore } from "@/stores/chatStore";
+import { trpc } from "@/utils/trpc";
 
 import { type LessonPlanStore, createLessonPlanStore } from "./lessonPlanStore";
 
@@ -15,14 +16,29 @@ export const AilaStoresContext = createContext<
   AilaStoresContextProps | undefined
 >(undefined);
 
-export const AilaStoresProvider = ({ children }) => {
-  const [store] = useState(() => ({
+type AilaStoresProviderProps = {
+  id: string;
+  children: React.ReactNode;
+};
+
+export const AilaStoresProvider = ({
+  id,
+  children,
+}: AilaStoresProviderProps) => {
+  const trpcUtils = trpc.useUtils();
+
+  const [stores] = useState(() => ({
     chat: createChatStore(),
-    lessonPlan: createLessonPlanStore(),
+    lessonPlan: createLessonPlanStore(id, trpcUtils),
   }));
 
+  // Store initialisation
+  useEffect(() => {
+    void stores.lessonPlan.getState().refetch();
+  }, [stores.lessonPlan, id]);
+
   return (
-    <AilaStoresContext.Provider value={store}>
+    <AilaStoresContext.Provider value={stores}>
       {children}
     </AilaStoresContext.Provider>
   );

--- a/apps/nextjs/src/stores/lessonPlanStore/stateActionFunctions/handleMessagesUpdated.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/stateActionFunctions/handleMessagesUpdated.ts
@@ -6,12 +6,10 @@ import {
 import { LessonPlanKeySchema } from "@oakai/aila/src/protocol/schema";
 import { aiLogger } from "@oakai/logger";
 import { createHash } from "crypto";
-import { StoreApi } from "zustand";
 
 import type { AiMessage } from "@/stores/chatStore/types";
 
-import type { LessonPlanStore } from "..";
-import { LessonPlanGetter, LessonPlanSetter } from "../types";
+import type { LessonPlanGetter, LessonPlanSetter } from "../types";
 
 const log = aiLogger("lessons:store");
 

--- a/apps/nextjs/src/stores/lessonPlanStore/stateActionFunctions/handleRefetch.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/stateActionFunctions/handleRefetch.ts
@@ -1,0 +1,41 @@
+import { aiLogger } from "@oakai/logger";
+import * as Sentry from "@sentry/nextjs";
+import invariant from "tiny-invariant";
+
+import type { TrpcUtils } from "@/utils/trpc";
+
+import type { LessonPlanGetter, LessonPlanSetter } from "../types";
+
+const log = aiLogger("lessons:store");
+
+export const handleRefetch = (
+  set: LessonPlanSetter,
+  get: LessonPlanGetter,
+  trpc: TrpcUtils,
+) => {
+  return async () => {
+    log.info("Refetching");
+    try {
+      const id = get().id;
+      const result = await trpc.client.chat.appSessions.getChat.query({ id });
+      invariant(result, "result should not be null");
+      const { lessonPlan, iteration } = result;
+
+      if (get().isAcceptingChanges) {
+        log.info("Lesson plan from DB ignored while streaming");
+        return;
+      }
+      const currentIteration = get().iteration;
+      if (iteration && currentIteration && iteration <= currentIteration) {
+        log.info(`Ignored lesson plan from DB with iteration #${iteration}`);
+        return;
+      }
+
+      set({ lessonPlan, iteration });
+      log.info(`Set lesson plan iteration #${iteration} from DB`);
+    } catch (err) {
+      log.error("Error refetching lessonPlanStore", err);
+      Sentry.captureException(err);
+    }
+  };
+};

--- a/apps/nextjs/src/utils/trpc.tsx
+++ b/apps/nextjs/src/utils/trpc.tsx
@@ -20,6 +20,8 @@ const getBaseUrl = () => {
 
 type CombinedRouter = AppRouter & ChatAppRouter;
 
+export type TrpcUtils = ReturnType<typeof trpc.useUtils>;
+
 const trpc = createTRPCReact<CombinedRouter>();
 
 const discriminatingRouterLink: TRPCLink<CombinedRouter> = (runtime) => {


### PR DESCRIPTION
The lesson plan store supports applying patches like `useTemporaryLessonPlanWithStreamingEdits`, but it doesn't have any logic for replacing the temporary lesson plan with a stable version from the API

This PR adds a `refetch` function which runs when the AI SDK stops streaming