### PR TITLE
fix: add basedOn to LessonPlanKeySchema

### DIFF
--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -427,6 +427,7 @@ export const LessonPlanKeySchema = z.enum([
   "keyStage",
   "subject",
   "topic",
+  "basedOn",
   ...allSectionsInOrder,
 ]);
 


### PR DESCRIPTION
In #523 I created LessonPlanKeySchema. I didn't include `basedOn`, which causes zod to fail to parse if you select a lesson from rag