### PR TITLE
build: release candidate

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -45,7 +45,7 @@ jobs:
           echo "version=$APP_VERSION" >> $GITHUB_OUTPUT
 
       - name: SonarCloud scan
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ steps.doppler.outputs.SONAR_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
       # Run only on production branch
       - name: Report coverage to SonarCloud
         if: ${{ github.event.pull_request.merged == true && github.base_ref == 'production' }}
-        uses: sonarsource/sonarcloud-github-action@master
+        uses: SonarSource/sonarqube-scan-action@v4.2.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -51,10 +51,13 @@ yarn-error.log*
 .tool-versions
 
 # Allow each developer to have personal settings, but ignore these files
-.vscode/launch.json 
+.vscode/launch.json
 .vscode/*.settings.json
+.gitleaks.toml
+.pre-commit-config.yaml
+
 
 .sonar
 .sonar/**/*
 
-dependency-graph.svg
+

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -105,6 +105,7 @@
     "llms",
     "manypkg",
     "maror",
+    "miscon",
     "moderations",
     "multilogical",
     "NDJSON",

--- a/apps/nextjs/.storybook/decorators/ChatStoreDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/ChatStoreDecorator.tsx
@@ -8,6 +8,7 @@ import {
   createLessonPlanStore,
   type LessonPlanStore,
 } from "@/stores/lessonPlanStore";
+import { trpc, TrpcUtils } from "@/utils/trpc";
 
 declare module "@storybook/csf" {
   interface Parameters {
@@ -18,9 +19,16 @@ declare module "@storybook/csf" {
 
 export const ChatStoreDecorator: Decorator = (Story, { parameters }) => {
   const value = useMemo(() => {
+    const id = "dummy-chat-id";
+    const trpcUtils = {} as TrpcUtils;
+
     return {
       chat: createChatStore(parameters.chatStoreState),
-      lessonPlan: createLessonPlanStore(parameters.lessonPlanStoreState),
+      lessonPlan: createLessonPlanStore(
+        id,
+        trpcUtils,
+        parameters.lessonPlanStoreState,
+      ),
     };
   }, [parameters.chatStoreState]);
 

--- a/apps/nextjs/.storybook/decorators/ChatStoreDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/ChatStoreDecorator.tsx
@@ -3,12 +3,16 @@ import React, { useMemo } from "react";
 import type { Decorator } from "@storybook/react";
 
 import { AilaStoresContext } from "@/stores/AilaStoresProvider";
-
-import { createChatStore, type ChatStore } from "../../src/stores/chatStore";
+import { createChatStore, type ChatStore } from "@/stores/chatStore";
+import {
+  createLessonPlanStore,
+  type LessonPlanStore,
+} from "@/stores/lessonPlanStore";
 
 declare module "@storybook/csf" {
   interface Parameters {
     chatStoreState?: Partial<ChatStore>;
+    lessonPlanStoreState?: Partial<LessonPlanStore>;
   }
 }
 
@@ -16,6 +20,7 @@ export const ChatStoreDecorator: Decorator = (Story, { parameters }) => {
   const value = useMemo(() => {
     return {
       chat: createChatStore(parameters.chatStoreState),
+      lessonPlan: createLessonPlanStore(parameters.lessonPlanStoreState),
     };
   }, [parameters.chatStoreState]);
 

--- a/apps/nextjs/.storybook/decorators/ChatStoreDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/ChatStoreDecorator.tsx
@@ -1,32 +1,27 @@
-import React, { useEffect } from "react";
+import React, { useMemo } from "react";
 
 import type { Decorator } from "@storybook/react";
 
-import {
-  useChatStore,
-  type AilaStreamingStatus,
-} from "../../src/stores/chatStore";
+import { AilaStoresContext } from "@/stores/AilaStoresProvider";
+
+import { createChatStore, type ChatStore } from "../../src/stores/chatStore";
 
 declare module "@storybook/csf" {
   interface Parameters {
-    chatStoreState?: {
-      ailaStreamingStatus: AilaStreamingStatus;
-      queuedUserAction?: string | null;
-    };
+    chatStoreState?: Partial<ChatStore>;
   }
 }
 
 export const ChatStoreDecorator: Decorator = (Story, { parameters }) => {
-  const reset = useChatStore((state) => state.reset);
+  const value = useMemo(() => {
+    return {
+      chat: createChatStore(parameters.chatStoreState),
+    };
+  }, [parameters.chatStoreState]);
 
-  useEffect(() => {
-    if (!parameters.chatStoreState) {
-      return;
-    }
-    reset({
-      ...parameters.chatStoreState,
-    });
-  }, [reset]);
-
-  return <Story />;
+  return (
+    <AilaStoresContext.Provider value={value}>
+      <Story />
+    </AilaStoresContext.Provider>
+  );
 };

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -66,6 +66,7 @@
     "@trpc/next": "10.45.2",
     "@trpc/react-query": "10.45.2",
     "@trpc/server": "10.45.2",
+    "@types/object-hash": "^3.0.6",
     "@types/ramda": "^0.30.2",
     "@uidotdev/usehooks": "^2.4.1",
     "ai": "^4.0.20",

--- a/apps/nextjs/src/ai-apps/common/parseLocalStorageData.ts
+++ b/apps/nextjs/src/ai-apps/common/parseLocalStorageData.ts
@@ -19,7 +19,9 @@ export function parseLocalStorageData<S extends z.ZodTypeAny>(
   try {
     if (storedData) {
       const jsonParsedData = JSON.parse(storedData);
-      return schema.parse(jsonParsedData);
+      const parsed = schema.parse(jsonParsedData);
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      return parsed;
     }
   } catch (err) {
     log.error(err);

--- a/apps/nextjs/src/app/admin/aila/[chatId]/page.tsx
+++ b/apps/nextjs/src/app/admin/aila/[chatId]/page.tsx
@@ -44,5 +44,11 @@ export default function AdminChat({ params }: Readonly<AdminChatProps>) {
     return <div>No moderations found</div>;
   }
 
-  return <AdminChatView chat={chat} moderations={moderations} />;
+  return (
+    <AdminChatView
+      chat={chat}
+      moderations={moderations.moderations}
+      safetyViolations={moderations.safetyViolations}
+    />
+  );
 }

--- a/apps/nextjs/src/app/admin/aila/[chatId]/view.stories.tsx
+++ b/apps/nextjs/src/app/admin/aila/[chatId]/view.stories.tsx
@@ -1,0 +1,72 @@
+import type { AilaPersistedChat } from "@oakai/aila/src/protocol/schema";
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { chromaticParams } from "@/storybook/chromatic";
+
+import { AdminChatView } from "./view";
+
+const meta = {
+  title: "Pages/Admin/Aila/[chatId]/View",
+  component: AdminChatView,
+  parameters: {
+    ...chromaticParams(["desktop"]),
+  },
+} satisfies Meta<typeof AdminChatView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    chat: {
+      lessonPlan: {
+        title: "A naughty lesson plan",
+      },
+    } as AilaPersistedChat,
+    moderations: [
+      {
+        id: "cm654k0a50007tf413jc6po5f",
+        createdAt: new Date("2025-01-20T14:11:26.957Z"),
+        updatedAt: new Date("2025-01-20T14:11:26.957Z"),
+        userId: "user_2nQuq4jFWLfo4w1WNA6xEBp93IY",
+        appSessionId: "ElzgFmHVS6JTdldd",
+        messageId: "a-bMjytJMVEJYa24Lk",
+        categories: ["t/encouragement-violence"],
+        scores: null,
+        justification: "Mock toxic result",
+        lessonSnapshotId: "cm654k08y0005tf412e0g9f5y",
+        userComment: null,
+        invalidatedAt: null,
+        invalidatedBy: null,
+      },
+      {
+        id: "cm654iz8z0003tf41e42karvo",
+        createdAt: new Date("2025-01-20T14:10:38.963Z"),
+        updatedAt: new Date("2025-01-20T14:10:38.963Z"),
+        userId: "user_2nQuq4jFWLfo4w1WNA6xEBp93IY",
+        appSessionId: "ElzgFmHVS6JTdldd",
+        messageId: "a-ZAlNJ9Dykdu0TLoB",
+        categories: [],
+        scores: { l: 5, p: 5, s: 5, t: 5, u: 5, v: 5 },
+        justification:
+          "The lesson plan titled 'The end of Roman Britain' for key-stage-3 history is fully compliant across all categories. It focuses on historical events and their impacts without involving any sensitive or inappropriate content. There is no use of discriminatory or offensive language, nor any depiction of violence or conflict beyond the historical context, which is appropriate for the age group. The content does not include any upsetting, sensitive, or distressing material, nor does it involve nudity or sexual content. There is no physical activity or safety concerns associated with the lesson, and it does not contain any toxic or harmful instructions or encouragement. Overall, the lesson plan is suitable for the intended educational purpose and audience.",
+        lessonSnapshotId: "cm654ito20001tf41k2fbjeu6",
+        userComment: null,
+        invalidatedAt: null,
+        invalidatedBy: null,
+      },
+    ],
+    safetyViolations: [
+      {
+        id: "cm654k0cm0008tf410t5ml610",
+        createdAt: new Date("2025-01-20T14:11:27.047Z"),
+        updatedAt: new Date("2025-01-20T14:11:27.047Z"),
+        userId: "user_2nQuq4jFWLfo4w1WNA6xEBp93IY",
+        userAction: "CHAT_MESSAGE",
+        detectionSource: "MODERATION",
+        recordType: "MODERATION",
+        recordId: "cm654k0a50007tf413jc6po5f",
+      },
+    ],
+  },
+};

--- a/apps/nextjs/src/app/admin/aila/[chatId]/view.tsx
+++ b/apps/nextjs/src/app/admin/aila/[chatId]/view.tsx
@@ -1,26 +1,76 @@
 import { useState } from "react";
+import { toast } from "react-hot-toast";
 
 import type { AilaPersistedChat } from "@oakai/aila/src/protocol/schema";
 import { getSafetyResult } from "@oakai/core/src/utils/ailaModeration/helpers";
-import type { Moderation } from "@oakai/db";
-import { OakAccordion, OakPrimaryButton } from "@oaknational/oak-components";
+import type { Moderation, SafetyViolation } from "@oakai/db";
+import {
+  OakAccordion,
+  OakPrimaryButton,
+  OakFlex,
+  OakSmallSecondaryButton,
+  OakP,
+} from "@oaknational/oak-components";
+import * as Sentry from "@sentry/nextjs";
 
 import { trpc } from "@/utils/trpc";
 
+function SafetyViolationItem({
+  safetyViolation,
+}: {
+  readonly safetyViolation: SafetyViolation;
+}) {
+  const { recordId } = safetyViolation;
+  const removeSafetyViolation = trpc.admin.removeSafetyViolation.useMutation({
+    onError: (err) => {
+      toast.error("Error removing safety violation");
+      Sentry.captureException(err);
+    },
+  });
+
+  return (
+    <>
+      <OakFlex $alignItems="center" $background="pink" $pa="inner-padding-m">
+        <OakP $font="body-2" $mr="space-between-m">
+          <OakP $font="heading-7">
+            This moderation triggered a safety violation.
+          </OakP>{" "}
+          Reversing may unban a banned user
+        </OakP>
+        <OakSmallSecondaryButton
+          iconName={removeSafetyViolation.isSuccess ? "tick" : "cross"}
+          onClick={() =>
+            void removeSafetyViolation.mutateAsync({ recordId: recordId })
+          }
+          isLoading={removeSafetyViolation.isLoading}
+          disabled={
+            removeSafetyViolation.isLoading || removeSafetyViolation.isSuccess
+          }
+        >
+          {removeSafetyViolation.isSuccess ? "Reversed" : "Reverse violation"}
+        </OakSmallSecondaryButton>
+      </OakFlex>
+    </>
+  );
+}
+
 function ModerationListItem({
   moderation,
+  safetyViolation,
 }: {
   readonly moderation: Moderation;
+  readonly safetyViolation: SafetyViolation | null;
 }) {
   const { id, invalidatedAt } = moderation;
   const [invalidated, setInvalidated] = useState(Boolean(invalidatedAt));
   const invalidateModeration = trpc.admin.invalidateModeration.useMutation({
     onSuccess: () => setInvalidated(true),
   });
+
   return (
     <li
       key={moderation.id}
-      className={`rounded-md border  p-4 shadow-sm ${invalidated ? "opacity-50" : "opacity-100"}`}
+      className={`rounded-md border p-4 shadow-sm ${invalidated ? "opacity-50" : "opacity-100"}`}
     >
       <div className="flex w-full items-start justify-between">
         <div className="flex w-full flex-col space-y-8">
@@ -56,6 +106,10 @@ function ModerationListItem({
                 </span>
               ))}
           </div>
+
+          {!!safetyViolation && (
+            <SafetyViolationItem safetyViolation={safetyViolation} />
+          )}
         </div>
       </div>
     </li>
@@ -65,9 +119,11 @@ function ModerationListItem({
 export function AdminChatView({
   chat,
   moderations,
+  safetyViolations,
 }: {
   readonly chat: AilaPersistedChat;
   readonly moderations: Moderation[];
+  readonly safetyViolations: SafetyViolation[];
 }) {
   return (
     <>
@@ -75,8 +131,16 @@ export function AdminChatView({
       <h2 className="mb-4 text-2xl font-bold">Moderations</h2>
       <ul className="mb-18 space-y-4">
         {moderations.map((moderation) => {
+          const safetyViolation =
+            safetyViolations.find(
+              (safetyViolation) => safetyViolation.recordId === moderation.id,
+            ) ?? null;
           return (
-            <ModerationListItem key={moderation.id} moderation={moderation} />
+            <ModerationListItem
+              key={moderation.id}
+              moderation={moderation}
+              safetyViolation={safetyViolation}
+            />
           );
         })}
       </ul>

--- a/apps/nextjs/src/app/aila/page-contents.tsx
+++ b/apps/nextjs/src/app/aila/page-contents.tsx
@@ -16,7 +16,7 @@ const ChatPageContents = ({ id }: { readonly id: string }) => {
   return (
     <Layout>
       <LessonPlanTrackingProvider chatId={id}>
-        <AilaStoresProvider>
+        <AilaStoresProvider id={id}>
           <ChatProvider id={id}>
             <Chat />
           </ChatProvider>

--- a/apps/nextjs/src/app/aila/page-contents.tsx
+++ b/apps/nextjs/src/app/aila/page-contents.tsx
@@ -8,6 +8,7 @@ import Layout from "@/components/AppComponents/Layout";
 import { ChatProvider } from "@/components/ContextProviders/ChatProvider";
 import { useReactScan } from "@/hooks/useReactScan";
 import LessonPlanTrackingProvider from "@/lib/analytics/lessonPlanTrackingContext";
+import { AilaStoresProvider } from "@/stores/AilaStoresProvider";
 
 const ChatPageContents = ({ id }: { readonly id: string }) => {
   useReactScan({ component: LessonPlanDisplay, interval: 10000 });
@@ -15,9 +16,11 @@ const ChatPageContents = ({ id }: { readonly id: string }) => {
   return (
     <Layout>
       <LessonPlanTrackingProvider chatId={id}>
-        <ChatProvider id={id}>
-          <Chat />
-        </ChatProvider>
+        <AilaStoresProvider>
+          <ChatProvider id={id}>
+            <Chat />
+          </ChatProvider>
+        </AilaStoresProvider>
       </LessonPlanTrackingProvider>
     </Layout>
   );

--- a/apps/nextjs/src/app/aila/page.tsx
+++ b/apps/nextjs/src/app/aila/page.tsx
@@ -5,18 +5,40 @@ import { redirect } from "next/navigation";
 import { ChatStart } from "@/components/AppComponents/Chat/chat-start";
 import Layout from "@/components/AppComponents/Layout";
 
-export default function IndexPage() {
+interface IndexPageProps {
+  searchParams: {
+    keyStage?: string;
+    subject?: string;
+    unitTitle?: string;
+    searchExpression?: string;
+  };
+}
+
+export default async function IndexPage({ searchParams }: IndexPageProps) {
   const clerkAuthentication = auth();
   const { userId }: { userId: string | null } = clerkAuthentication;
   if (!userId) {
     redirect("/sign-in?next=/aila");
   }
 
+  // Destructure searchParams with default values of null if not present
+  const {
+    keyStage = undefined,
+    subject = undefined,
+    unitTitle = undefined,
+    searchExpression = undefined,
+  } = searchParams;
+
   return (
     <>
       <SignedIn>
         <Layout>
-          <ChatStart />
+          <ChatStart
+            keyStage={keyStage}
+            subject={subject}
+            unitTitle={unitTitle}
+            searchExpression={searchExpression}
+          />
         </Layout>
       </SignedIn>
       <SignedOut></SignedOut>

--- a/apps/nextjs/src/app/api/aila-download-all/route.ts
+++ b/apps/nextjs/src/app/api/aila-download-all/route.ts
@@ -156,7 +156,9 @@ async function getHandler(req: Request): Promise<Response> {
     return new Response("No files found or processed", { status: 404 });
   }
 
-  await archive.finalize();
+  // @todo fix this
+  // eslint-disable-next-line @typescript-eslint/no-floating-promises
+  archive.finalize();
 
   const readableStream = nodePassThroughToReadableStream(zipStream);
 

--- a/apps/nextjs/src/app/api/chat/route.test.ts
+++ b/apps/nextjs/src/app/api/chat/route.test.ts
@@ -36,31 +36,35 @@ describe("Chat API Route", () => {
     jest.spyOn(mockLLMService, "createChatCompletionObjectStream");
 
     testConfig = {
-      createAila: jest.fn().mockImplementation(async (options) => {
-        const ailaConfig: AilaInitializationOptions = {
-          options: {
-            usePersistence: false,
-            useRag: false,
-            useAnalytics: false,
-            useModeration: false,
-            useErrorReporting: false,
-            useThreatDetection: false,
+      createAila: jest
+        .fn()
+        .mockImplementation(
+          async (options: Partial<AilaInitializationOptions>) => {
+            const ailaConfig: AilaInitializationOptions = {
+              options: {
+                usePersistence: false,
+                useRag: false,
+                useAnalytics: false,
+                useModeration: false,
+                useErrorReporting: false,
+                useThreatDetection: false,
+              },
+              chat: {
+                id: chatId,
+                userId,
+                messages: options?.chat?.messages ?? [],
+              },
+              plugins: [],
+              services: {
+                chatLlmService: mockLLMService,
+                chatCategoriser: mockChatCategoriser,
+              },
+            };
+            const ailaInstance = new Aila(ailaConfig);
+            await ailaInstance.initialise();
+            return ailaInstance;
           },
-          chat: {
-            id: chatId,
-            userId,
-            messages: options.chat.messages ?? [],
-          },
-          plugins: [],
-          services: {
-            chatLlmService: mockLLMService,
-            chatCategoriser: mockChatCategoriser,
-          },
-        };
-        const ailaInstance = new Aila(ailaConfig);
-        await ailaInstance.initialise();
-        return ailaInstance;
-      }),
+        ),
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       prisma: {} as any,
     };

--- a/apps/nextjs/src/app/api/chat/webActionsPlugin.ts
+++ b/apps/nextjs/src/app/api/chat/webActionsPlugin.ts
@@ -6,6 +6,7 @@ import { SafetyViolations as defaultSafetyViolations } from "@oakai/core/src/mod
 import { UserBannedError } from "@oakai/core/src/models/userBannedError";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
+import * as Sentry from "@sentry/nextjs";
 import { waitUntil } from "@vercel/functions";
 
 const log = aiLogger("chat");
@@ -56,17 +57,24 @@ export const createWebActionsPlugin: PluginCreator = (
       throw new Error("User ID not set");
     }
 
-    await inngest.send({
-      name: "app/slack.notifyModeration",
-      user: {
-        id: userId,
-      },
-      data: {
-        chatId: aila.chatId || "Unknown",
-        categories: moderation.categories as string[],
-        justification: moderation.justification ?? "Unknown",
-      },
-    });
+    try {
+      log.info("Sending slack notification");
+      await inngest.send({
+        name: "app/slack.notifyModeration",
+        user: {
+          id: userId,
+        },
+        data: {
+          chatId: aila.chatId || "Unknown",
+          categories: moderation.categories as string[],
+          justification: moderation.justification ?? "Unknown",
+        },
+      });
+    } catch (e) {
+      log.error("Error scheduling slack notification", e);
+      Sentry.captureException(e);
+      throw e;
+    }
 
     try {
       const safetyViolations = new SafetyViolations(prisma);

--- a/apps/nextjs/src/app/lesson-planner/preview/[slug]/preview.tsx
+++ b/apps/nextjs/src/app/lesson-planner/preview/[slug]/preview.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-member-access */
 "use client";
 
 import { Box, Container, Flex, Heading, Text } from "@radix-ui/themes";

--- a/apps/nextjs/src/app/lesson-planner/preview/preview-redirect.tsx
+++ b/apps/nextjs/src/app/lesson-planner/preview/preview-redirect.tsx
@@ -15,6 +15,7 @@ export default function PreviewRedirect() {
 
   // Potentially incorrect
   const id =
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     searchParams && searchParams?.entries.length > 1 && searchParams[0][1];
   router.push(`/lesson-planner/preview/${id}`);
   return null;

--- a/apps/nextjs/src/app/quiz-designer/preview/[slug]/preview.tsx
+++ b/apps/nextjs/src/app/quiz-designer/preview/[slug]/preview.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-unsafe-return */
 "use client";
 
 import { Box, Container, Flex, Text } from "@radix-ui/themes";
@@ -12,7 +11,6 @@ import { Icon } from "@/components/Icon";
 import Layout from "@/components/Layout";
 
 /* eslint-disable @typescript-eslint/no-unsafe-return */
-
 /* eslint-disable @typescript-eslint/no-explicit-any */
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
 

--- a/apps/nextjs/src/cms/data/fetchAiHomepage.ts
+++ b/apps/nextjs/src/cms/data/fetchAiHomepage.ts
@@ -5,7 +5,7 @@ import type { HomePageQueryResult } from "@/cms/types/aiHomePageType";
 export async function fetchAiHomepage(): Promise<HomePageQueryResult | null> {
   const query = homePageQuery;
 
-  const result = await sanityClient.fetch(query);
+  const result = await sanityClient.fetch<HomePageQueryResult>(query);
 
   return result;
 }

--- a/apps/nextjs/src/cms/data/fetchPolicyDocument.ts
+++ b/apps/nextjs/src/cms/data/fetchPolicyDocument.ts
@@ -16,7 +16,7 @@ export async function fetchPolicyDocument({
   ...seoFields[]               
 }`;
 
-  const result = await sanityClient.fetch(query);
+  const result = await sanityClient.fetch<PolicyDocument[]>(query);
 
   const policyDocument = result.filter((policy) => policy.slug === slug)[0];
 

--- a/apps/nextjs/src/components/AppComponents/Chat/Chat/utils/index.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/Chat/utils/index.ts
@@ -1,45 +1,82 @@
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
 import { aiLogger } from "@oakai/logger";
 import type { Message } from "ai/react";
+import { z } from "zod";
 
 const log = aiLogger("chat");
 
-export function findMessageIdFromContent({ content }: { content: string }) {
+interface IdPart {
+  type: "id";
+  value: string;
+}
+
+function isIdPart(obj: unknown): obj is IdPart {
+  return (
+    typeof obj === "object" &&
+    obj !== null &&
+    "type" in obj &&
+    obj.type === "id" &&
+    "value" in obj &&
+    typeof obj.value === "string"
+  );
+}
+
+export function findMessageIdFromContent({
+  content,
+}: {
+  content: string;
+}): string | undefined {
   return content
     .split("␞")
     .map((s) => {
       try {
-        return JSON.parse(s.trim());
+        return JSON.parse(s.trim()) as unknown;
       } catch {
         // ignore invalid JSON
         return null;
       }
     })
-    .find((i) => i?.type === "id")?.value;
+    .find(isIdPart)?.value;
 }
 
-export function findLatestServerSideState(workingMessages: Message[]) {
+interface StatePart {
+  type: "state";
+  value: LooseLessonPlan;
+}
+
+const statePartSchema = z.object({
+  type: z.literal("state"),
+  value: z.object({}).passthrough(),
+});
+
+export function findLatestServerSideState(
+  workingMessages: Message[],
+): LooseLessonPlan | undefined {
   log.info("Finding latest server-side state", { workingMessages });
   const lastMessage = workingMessages[workingMessages.length - 1];
   if (!lastMessage?.content.includes('"type":"state"')) {
     log.info("No server state found");
-    return;
+    return undefined;
   }
-  const state: LooseLessonPlan = lastMessage.content
+
+  const stateParts = lastMessage.content
     .split("␞")
     .map((s) => {
       try {
-        return JSON.parse(s.trim());
+        const parsed = JSON.parse(s.trim());
+        return statePartSchema.safeParse(parsed);
       } catch {
         // ignore invalid JSON
-        return null;
+        return { success: false };
       }
     })
-    .filter((i) => i !== null)
-    .filter((i) => i.type === "state")
-    .map((i) => i.value)[0];
-  log.info("Got latest server state", { state });
-  return state;
+    .filter((result): result is z.SafeParseSuccess<StatePart> => result.success)
+    .map((result) => result.data);
+
+  const latestState = stateParts[stateParts.length - 1]?.value;
+
+  log.info("Got latest server state", { state: latestState });
+  return latestState;
 }
 
 export function openSharePage(chat: { id: string }) {

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-layout.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-layout.tsx
@@ -3,7 +3,7 @@ import { useDemoUser } from "@/components/ContextProviders/Demo";
 import { useDemoLocking } from "@/hooks/useDemoLocking";
 import { useMobileLessonPullOutControl } from "@/hooks/useMobileLessonPullOutControl";
 import { cn } from "@/lib/utils";
-import { useChatStore } from "@/stores/chatStore";
+import { useChatStore } from "@/stores/AilaStoresProvider";
 
 import ChatLeftHandSide from "./chat-left-hand-side";
 import ChatRightHandSideLesson from "./chat-right-hand-side-lesson";

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.tsx
@@ -6,7 +6,7 @@ import { cva } from "class-variance-authority";
 
 import { useLessonChat } from "@/components/ContextProviders/ChatProvider";
 import { organiseSections } from "@/lib/lessonPlan/organiseSections";
-import { useChatStore } from "@/stores/chatStore";
+import { useChatStore } from "@/stores/AilaStoresProvider";
 import { slugToSentenceCase } from "@/utils/toSentenceCase";
 
 import Skeleton from "../common/Skeleton";

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-lhs-header.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-lhs-header.tsx
@@ -2,7 +2,7 @@ import React from "react";
 
 import { useRouter } from "next/navigation";
 
-import { useChatStore } from "@/stores/chatStore";
+import { useChatStore } from "@/stores/AilaStoresProvider";
 
 import AiIcon from "../../AiIcon";
 import ChatButton from "./ui/chat-button";

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-list/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-list/index.tsx
@@ -8,7 +8,7 @@ import type { Message } from "ai";
 import { ChatMessage } from "@/components/AppComponents/Chat/chat-message";
 import { useLessonChat } from "@/components/ContextProviders/ChatProvider";
 import type { DemoContextProps } from "@/components/ContextProviders/Demo";
-import { useChatStore } from "@/stores/chatStore";
+import { useChatStore } from "@/stores/AilaStoresProvider";
 import type { AilaStreamingStatus } from "@/stores/chatStore";
 
 import { useProgressForDownloads } from "../Chat/hooks/useProgressForDownloads";

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-panel.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-panel.stories.tsx
@@ -64,16 +64,6 @@ export const Idle: Story = {
   },
 };
 
-export const IdleWithQueuedUserAction: Story = {
-  args: {},
-  parameters: {
-    chatStoreState: {
-      queuedUserAction: "regenerate",
-      ailaStreamingStatus: "Idle",
-    },
-  },
-};
-
 export const Loading: Story = {
   args: {},
   parameters: {
@@ -109,17 +99,6 @@ export const StreamingChatResponse: Story = {
     },
   },
 };
-
-export const StreamingWithQueuedUserAction: Story = {
-  args: {},
-  parameters: {
-    chatStoreState: {
-      queuedUserAction: "regenerate",
-      ailaStreamingStatus: "StreamingLessonPlan",
-    },
-  },
-};
-
 export const Moderating: Story = {
   args: {},
   parameters: {

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-panel.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-panel.tsx
@@ -7,7 +7,7 @@ import { useLessonChat } from "@/components/ContextProviders/ChatProvider";
 import { useLessonPlanTracking } from "@/lib/analytics/lessonPlanTrackingContext";
 import useAnalytics from "@/lib/analytics/useAnalytics";
 import { useSidebar } from "@/lib/hooks/use-sidebar";
-import { useChatStore } from "@/stores/chatStore";
+import { useChatStore } from "@/stores/AilaStoresProvider";
 import { canAppendSelector } from "@/stores/chatStore/selectors";
 
 import ChatPanelDisclaimer from "./chat-panel-disclaimer";

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-panel.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-panel.tsx
@@ -54,6 +54,16 @@ export function ChatPanel({ isDemoLocked }: Readonly<ChatPanelProps>) {
     [isLoading, trackEvent, id, append],
   );
 
+  const wrappedQueueUserAction = useCallback(
+    (action: Parameters<typeof queueUserAction>[0]) => {
+      queueUserAction(action).catch((error) => {
+        Sentry.captureException(error);
+        toast.error("Failed to queue action");
+      });
+    },
+    [queueUserAction],
+  );
+
   const containerClass = `grid w-full grid-cols-1 ${hasMessages ? "sm:grid-cols-1" : ""} peer-[[data-state=open]]:group-[]:lg:pl-[250px] peer-[[data-state=open]]:group-[]:xl:pl-[300px]`;
 
   return (
@@ -66,7 +76,7 @@ export function ChatPanel({ isDemoLocked }: Readonly<ChatPanelProps>) {
             setInput={setInput}
             ailaStreamingStatus={ailaStreamingStatus}
             hasMessages={hasMessages}
-            queueUserAction={queueUserAction}
+            queueUserAction={wrappedQueueUserAction}
             queuedUserAction={queuedUserAction}
           />
         )}

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.tsx
@@ -6,8 +6,8 @@ import { useLessonChat } from "@/components/ContextProviders/ChatProvider";
 import { Icon } from "@/components/Icon";
 import { useLessonPlanTracking } from "@/lib/analytics/lessonPlanTrackingContext";
 import useAnalytics from "@/lib/analytics/useAnalytics";
+import { useChatStore } from "@/stores/AilaStoresProvider";
 import type { AilaStreamingStatus } from "@/stores/chatStore";
-import { useChatStore } from "@/stores/chatStore";
 import { canAppendSelector } from "@/stores/chatStore/selectors";
 
 import { useDialog } from "../DialogContext";

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.tsx
@@ -8,6 +8,7 @@ import { useLessonPlanTracking } from "@/lib/analytics/lessonPlanTrackingContext
 import useAnalytics from "@/lib/analytics/useAnalytics";
 import type { AilaStreamingStatus } from "@/stores/chatStore";
 import { useChatStore } from "@/stores/chatStore";
+import { canAppendSelector } from "@/stores/chatStore/selectors";
 
 import { useDialog } from "../DialogContext";
 import ChatButton from "./ui/chat-button";
@@ -45,33 +46,31 @@ const QuickActionButtons = () => {
   const { trackEvent } = useAnalytics();
   const lessonPlanTracking = useLessonPlanTracking();
   const { setDialogWindow } = useDialog();
-  const queueUserAction = useChatStore((state) => state.queueUserAction);
   const queuedUserAction = useChatStore((state) => state.queuedUserAction);
+  const append = useChatStore((state) => state.append);
   const stop = useChatStore((state) => state.stop);
   const { messages, id } = chat;
 
   const ailaStreamingStatus = useChatStore(
     (state) => state.ailaStreamingStatus,
   );
+  const shouldAllowUserAction = useChatStore(canAppendSelector);
 
   const hasMessages = !!messages.length;
-
-  const shouldAllowUserAction =
-    ["Idle", "Moderating"].includes(ailaStreamingStatus) && !queuedUserAction;
 
   const handleRegenerate = useCallback(() => {
     trackEvent("chat:regenerate", { id: id });
     const lastUserMessage =
       findLast(messages, (m) => m.role === "user")?.content ?? "";
     lessonPlanTracking.onClickRetry(lastUserMessage);
-    void queueUserAction("regenerate");
-  }, [queueUserAction, lessonPlanTracking, messages, trackEvent, id]);
+    append("regenerate");
+  }, [append, lessonPlanTracking, messages, trackEvent, id]);
 
   const handleContinue = useCallback(() => {
     trackEvent("chat:continue");
     lessonPlanTracking.onClickContinue();
-    void queueUserAction("continue");
-  }, [queueUserAction, lessonPlanTracking, trackEvent]);
+    append("continue");
+  }, [append, lessonPlanTracking, trackEvent]);
 
   return (
     <div className="-ml-7 flex justify-between space-x-7 rounded-bl rounded-br pt-8">

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-right-hand-side-lesson.stories.tsx
@@ -4,6 +4,7 @@ import { fn } from "@storybook/test";
 
 import { chromaticParams } from "@/storybook/chromatic";
 import { ChatDecorator } from "@/storybook/decorators/ChatDecorator";
+import { ChatStoreDecorator } from "@/storybook/decorators/ChatStoreDecorator";
 import {
   DemoDecorator,
   demoParams,
@@ -29,7 +30,7 @@ const meta = {
   title: "Components/LessonPlan/ChatRightHandSideLesson",
   component: ChatRightHandSideLesson,
   tags: ["autodocs"],
-  decorators: [ChatDecorator, DemoDecorator],
+  decorators: [ChatDecorator, DemoDecorator, ChatStoreDecorator],
   args: {
     showLessonMobile: true,
     closeMobileLessonPullOut: fn,

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/action-drop-down.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/action-drop-down.tsx
@@ -124,6 +124,8 @@ function handleLabelText({
 }): string {
   log.info("section", section);
   if (
+    // @todo this is a bug - "additional materials" always returns true
+    // eslint-disable-next-line no-constant-condition
     section === "Misconceptions" ||
     section === "Key learning points" ||
     section === "Learning cycles" ||

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/index.tsx
@@ -75,6 +75,8 @@ const DropDownSection = ({
       setIsOpen(true);
       const timer = setTimeout(() => {
         setStatus("isLoaded");
+        // @todo this is a bug - value is not typed
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
         setPrevValue(value);
       }, streamingTimeout);
 

--- a/apps/nextjs/src/components/AppComponents/Chat/prompt-form.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/prompt-form.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useRef } from "react";
+import { useEffect, useRef } from "react";
 
 import type { UseChatHelpers } from "ai/react";
 
@@ -8,60 +8,32 @@ import {
   TooltipTrigger,
 } from "@/components/AppComponents/Chat/ui/tooltip";
 import { Icon } from "@/components/Icon";
-import { useLessonPlanTracking } from "@/lib/analytics/lessonPlanTrackingContext";
 import { useEnterSubmit } from "@/lib/hooks/use-enter-submit";
-import { useSidebar } from "@/lib/hooks/use-sidebar";
-import type { AilaStreamingStatus } from "@/stores/chatStore";
+import { useChatStore } from "@/stores/chatStore";
 
 export interface PromptFormProps
   extends Pick<UseChatHelpers, "input" | "setInput"> {
   onSubmit: (value: string) => void;
   hasMessages: boolean;
-  ailaStreamingStatus: AilaStreamingStatus;
-  queuedUserAction?: string | null;
-  queueUserAction?: (action: string) => void;
+  isDisabled: boolean;
 }
 
 export function PromptForm({
-  ailaStreamingStatus,
   onSubmit,
+  isDisabled,
   input,
   setInput,
   hasMessages,
-  queuedUserAction,
-  queueUserAction,
 }: Readonly<PromptFormProps>) {
   const { formRef, onKeyDown } = useEnterSubmit();
   const inputRef = useRef<HTMLTextAreaElement>(null);
-  const lessonPlanTracking = useLessonPlanTracking();
+  const queuedUserAction = useChatStore((state) => state.queuedUserAction);
 
   useEffect(() => {
     if (inputRef.current) {
       inputRef.current.focus();
     }
   }, []);
-
-  const sidebar = useSidebar();
-
-  const handleSubmit = useCallback(
-    (value: string) => {
-      setInput("");
-      if (sidebar.isSidebarOpen) {
-        sidebar.toggleSidebar();
-      }
-
-      lessonPlanTracking.onSubmitText(value);
-      if (queueUserAction) {
-        queueUserAction(value);
-      } else {
-        onSubmit(value);
-      }
-    },
-    [lessonPlanTracking, queueUserAction, onSubmit, setInput, sidebar],
-  );
-
-  const shouldAllowUserInput =
-    ["Idle", "Moderating"].includes(ailaStreamingStatus) && !queuedUserAction;
 
   return (
     <form
@@ -70,19 +42,19 @@ export function PromptForm({
         if (!input?.trim()) {
           return;
         }
-        handleSubmit(input);
+        onSubmit(input);
       }}
       ref={formRef}
     >
       <div
-        className={`${!shouldAllowUserInput ? "block" : "hidden"} h-[60px] w-full rounded-md border-2 border-oakGrey3 sm:hidden`}
+        className={`${isDisabled ? "block" : "hidden"} h-[60px] w-full rounded-md border-2 border-oakGrey3 sm:hidden`}
       />
       <div
-        className={`${!shouldAllowUserInput ? "hidden" : "flex"} relative max-h-60 w-full grow flex-col overflow-hidden rounded-md border-2 border-black bg-white pr-20 sm:flex`}
+        className={`${isDisabled ? "hidden" : "flex"} relative max-h-60 w-full grow flex-col overflow-hidden rounded-md border-2 border-black bg-white pr-20 sm:flex`}
       >
         <textarea
           data-testid="chat-input"
-          disabled={!shouldAllowUserInput}
+          disabled={isDisabled}
           ref={inputRef}
           tabIndex={0}
           onKeyDown={onKeyDown}
@@ -102,8 +74,8 @@ export function PromptForm({
               <button
                 data-testid="send-message"
                 type="submit"
-                className={`rounded-full bg-black p-4 ${!shouldAllowUserInput ? "cursor-not-allowed opacity-50" : ""}`}
-                disabled={!shouldAllowUserInput}
+                className={`rounded-full bg-black p-4 ${isDisabled ? "cursor-not-allowed opacity-50" : ""}`}
+                disabled={isDisabled}
               >
                 <Icon icon="chevron-right" color="white" size="sm" />
               </button>

--- a/apps/nextjs/src/components/AppComponents/Chat/prompt-form.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/prompt-form.tsx
@@ -9,7 +9,7 @@ import {
 } from "@/components/AppComponents/Chat/ui/tooltip";
 import { Icon } from "@/components/Icon";
 import { useEnterSubmit } from "@/lib/hooks/use-enter-submit";
-import { useChatStore } from "@/stores/chatStore";
+import { useChatStore } from "@/stores/AilaStoresProvider";
 
 export interface PromptFormProps
   extends Pick<UseChatHelpers, "input" | "setInput"> {

--- a/apps/nextjs/src/components/AppComponents/ComparativeJudgement/JudgementFeedbackDialog.tsx
+++ b/apps/nextjs/src/components/AppComponents/ComparativeJudgement/JudgementFeedbackDialog.tsx
@@ -81,6 +81,7 @@ function JudgementFeedbackDialog({
       setContentIsInappropriate={setContentIsInappropriate}
       setContentIsFactuallyIncorrect={setContentIsFactuallyIncorrect}
       setContentIsNotHelpful={setContentIsNotHelpful}
+      // eslint-disable-next-line @typescript-eslint/no-misused-promises
       sendFeedback={sendFeedback}
       setHasSubmitted={setHasSubmitted}
     />

--- a/apps/nextjs/src/components/AppComponents/ComparativeJudgement/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/ComparativeJudgement/index.tsx
@@ -80,6 +80,7 @@ const ComparativeJudgement = ({
           title={data?.questionForJudgement?.quizQuestion?.lesson.title ?? ""}
           lessonDescription={lessonDescription}
           setFlaggedItems={setFlaggedOption}
+          // eslint-disable-next-line @typescript-eslint/no-misused-promises
           skipQuestion={skipQuestion}
           questionText={questionText}
           optionA={optionA}
@@ -88,6 +89,7 @@ const ComparativeJudgement = ({
           winnerId={winnerId}
           setReasonForChoice={setReasonForChoice}
           clearReasonForChoice={() => setReasonForChoice("")}
+          // eslint-disable-next-line @typescript-eslint/no-misused-promises
           chooseQuestion={chooseQuestion}
           judgementId={judgementId}
         />

--- a/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
@@ -61,7 +61,6 @@ export type ChatContextProps = {
   setInput: React.Dispatch<React.SetStateAction<string>>;
   chatAreaRef: React.RefObject<HTMLDivElement>;
   // queuedUserAction: string | null;
-  // queueUserAction: (action: string) => void;
   // executeQueuedAction: () => Promise<void>;
 };
 
@@ -169,6 +168,8 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
     LooseLessonPlan | undefined
   >(undefined);
 
+  const streamingFinished = useChatStore((state) => state.streamingFinished);
+
   /******************* Functions *******************/
 
   const { invokeActionMessages } = useActionMessages();
@@ -253,6 +254,7 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
       setHasFinished(true);
       shouldTrackStreamFinished.current = true;
       chatAreaRef.current?.scrollTo(0, chatAreaRef.current?.scrollHeight);
+      streamingFinished();
     },
   });
 
@@ -290,18 +292,6 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
       isStreaming: !hasFinished,
       messageHashes,
     });
-
-  // Handle queued user actions and messages
-
-  const executeQueuedAction = useChatStore(
-    (state) => state.executeQueuedAction,
-  );
-
-  useEffect(() => {
-    if (hasFinished) {
-      void executeQueuedAction();
-    }
-  }, [hasFinished, executeQueuedAction]);
 
   const handleReload = useCallback(() => {
     reload().catch((err) => {

--- a/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
@@ -24,12 +24,12 @@ import type { ChatRequestOptions, CreateMessage, Message } from "ai";
 import { useChat } from "ai/react";
 import { nanoid } from "nanoid";
 import { redirect, usePathname, useRouter } from "next/navigation";
-import { useChatStoreMirror } from "src/stores/chatStore/hooks/useChatStoreMirror";
+import { useChatStoreAiSdkSync } from "src/stores/chatStore/hooks/useChatStoreAiSdkSync";
 
 import { useTemporaryLessonPlanWithStreamingEdits } from "@/hooks/useTemporaryLessonPlanWithStreamingEdits";
 import { useLessonPlanTracking } from "@/lib/analytics/lessonPlanTrackingContext";
 import useAnalytics from "@/lib/analytics/useAnalytics";
-import { useChatStore } from "@/stores/chatStore";
+import { useChatStore } from "@/stores/AilaStoresProvider";
 import { trpc } from "@/utils/trpc";
 
 import { findMessageIdFromContent } from "../AppComponents/Chat/Chat/utils";
@@ -302,7 +302,13 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
   }, [reload]);
 
   // Hooks to update the Zustand chat store mirror
-  useChatStoreMirror(messages, isLoading, stopStreaming, append, handleReload);
+  useChatStoreAiSdkSync(
+    messages,
+    isLoading,
+    stopStreaming,
+    append,
+    handleReload,
+  );
 
   /**
    *  If the state is being restored from a previous lesson plan, set the lesson plan

--- a/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
@@ -1,6 +1,5 @@
 import React, {
   createContext,
-  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -25,11 +24,12 @@ import { useChat } from "ai/react";
 import { nanoid } from "nanoid";
 import { redirect, usePathname, useRouter } from "next/navigation";
 import { useChatStoreAiSdkSync } from "src/stores/chatStore/hooks/useChatStoreAiSdkSync";
+import { useLessonPlanStoreAiSdkSync } from "src/stores/lessonPlanStore/hooks/useLessonPlanStoreAiSdkSync";
 
 import { useTemporaryLessonPlanWithStreamingEdits } from "@/hooks/useTemporaryLessonPlanWithStreamingEdits";
 import { useLessonPlanTracking } from "@/lib/analytics/lessonPlanTrackingContext";
 import useAnalytics from "@/lib/analytics/useAnalytics";
-import { useChatStore } from "@/stores/AilaStoresProvider";
+import { useChatStore, useLessonPlanStore } from "@/stores/AilaStoresProvider";
 import { trpc } from "@/utils/trpc";
 
 import { findMessageIdFromContent } from "../AppComponents/Chat/Chat/utils";
@@ -169,6 +169,8 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
   >(undefined);
 
   const streamingFinished = useChatStore((state) => state.streamingFinished);
+  const messageStarted = useLessonPlanStore((state) => state.messageStarted);
+  const messageFinished = useLessonPlanStore((state) => state.messageFinished);
 
   /******************* Functions *******************/
 
@@ -205,6 +207,7 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
     },
     fetch(input: RequestInfo | URL, init?: RequestInit | undefined) {
       lessonPlanSnapshot.current = chat?.lessonPlan ?? {};
+      messageStarted();
       return fetch(input, init);
     },
     onError(error) {
@@ -254,7 +257,9 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
       setHasFinished(true);
       shouldTrackStreamFinished.current = true;
       chatAreaRef.current?.scrollTo(0, chatAreaRef.current?.scrollHeight);
+
       streamingFinished();
+      messageFinished();
     },
   });
 
@@ -293,22 +298,9 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
       messageHashes,
     });
 
-  const handleReload = useCallback(() => {
-    reload().catch((err) => {
-      log.error("Failed to reload chat", err);
-      toast.error("Failed to reload chat");
-      Sentry.captureException(err);
-    });
-  }, [reload]);
-
-  // Hooks to update the Zustand chat store mirror
-  useChatStoreAiSdkSync(
-    messages,
-    isLoading,
-    stopStreaming,
-    append,
-    handleReload,
-  );
+  // Hooks to update the Zustand stores
+  useChatStoreAiSdkSync(messages, isLoading, stopStreaming, append, reload);
+  useLessonPlanStoreAiSdkSync(messages, isLoading);
 
   /**
    *  If the state is being restored from a previous lesson plan, set the lesson plan

--- a/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/ChatProvider.tsx
@@ -1,5 +1,6 @@
 import React, {
   createContext,
+  useCallback,
   useContext,
   useEffect,
   useMemo,
@@ -302,8 +303,16 @@ export function ChatProvider({ id, children }: Readonly<ChatProviderProps>) {
     }
   }, [hasFinished, executeQueuedAction]);
 
+  const handleReload = useCallback(() => {
+    reload().catch((err) => {
+      log.error("Failed to reload chat", err);
+      toast.error("Failed to reload chat");
+      Sentry.captureException(err);
+    });
+  }, [reload]);
+
   // Hooks to update the Zustand chat store mirror
-  useChatStoreMirror(messages, isLoading, stopStreaming, append, reload);
+  useChatStoreMirror(messages, isLoading, stopStreaming, append, handleReload);
 
   /**
    *  If the state is being restored from a previous lesson plan, set the lesson plan

--- a/apps/nextjs/src/components/ContextProviders/GleapProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/GleapProvider.tsx
@@ -25,7 +25,8 @@ export const GleapProvider = ({ children }: PropsWithChildren) => {
       return;
     }
     if (gleapApiKey && analyticsAccepted) {
-      if (!Gleap.getInstance().initialized) {
+      const gleapInstance = Gleap.getInstance();
+      if (!gleapInstance.initialized) {
         // use first party domains
         Gleap.setFrameUrl(gleapFrameUrl);
         Gleap.setApiUrl(gleapApiUrl);

--- a/apps/nextjs/src/hooks/useGeneration.ts
+++ b/apps/nextjs/src/hooks/useGeneration.ts
@@ -156,7 +156,10 @@ export const useGeneration = <TSchema extends z.Schema>(
 
         const isRateLimited =
           err instanceof TRPCClientError &&
-          err?.data.code === "TOO_MANY_REQUESTS";
+          typeof err.data === "object" &&
+          err.data !== null &&
+          "code" in err.data &&
+          (err.data as { code: string }).code === "TOO_MANY_REQUESTS";
 
         const message = isRateLimited
           ? "You are out of generations, please come back later"

--- a/apps/nextjs/src/hooks/useTemporaryLessonPlanWithStreamingEdits.ts
+++ b/apps/nextjs/src/hooks/useTemporaryLessonPlanWithStreamingEdits.ts
@@ -14,7 +14,7 @@ import { equals } from "remeda";
 
 type PatchDocumentWithHash = PatchDocument & { hash: string };
 
-const hashFor = (obj: object, messageHashes) => {
+const hashFor = (obj: object, messageHashes: Record<string, string>) => {
   const cached = messageHashes[JSON.stringify(obj)];
   if (cached) return cached;
   const h = hash(obj, { algorithm: "md5" });

--- a/apps/nextjs/src/lib/hooks/use-local-storage.ts
+++ b/apps/nextjs/src/lib/hooks/use-local-storage.ts
@@ -10,6 +10,7 @@ export const useLocalStorage = <T>(
     // Retrieve from localStorage
     const item = window.localStorage.getItem(key);
     if (item) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
       setStoredValue(JSON.parse(item));
     }
   }, [key]);

--- a/apps/nextjs/src/lib/lessonPlan/sectionsInOrder.ts
+++ b/apps/nextjs/src/lib/lessonPlan/sectionsInOrder.ts
@@ -1,19 +1,9 @@
-import type { LessonPlanKey } from "@oakai/aila/src/protocol/schema";
+import {
+  allSectionsInOrder,
+  type LessonPlanKey,
+} from "@oakai/aila/src/protocol/schema";
 
-export const allSectionsInOrder: LessonPlanKey[] = [
-  "learningOutcome",
-  "learningCycles",
-  "priorKnowledge",
-  "keyLearningPoints",
-  "misconceptions",
-  "keywords",
-  "starterQuiz",
-  "cycle1",
-  "cycle2",
-  "cycle3",
-  "exitQuiz",
-  "additionalMaterials",
-];
+export { allSectionsInOrder };
 
 export const groupedSectionsInOrder: LessonPlanKey[][] = [
   ["learningOutcome", "learningCycles"],

--- a/apps/nextjs/src/middleware.test.ts
+++ b/apps/nextjs/src/middleware.test.ts
@@ -192,6 +192,9 @@ describe("addCspHeaders", () => {
     expect(cspHeader).toContain("*.hubspot.com");
     expect(cspHeader).toContain("https://img.clerk.com");
     expect(cspHeader).toContain("https://res.cloudinary.com");
+    expect(cspHeader).toContain(
+      "https://oaknationalacademy-res.cloudinary.com",
+    );
   });
 
   it("includes Clerk policies when enabled", () => {

--- a/apps/nextjs/src/middlewares/__snapshots__/csp.test.ts.snap
+++ b/apps/nextjs/src/middlewares/__snapshots__/csp.test.ts.snap
@@ -7,7 +7,7 @@ script-src 'self' 'nonce-REPLACED_NONCE' 'strict-dynamic' https: http: 'unsafe-i
 style-src 'self' 'unsafe-inline' https://*.mux.com
 connect-src 'self' *.thenational.academy *.hubspot.com *.clerk.accounts.dev https://api.avo.app/ https://eu.i.posthog.com https://europe-west2-oak-ai-beta-staging.cloudfunctions.net https://mux.com https://*.mux.com https://stream.mux.com https://inferred.litix.io
 worker-src 'self' blob:
-img-src 'self' blob: data: https://img.clerk.com https://res.cloudinary.com https://*.hubspot.com https://*.hsforms.com https://*.mux.com https://stream.mux.com
+img-src 'self' blob: data: https://img.clerk.com https://res.cloudinary.com https://oaknationalacademy-res.cloudinary.com https://*.hubspot.com https://*.hsforms.com https://*.mux.com https://stream.mux.com
 font-src 'self' gstatic-fonts.thenational.academy fonts.gstatic.com
 object-src 'none'
 base-uri 'self'
@@ -24,7 +24,7 @@ script-src 'self' 'nonce-REPLACED_NONCE' 'strict-dynamic' https: http: 'unsafe-i
 style-src 'self' 'unsafe-inline' https://vercel.live/ https://*.mux.com
 connect-src 'self' *.thenational.academy *.hubspot.com https://vercel.live/ https://vercel.com *.pusher.com *.pusherapp.com *.clerk.accounts.dev https://api.avo.app/ https://mux.com https://*.mux.com https://stream.mux.com https://inferred.litix.io
 worker-src 'self' blob:
-img-src 'self' blob: data: https://img.clerk.com https://res.cloudinary.com https://*.hubspot.com https://*.hsforms.com https://vercel.live/ https://vercel.com *.pusher.com/ data: blob: https://*.mux.com https://stream.mux.com
+img-src 'self' blob: data: https://img.clerk.com https://res.cloudinary.com https://oaknationalacademy-res.cloudinary.com https://*.hubspot.com https://*.hsforms.com https://vercel.live/ https://vercel.com *.pusher.com/ data: blob: https://*.mux.com https://stream.mux.com
 font-src 'self' gstatic-fonts.thenational.academy fonts.gstatic.com https://vercel.live/ https://assets.vercel.com
 object-src 'none'
 base-uri 'self'
@@ -42,7 +42,7 @@ script-src 'self' 'nonce-REPLACED_NONCE' 'strict-dynamic' https: http: 'unsafe-i
 style-src 'self' 'unsafe-inline' https://*.mux.com
 connect-src 'self' *.thenational.academy *.hubspot.com https://mux.com https://*.mux.com https://stream.mux.com https://inferred.litix.io
 worker-src 'self' blob:
-img-src 'self' blob: data: https://img.clerk.com https://res.cloudinary.com https://*.hubspot.com https://*.hsforms.com https://*.mux.com https://stream.mux.com
+img-src 'self' blob: data: https://img.clerk.com https://res.cloudinary.com https://oaknationalacademy-res.cloudinary.com https://*.hubspot.com https://*.hsforms.com https://*.mux.com https://stream.mux.com
 font-src 'self' gstatic-fonts.thenational.academy fonts.gstatic.com
 object-src 'none'
 base-uri 'self'
@@ -60,7 +60,7 @@ script-src 'self' 'nonce-REPLACED_NONCE'  https: http: 'unsafe-inline' 'unsafe-e
 style-src 'self' 'unsafe-inline' https://*.mux.com
 connect-src 'self' *.thenational.academy *.hubspot.com *.clerk.accounts.dev https://api.avo.app/ https://mux.com https://*.mux.com https://stream.mux.com https://inferred.litix.io
 worker-src 'self' blob:
-img-src 'self' blob: data: https://img.clerk.com https://res.cloudinary.com https://*.hubspot.com https://*.hsforms.com https://*.mux.com https://stream.mux.com
+img-src 'self' blob: data: https://img.clerk.com https://res.cloudinary.com https://oaknationalacademy-res.cloudinary.com https://*.hubspot.com https://*.hsforms.com https://*.mux.com https://stream.mux.com
 font-src 'self' gstatic-fonts.thenational.academy fonts.gstatic.com
 object-src 'none'
 base-uri 'self'

--- a/apps/nextjs/src/middlewares/csp.ts
+++ b/apps/nextjs/src/middlewares/csp.ts
@@ -129,6 +129,7 @@ export const buildCspHeaders = (nonce: string, config: CspConfig) => {
       "data:",
       "https://img.clerk.com",
       "https://res.cloudinary.com",
+      "https://oaknationalacademy-res.cloudinary.com",
       "https://*.hubspot.com",
       "https://*.hsforms.com",
     ],

--- a/apps/nextjs/src/stores/AilaStoresProvider.tsx
+++ b/apps/nextjs/src/stores/AilaStoresProvider.tsx
@@ -1,8 +1,9 @@
-import { useState, createContext, useContext } from "react";
+import { useState, createContext, useContext, useEffect } from "react";
 
 import { useStore, type StoreApi } from "zustand";
 
 import { type ChatStore, createChatStore } from "@/stores/chatStore";
+import { trpc } from "@/utils/trpc";
 
 import { type LessonPlanStore, createLessonPlanStore } from "./lessonPlanStore";
 
@@ -15,14 +16,29 @@ export const AilaStoresContext = createContext<
   AilaStoresContextProps | undefined
 >(undefined);
 
-export const AilaStoresProvider = ({ children }) => {
-  const [store] = useState(() => ({
+type AilaStoresProviderProps = {
+  id: string;
+  children: React.ReactNode;
+};
+
+export const AilaStoresProvider = ({
+  id,
+  children,
+}: AilaStoresProviderProps) => {
+  const trpcUtils = trpc.useUtils();
+
+  const [stores] = useState(() => ({
     chat: createChatStore(),
-    lessonPlan: createLessonPlanStore(),
+    lessonPlan: createLessonPlanStore(id, trpcUtils),
   }));
 
+  // Store initialisation
+  useEffect(() => {
+    void stores.lessonPlan.getState().refetch();
+  }, [stores.lessonPlan, id]);
+
   return (
-    <AilaStoresContext.Provider value={store}>
+    <AilaStoresContext.Provider value={stores}>
       {children}
     </AilaStoresContext.Provider>
   );

--- a/apps/nextjs/src/stores/AilaStoresProvider.tsx
+++ b/apps/nextjs/src/stores/AilaStoresProvider.tsx
@@ -1,0 +1,33 @@
+import { useState, createContext, useContext } from "react";
+
+import { useStore, type StoreApi } from "zustand";
+
+import { type ChatStore, createChatStore } from "@/stores/chatStore";
+
+type AilaStoresContextProps = {
+  chat: StoreApi<ChatStore>;
+};
+
+export const AilaStoresContext = createContext<
+  AilaStoresContextProps | undefined
+>(undefined);
+
+export const AilaStoresProvider = ({ children }) => {
+  const [store] = useState(() => ({
+    chat: createChatStore(),
+  }));
+
+  return (
+    <AilaStoresContext.Provider value={store}>
+      {children}
+    </AilaStoresContext.Provider>
+  );
+};
+
+export const useChatStore = <T,>(selector: (store: ChatStore) => T) => {
+  const context = useContext(AilaStoresContext);
+  if (!context) {
+    throw new Error("Missing AilaStoresProvider");
+  }
+  return useStore(context.chat, selector);
+};

--- a/apps/nextjs/src/stores/AilaStoresProvider.tsx
+++ b/apps/nextjs/src/stores/AilaStoresProvider.tsx
@@ -4,8 +4,11 @@ import { useStore, type StoreApi } from "zustand";
 
 import { type ChatStore, createChatStore } from "@/stores/chatStore";
 
+import { type LessonPlanStore, createLessonPlanStore } from "./lessonPlanStore";
+
 type AilaStoresContextProps = {
   chat: StoreApi<ChatStore>;
+  lessonPlan: StoreApi<LessonPlanStore>;
 };
 
 export const AilaStoresContext = createContext<
@@ -15,6 +18,7 @@ export const AilaStoresContext = createContext<
 export const AilaStoresProvider = ({ children }) => {
   const [store] = useState(() => ({
     chat: createChatStore(),
+    lessonPlan: createLessonPlanStore(),
   }));
 
   return (
@@ -30,4 +34,14 @@ export const useChatStore = <T,>(selector: (store: ChatStore) => T) => {
     throw new Error("Missing AilaStoresProvider");
   }
   return useStore(context.chat, selector);
+};
+
+export const useLessonPlanStore = <T,>(
+  selector: (store: LessonPlanStore) => T,
+) => {
+  const context = useContext(AilaStoresContext);
+  if (!context) {
+    throw new Error("Missing AilaStoresProvider");
+  }
+  return useStore(context.lessonPlan, selector);
 };

--- a/apps/nextjs/src/stores/chatStore/actions/calculateStreamingStatus.ts
+++ b/apps/nextjs/src/stores/chatStore/actions/calculateStreamingStatus.ts
@@ -3,26 +3,23 @@ import type { AiMessage } from "../types";
 
 export function calculateStreamingStatus(
   currentMessageData: AiMessage | null,
-  streamingStatus: AilaStreamingStatus,
-) {
-  // Determine streaming status
+): Exclude<AilaStreamingStatus, "Idle"> {
   if (!currentMessageData) {
-    streamingStatus = "Loading";
+    return "Loading";
   } else if (currentMessageData.role === "user") {
-    streamingStatus = "RequestMade";
+    return "RequestMade";
   } else if (currentMessageData.content.includes("MODERATION_START")) {
-    streamingStatus = "Moderating";
+    return "Moderating";
   } else if (currentMessageData.content.includes("experimentalPatch")) {
-    streamingStatus = "StreamingExperimentalPatches";
+    return "StreamingExperimentalPatches";
   } else if (
     currentMessageData.content.includes('"type":"prompt"') ||
     currentMessageData.content.includes('\\"type\\":\\"prompt\\"')
   ) {
-    streamingStatus = "StreamingChatResponse";
+    return "StreamingChatResponse";
   } else if (currentMessageData.content.includes("CHAT_START")) {
-    streamingStatus = "StreamingLessonPlan";
+    return "StreamingLessonPlan";
   } else {
-    streamingStatus = "Loading";
+    return "Loading";
   }
-  return streamingStatus;
 }

--- a/apps/nextjs/src/stores/chatStore/hooks/useChatStoreAiSdkSync.ts
+++ b/apps/nextjs/src/stores/chatStore/hooks/useChatStoreAiSdkSync.ts
@@ -7,9 +7,9 @@ import type {
   Message,
 } from "ai";
 
-import { useChatStore } from "../index";
+import { useChatStore } from "@/stores/AilaStoresProvider";
 
-export const useChatStoreMirror = (
+export const useChatStoreAiSdkSync = (
   messages: AiMessage[],
   isLoading: boolean,
   stop: () => void,

--- a/apps/nextjs/src/stores/chatStore/hooks/useChatStoreAiSdkSync.ts
+++ b/apps/nextjs/src/stores/chatStore/hooks/useChatStoreAiSdkSync.ts
@@ -17,7 +17,7 @@ export const useChatStoreAiSdkSync = (
     message: Message | CreateMessage,
     chatRequestOptions?: ChatRequestOptions | undefined,
   ) => Promise<string | null | undefined>,
-  reload: () => void,
+  reload: () => Promise<string | null | undefined>,
 ) => {
   const setMessages = useChatStore((state) => state.setMessages);
   const setAiSdkActions = useChatStore((state) => state.setAiSdkActions);

--- a/apps/nextjs/src/stores/chatStore/index.ts
+++ b/apps/nextjs/src/stores/chatStore/index.ts
@@ -1,22 +1,23 @@
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
 import { aiLogger } from "@oakai/logger";
-import type { ChatRequestOptions, CreateMessage, Message } from "ai";
+import type { ChatRequestOptions, CreateMessage } from "ai";
 import { create } from "zustand";
 
 import { logStoreUpdates } from "../zustandHelpers";
+import { handleAppend } from "./stateActionFunctions/handleAppend";
 import { handleExecuteQueuedAction } from "./stateActionFunctions/handleExecuteQueuedAction";
-import { handleQueueUserAction } from "./stateActionFunctions/handleQueueUserAction";
 import { handleSetMessages } from "./stateActionFunctions/handleSetMessages";
 import { handleStop } from "./stateActionFunctions/handleStop";
+import { handleStreamingFinished } from "./stateActionFunctions/handleStreamingFinished";
 import type { AiMessage, ParsedMessage } from "./types";
 
 const log = aiLogger("chat:store");
 
-type Actions = {
+type AiSdkActions = {
   stop: () => void;
   reload: () => void;
   append: (
-    message: Message | CreateMessage,
+    message: AiMessage | CreateMessage,
     chatRequestOptions?: ChatRequestOptions | undefined,
   ) => Promise<string | null | undefined>;
 };
@@ -36,22 +37,21 @@ export type ChatStore = {
   stableMessages: ParsedMessage[];
   streamingMessage: ParsedMessage | null;
   queuedUserAction: string | null;
-  isExecutingQueuedAction: boolean;
   lessonPlan: LooseLessonPlan | null;
 
   // From AI SDK
-  isLoading: boolean;
-  // Grouped Actions
-  actions: Actions;
+  aiSdkActions: AiSdkActions;
 
   // Setters
   setLessonPlan: (lessonPlan: LooseLessonPlan) => void;
-  setAiSdkActions: (actions: Actions) => void;
+  setAiSdkActions: (actions: AiSdkActions) => void;
   setMessages: (messages: AiMessage[], isLoading: boolean) => void;
-  setIsLoading: (isLoading: boolean) => void;
-  queueUserAction: (action: string) => Promise<void>;
-  executeQueuedAction: () => Promise<void>;
+
+  // Action functions
+  executeQueuedAction: () => void;
+  append: (message: string) => void;
   stop: () => void;
+  streamingFinished: () => void;
 
   reset: (
     params: Pick<ChatStore, "ailaStreamingStatus"> & {
@@ -65,27 +65,25 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   stableMessages: [],
   streamingMessage: null,
   queuedUserAction: null,
-  isExecutingQueuedAction: false,
   lessonPlan: null,
 
   // From AI SDK
-  isLoading: false,
-  actions: {
+  aiSdkActions: {
     stop: () => {},
     reload: () => {},
     append: async () => Promise.resolve(""),
   },
 
   // Setters
-  setAiSdkActions: (actions) => set({ actions }),
-  setIsLoading: (isLoading) => set({ isLoading }),
+  setAiSdkActions: (aiSdkActions) => set({ aiSdkActions }),
   setLessonPlan: (lessonPlan) => set({ lessonPlan }),
 
   // Action functions
-  queueUserAction: handleQueueUserAction(set, get),
   executeQueuedAction: handleExecuteQueuedAction(set, get),
+  append: handleAppend(set, get),
   stop: handleStop(set, get),
   setMessages: handleSetMessages(set, get),
+  streamingFinished: handleStreamingFinished(set, get),
 
   // reset
   reset: ({ ailaStreamingStatus = "Idle", queuedUserAction }) => {

--- a/apps/nextjs/src/stores/chatStore/index.ts
+++ b/apps/nextjs/src/stores/chatStore/index.ts
@@ -1,7 +1,7 @@
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
 import { aiLogger } from "@oakai/logger";
 import type { ChatRequestOptions, CreateMessage } from "ai";
-import { create } from "zustand";
+import { createStore } from "zustand";
 
 import { logStoreUpdates } from "../zustandHelpers";
 import { handleAppend } from "./stateActionFunctions/handleAppend";
@@ -11,6 +11,7 @@ import { handleStop } from "./stateActionFunctions/handleStop";
 import { handleStreamingFinished } from "./stateActionFunctions/handleStreamingFinished";
 import type { AiMessage, ParsedMessage } from "./types";
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 const log = aiLogger("chat:store");
 
 type AiSdkActions = {
@@ -52,46 +53,37 @@ export type ChatStore = {
   append: (message: string) => void;
   stop: () => void;
   streamingFinished: () => void;
-
-  reset: (
-    params: Pick<ChatStore, "ailaStreamingStatus"> & {
-      queuedUserAction?: ChatStore["queuedUserAction"];
-    },
-  ) => void;
 };
 
-export const useChatStore = create<ChatStore>((set, get) => ({
-  ailaStreamingStatus: "Idle",
-  stableMessages: [],
-  streamingMessage: null,
-  queuedUserAction: null,
-  lessonPlan: null,
+export const createChatStore = (initialValues: Partial<ChatStore> = {}) => {
+  const chatStore = createStore<ChatStore>((set, get) => ({
+    ailaStreamingStatus: "Idle",
+    stableMessages: [],
+    streamingMessage: null,
+    queuedUserAction: null,
+    lessonPlan: null,
 
-  // From AI SDK
-  aiSdkActions: {
-    stop: () => {},
-    reload: () => {},
-    append: async () => Promise.resolve(""),
-  },
+    // From AI SDK
+    aiSdkActions: {
+      stop: () => {},
+      reload: () => {},
+      append: async () => Promise.resolve(""),
+    },
 
-  // Setters
-  setAiSdkActions: (aiSdkActions) => set({ aiSdkActions }),
-  setLessonPlan: (lessonPlan) => set({ lessonPlan }),
+    // Setters
+    setAiSdkActions: (aiSdkActions) => set({ aiSdkActions }),
+    setLessonPlan: (lessonPlan) => set({ lessonPlan }),
 
-  // Action functions
-  executeQueuedAction: handleExecuteQueuedAction(set, get),
-  append: handleAppend(set, get),
-  stop: handleStop(set, get),
-  setMessages: handleSetMessages(set, get),
-  streamingFinished: handleStreamingFinished(set, get),
+    // Action functions
+    executeQueuedAction: handleExecuteQueuedAction(set, get),
+    append: handleAppend(set, get),
+    stop: handleStop(set, get),
+    setMessages: handleSetMessages(set, get),
+    streamingFinished: handleStreamingFinished(set, get),
 
-  // reset
-  reset: ({ ailaStreamingStatus = "Idle", queuedUserAction }) => {
-    set({
-      ailaStreamingStatus: ailaStreamingStatus,
-      queuedUserAction: queuedUserAction,
-    });
-  },
-}));
+    ...initialValues,
+  }));
 
-logStoreUpdates(useChatStore, "chat:store");
+  logStoreUpdates(chatStore, "chat:store");
+  return chatStore;
+};

--- a/apps/nextjs/src/stores/chatStore/index.ts
+++ b/apps/nextjs/src/stores/chatStore/index.ts
@@ -72,7 +72,7 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   actions: {
     stop: () => {},
     reload: () => {},
-    append: async () => "",
+    append: async () => Promise.resolve(""),
   },
 
   // Setters

--- a/apps/nextjs/src/stores/chatStore/index.ts
+++ b/apps/nextjs/src/stores/chatStore/index.ts
@@ -3,6 +3,7 @@ import { aiLogger } from "@oakai/logger";
 import type { ChatRequestOptions, CreateMessage, Message } from "ai";
 import { create } from "zustand";
 
+import { logStoreUpdates } from "../zustandHelpers";
 import { handleExecuteQueuedAction } from "./stateActionFunctions/handleExecuteQueuedAction";
 import { handleQueueUserAction } from "./stateActionFunctions/handleQueueUserAction";
 import { handleSetMessages } from "./stateActionFunctions/handleSetMessages";
@@ -95,6 +96,4 @@ export const useChatStore = create<ChatStore>((set, get) => ({
   },
 }));
 
-useChatStore.subscribe((state) => {
-  log.info("Chat store updated", state);
-});
+logStoreUpdates(useChatStore, "chat:store");

--- a/apps/nextjs/src/stores/chatStore/parsing.ts
+++ b/apps/nextjs/src/stores/chatStore/parsing.ts
@@ -24,7 +24,6 @@ export const getNextStableMessages = (
   currentMessages: ParsedMessage[],
 ): ParsedMessage[] | null => {
   if (stableMessagesMatch(messages, currentMessages)) {
-    log.info("Stable messages unchanged, not updating");
     return null;
   }
   return messages.map((m) => parseMessage(m));

--- a/apps/nextjs/src/stores/chatStore/selectors.ts
+++ b/apps/nextjs/src/stores/chatStore/selectors.ts
@@ -1,0 +1,8 @@
+import type { ChatStore } from ".";
+
+/**
+ * @example const canAppend = useChatStore(canAppend);
+ */
+export const canAppendSelector = (store: ChatStore) =>
+  store.ailaStreamingStatus === "Idle" ||
+  (store.ailaStreamingStatus === "Moderating" && !store.queuedUserAction);

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleAppend.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleAppend.ts
@@ -1,0 +1,34 @@
+import { aiLogger } from "@oakai/logger";
+import invariant from "tiny-invariant";
+
+import type { ChatStore } from "../index";
+import { canAppendSelector } from "../selectors";
+
+const log = aiLogger("chat:store");
+
+export const handleAppend =
+  (set: (partial: Partial<ChatStore>) => void, get: () => ChatStore) =>
+  (message: string) => {
+    const { ailaStreamingStatus, queuedUserAction, aiSdkActions } = get();
+    const canAppend = canAppendSelector(get());
+    if (!canAppend) {
+      log.error("Cannot append message");
+      return;
+    }
+
+    if (ailaStreamingStatus !== "Idle") {
+      invariant(
+        !queuedUserAction,
+        "Cannot append when a message is already queued",
+      );
+      log.info("Queueing user action", message);
+      set({ queuedUserAction: message });
+      return;
+    }
+
+    log.info("Appending message to AI SDK", message);
+    void aiSdkActions.append({
+      content: message,
+      role: "user",
+    });
+  };

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleQueueUserAction.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleQueueUserAction.ts
@@ -1,8 +1,0 @@
-import type { ChatStore } from "..";
-
-export const handleQueueUserAction =
-  (set: (partial: Partial<ChatStore>) => void, get: () => ChatStore) =>
-  async (action: string) => {
-    set({ queuedUserAction: action });
-    await get().executeQueuedAction();
-  };

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleSetMessages.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleSetMessages.ts
@@ -1,13 +1,14 @@
 import invariant from "tiny-invariant";
 
-import type { AilaStreamingStatus } from "..";
+import type { AilaStreamingStatus, ChatStore } from "..";
 import { calculateStreamingStatus } from "../actions/calculateStreamingStatus";
 import { getNextStableMessages, parseStreamingMessage } from "../parsing";
 import type { AiMessage } from "../types";
 
-// Add this import
-
-export function handleSetMessages(set, get) {
+export function handleSetMessages(
+  set: (partial: Partial<ChatStore>) => void,
+  get: () => ChatStore,
+) {
   return (messages: AiMessage[], isLoading: boolean) => {
     let streamingStatus: AilaStreamingStatus = "Idle";
 

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleStop.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleStop.ts
@@ -5,6 +5,6 @@ export const handleStop =
     if (get().queuedUserAction) {
       set({ queuedUserAction: null });
     } else {
-      get().actions.stop();
+      get().aiSdkActions.stop();
     }
   };

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleStreamingFinished.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleStreamingFinished.ts
@@ -1,0 +1,10 @@
+import type { ChatStore } from "../index";
+
+export const handleStreamingFinished =
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  (set: (partial: Partial<ChatStore>) => void, get: () => ChatStore) => () => {
+    // TODO: commented while we have the same in handleSetMessages
+    // if (get().queuedUserAction) {
+    //   void get().executeQueuedAction();
+    // }
+  };

--- a/apps/nextjs/src/stores/lessonPlanStore/hooks/useLessonPlanStoreAiSdkSync.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/hooks/useLessonPlanStoreAiSdkSync.ts
@@ -1,0 +1,15 @@
+import { useEffect } from "react";
+
+import { useLessonPlanStore } from "@/stores/AilaStoresProvider";
+import type { AiMessage } from "@/stores/chatStore/types";
+
+export const useLessonPlanStoreAiSdkSync = (
+  messages: AiMessage[],
+  isLoading: boolean,
+) => {
+  const messagesUpdated = useLessonPlanStore((state) => state.messagesUpdated);
+
+  useEffect(() => {
+    messagesUpdated(messages);
+  }, [messages, isLoading, messagesUpdated]);
+};

--- a/apps/nextjs/src/stores/lessonPlanStore/index.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/index.ts
@@ -1,0 +1,71 @@
+import type {
+  LessonPlanKey,
+  LooseLessonPlan,
+} from "@oakai/aila/src/protocol/schema";
+import { aiLogger } from "@oakai/logger";
+import { createStore } from "zustand";
+
+import type { AiMessage } from "../chatStore/types";
+import { logStoreUpdates } from "../zustandHelpers";
+import { handleMessagesUpdated } from "./stateActionFunctions/handleMessagesUpdated";
+
+const log = aiLogger("lessons:store");
+
+export type LessonPlanStore = {
+  lessonPlan: LooseLessonPlan;
+  appliedPatchHashes: string[];
+  appliedPatchPaths: LessonPlanKey[];
+  sectionsToEdit: LessonPlanKey[];
+  iteration: number | undefined;
+  isAcceptingChanges: boolean;
+  numberOfStreamedCompleteParts: number;
+
+  messageStarted: () => void;
+  messagesUpdated: (messages: AiMessage[]) => void;
+  messageFinished: () => void;
+};
+
+const initialPerMessageState = {
+  sectionsToEdit: [],
+  appliedPatchHashes: [],
+  appliedPatchPaths: [],
+  numberOfStreamedCompleteParts: 0,
+} satisfies Partial<LessonPlanStore>;
+
+export const createLessonPlanStore = (
+  initialValues: Partial<LessonPlanStore> = {},
+) => {
+  const lessonPlanStore = createStore<LessonPlanStore>((set, get) => ({
+    lessonPlan: {},
+    iteration: undefined,
+    isAcceptingChanges: false,
+
+    ...initialPerMessageState,
+
+    // Setters
+    setInitialLessonPlan: (lessonPlan: LooseLessonPlan) => set({ lessonPlan }),
+
+    // Action functions
+    messageStarted: () => {
+      log.info("Message started");
+      set({ isAcceptingChanges: true });
+    },
+    messagesUpdated: handleMessagesUpdated(set, get),
+    messageFinished: () => {
+      // TODO: time to refetch lesson plan from getChat?
+      log.info("Message finished");
+      set({ isAcceptingChanges: false, ...initialPerMessageState });
+    },
+
+    ...initialValues,
+  }));
+
+  // For early state debugging. Remove later
+  lessonPlanStore.subscribe((state) => {
+    log.info("sectionsToEdit ", state.sectionsToEdit);
+    log.info("appliedPatchPaths ", state.appliedPatchPaths);
+  });
+
+  logStoreUpdates(lessonPlanStore, "lessons:store");
+  return lessonPlanStore;
+};

--- a/apps/nextjs/src/stores/lessonPlanStore/stateActionFunctions/handleMessagesUpdated.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/stateActionFunctions/handleMessagesUpdated.ts
@@ -1,0 +1,124 @@
+import {
+  applyLessonPlanPatchImmutable,
+  extractPatches,
+  type PatchDocument,
+} from "@oakai/aila/src/protocol/jsonPatchProtocol";
+import { LessonPlanKeySchema } from "@oakai/aila/src/protocol/schema";
+import { aiLogger } from "@oakai/logger";
+import { createHash } from "crypto";
+import { StoreApi } from "zustand";
+
+import type { AiMessage } from "@/stores/chatStore/types";
+
+import type { LessonPlanStore } from "..";
+import { LessonPlanGetter, LessonPlanSetter } from "../types";
+
+const log = aiLogger("lessons:store");
+
+const timeOperation = <T>(fn: () => T): T => {
+  const startTime = performance.now();
+  const result = fn();
+  const endTime = performance.now();
+  log.info(`applyLessonPlanPatch took ${endTime - startTime} milliseconds`);
+  return result;
+};
+
+const generatePatchHash = (patch: PatchDocument): string => {
+  const patchString = JSON.stringify(patch);
+  const hash = createHash("sha256");
+  hash.update(patchString);
+  return hash.digest("hex");
+};
+
+const countCompleteParts = (messageStr: string) => {
+  return [...messageStr.matchAll(/"status":"complete"/g)].length;
+};
+
+const extractSectionsToEdit = (messageStr: string) => {
+  // ...,"sectionsToEdit":["a","b","c"],...
+  const sectionsToEditStr = messageStr.match(
+    /"sectionsToEdit":\[("([a-zA-Z0-9])+",?)*\]/,
+  )?.[0];
+  if (!sectionsToEditStr) {
+    return [];
+  }
+  // '"sectionsToEdit":["a","b","c"]' => ["a", "b", "c"]
+  return (
+    sectionsToEditStr
+      .replace('"sectionsToEdit":', "")
+      .match(/([a-zA-Z0-9])+/g) ?? []
+  );
+};
+
+export const handleMessagesUpdated = (
+  set: LessonPlanSetter,
+  get: LessonPlanGetter,
+) => {
+  const applyMessageToLessonPlan = (message: AiMessage) => {
+    log.info("Extracting patches from message", message);
+    // NOTE: we don't need partial patches as weextract them with a regex
+    const { validPatches } = extractPatches(message.content);
+    log.info("valid patches", validPatches);
+
+    validPatches.forEach((patch) => {
+      const { appliedPatchHashes, lessonPlan } = get();
+      const patchHash = generatePatchHash(patch);
+
+      if (!appliedPatchHashes.includes(patchHash)) {
+        const updatedLessonPlan = timeOperation(() => {
+          // NOTE: It's important that there isn't any cloning when applying the patch
+          return applyLessonPlanPatchImmutable(lessonPlan ?? {}, patch);
+        });
+        if (updatedLessonPlan) {
+          log.info("Applying patch", patch.value.path);
+          const patchPath = LessonPlanKeySchema.parse(
+            patch.value.path.replace("/", ""),
+          );
+          set((state) => ({
+            lessonPlan: updatedLessonPlan,
+            appliedPatchHashes: [...state.appliedPatchHashes, patchHash],
+            appliedPatchPaths: [...state.appliedPatchPaths, patchPath],
+          }));
+        } else {
+          log.info("Patch failed to apply");
+        }
+      }
+    });
+  };
+
+  return (messages: AiMessage[]) => {
+    if (!get().isAcceptingChanges) {
+      log.info("message skipped: not accepting changes");
+      return;
+    }
+    const streamingMessage = messages[messages.length - 1];
+    if (!streamingMessage) {
+      log.info("message skipped: no message");
+      return;
+    }
+    if (streamingMessage.role !== "assistant") {
+      log.info("message skipped: wrong role");
+      return;
+    }
+
+    const numberOfStreamedCompleteParts = countCompleteParts(
+      streamingMessage.content,
+    );
+
+    if (numberOfStreamedCompleteParts !== get().numberOfStreamedCompleteParts) {
+      log.info(
+        `numberOfCompleteParts changed to ${numberOfStreamedCompleteParts}`,
+      );
+      set({ numberOfStreamedCompleteParts });
+      applyMessageToLessonPlan(streamingMessage);
+    }
+
+    const sectionsToEdit = extractSectionsToEdit(streamingMessage.content);
+    if (sectionsToEdit.join(",") !== get().sectionsToEdit?.join(",")) {
+      log.info(`sectionsToEdit changed to ${sectionsToEdit.join(",")}`);
+      const parsedSectionsToEdit =
+        LessonPlanKeySchema.array().parse(sectionsToEdit);
+      set({ sectionsToEdit: parsedSectionsToEdit });
+    }
+  };
+};

--- a/apps/nextjs/src/stores/lessonPlanStore/stateActionFunctions/handleMessagesUpdated.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/stateActionFunctions/handleMessagesUpdated.ts
@@ -6,12 +6,10 @@ import {
 import { LessonPlanKeySchema } from "@oakai/aila/src/protocol/schema";
 import { aiLogger } from "@oakai/logger";
 import { createHash } from "crypto";
-import { StoreApi } from "zustand";
 
 import type { AiMessage } from "@/stores/chatStore/types";
 
-import type { LessonPlanStore } from "..";
-import { LessonPlanGetter, LessonPlanSetter } from "../types";
+import type { LessonPlanGetter, LessonPlanSetter } from "../types";
 
 const log = aiLogger("lessons:store");
 

--- a/apps/nextjs/src/stores/lessonPlanStore/stateActionFunctions/handleRefetch.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/stateActionFunctions/handleRefetch.ts
@@ -1,0 +1,41 @@
+import { aiLogger } from "@oakai/logger";
+import * as Sentry from "@sentry/nextjs";
+import invariant from "tiny-invariant";
+
+import type { TrpcUtils } from "@/utils/trpc";
+
+import type { LessonPlanGetter, LessonPlanSetter } from "../types";
+
+const log = aiLogger("lessons:store");
+
+export const handleRefetch = (
+  set: LessonPlanSetter,
+  get: LessonPlanGetter,
+  trpc: TrpcUtils,
+) => {
+  return async () => {
+    log.info("Refetching");
+    try {
+      const id = get().id;
+      const result = await trpc.client.chat.appSessions.getChat.query({ id });
+      invariant(result, "result should not be null");
+      const { lessonPlan, iteration } = result;
+
+      if (get().isAcceptingChanges) {
+        log.info("Lesson plan from DB ignored while streaming");
+        return;
+      }
+      const currentIteration = get().iteration;
+      if (iteration && currentIteration && iteration <= currentIteration) {
+        log.info(`Ignored lesson plan from DB with iteration #${iteration}`);
+        return;
+      }
+
+      set({ lessonPlan, iteration });
+      log.info(`Set lesson plan iteration #${iteration} from DB`);
+    } catch (err) {
+      log.error("Error refetching lessonPlanStore", err);
+      Sentry.captureException(err);
+    }
+  };
+};

--- a/apps/nextjs/src/stores/lessonPlanStore/types.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/types.ts
@@ -1,0 +1,6 @@
+import type { StoreApi } from "zustand";
+
+import type { LessonPlanStore } from ".";
+
+export type LessonPlanSetter = StoreApi<LessonPlanStore>["setState"];
+export type LessonPlanGetter = StoreApi<LessonPlanStore>["getState"];

--- a/apps/nextjs/src/stores/zustandHelpers.ts
+++ b/apps/nextjs/src/stores/zustandHelpers.ts
@@ -1,0 +1,29 @@
+import { aiLogger, type LoggerKey } from "@oakai/logger";
+import type { StoreApi } from "zustand";
+
+export const logStoreUpdates = <T extends object>(
+  store: StoreApi<T>,
+  loggerKey: LoggerKey,
+) => {
+  const log = aiLogger(loggerKey);
+  store.subscribe((state, prevState) => {
+    const changedKeys = Object.keys(state)
+      .filter((key) => state[key] !== prevState[key])
+      .map((key) => {
+        const value = state[key];
+        if (value && typeof value === "object") {
+          const prevValue = prevState[key] || {};
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+          const changedKeys = Object.keys(value).filter(
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+            (key) => value[key] !== prevValue[key],
+          );
+          return `/${key}/{${changedKeys.join(",")}}`;
+        }
+
+        return `/${key}`;
+      });
+    // .map((key) => `/${key}`);
+    log.info(`State updated: ${changedKeys.join(", ")}`);
+  });
+};

--- a/apps/nextjs/src/types/gleap.d.ts
+++ b/apps/nextjs/src/types/gleap.d.ts
@@ -1,0 +1,18 @@
+declare module "gleap" {
+  interface GleapInstance {
+    initialized: boolean;
+    // Add other methods and properties as needed
+  }
+
+  const Gleap: {
+    getInstance(): GleapInstance;
+    setFrameUrl(url: string): void;
+    setApiUrl(url: string): void;
+    initialize(apiKey: string): void;
+    showFeedbackButton(show: boolean): void;
+    identify(userId: string, userData: object): void;
+    clearIdentity(): void;
+  };
+
+  export default Gleap;
+}

--- a/apps/nextjs/src/utils/trpc.tsx
+++ b/apps/nextjs/src/utils/trpc.tsx
@@ -20,6 +20,8 @@ const getBaseUrl = () => {
 
 type CombinedRouter = AppRouter & ChatAppRouter;
 
+export type TrpcUtils = ReturnType<typeof trpc.useUtils>;
+
 const trpc = createTRPCReact<CombinedRouter>();
 
 const discriminatingRouterLink: TRPCLink<CombinedRouter> = (runtime) => {

--- a/apps/nextjs/tests-e2e/tests/aila-chat/helpers.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/helpers.ts
@@ -108,7 +108,7 @@ export const applyLlmFixtures = async (
 
 // The chat UI has a race condition when you submit a message too quickly after the previous response
 // This is a temporary fix to fix test flake
-export async function letUiSettle(page, testInfo: TestInfo) {
+export async function letUiSettle(page: Page, testInfo: TestInfo) {
   return await page.waitForTimeout(testInfo.retry === 0 ? 500 : 6000);
 }
 

--- a/packages/aila/package.json
+++ b/packages/aila/package.json
@@ -25,7 +25,10 @@
   },
   "dependencies": {
     "@ai-sdk/openai": "^0.0.55",
+    "@anatine/zod-mock": "^3.13.4",
     "@clerk/nextjs": "5.7.2",
+    "@elastic/elasticsearch": "^8.13.1",
+    "@faker-js/faker": "^9.4.0",
     "@oakai/core": "*",
     "@oakai/db": "*",
     "@oakai/exports": "*",

--- a/packages/aila/package.json
+++ b/packages/aila/package.json
@@ -41,6 +41,7 @@
     "cloudinary": "^1.41.1",
     "dedent": "^1.5.3",
     "dotenv-cli": "^6.0.0",
+    "immer": "^10.1.1",
     "jsonrepair": "^3.8.0",
     "openai": "^4.58.1",
     "remeda": "^1.29.0",

--- a/packages/aila/src/core/AilaServices.ts
+++ b/packages/aila/src/core/AilaServices.ts
@@ -20,6 +20,7 @@ import type {
 } from "../protocol/schema";
 import type { Message } from "./chat";
 import type { AilaPlugin } from "./plugins";
+import type { FullQuizService } from "./quiz/interfaces";
 import type { AilaOptionsWithDefaultFallbackValues } from "./types";
 
 // This provides a set of interfaces between the Aila core and the features that use it.
@@ -50,6 +51,7 @@ export interface AilaChatService {
   set relevantLessons(lessons: AilaRagRelevantLesson[]);
   readonly parsedMessages: MessagePart[][];
   readonly isShared: boolean | undefined;
+  readonly fullQuizService: FullQuizService;
   loadChat({ store }: { store: string }): Promise<void>;
   addMessage(message: Message): void;
   startStreaming(abortController?: AbortController): ReadableStream;

--- a/packages/aila/src/core/chat/AilaChat.ts
+++ b/packages/aila/src/core/chat/AilaChat.ts
@@ -3,6 +3,7 @@ import {
   unsupportedSubjects,
   subjectWarnings,
 } from "@oakai/core/src/utils/subjects";
+// TODO: GCLOMAX This is a bodge. Fix as soon as possible due to the new prisma client set up.
 import { aiLogger } from "@oakai/logger";
 import invariant from "tiny-invariant";
 
@@ -30,6 +31,9 @@ import type { LLMService } from "../llm/LLMService";
 import { OpenAIService } from "../llm/OpenAIService";
 import type { AilaPromptBuilder } from "../prompt/AilaPromptBuilder";
 import { AilaLessonPromptBuilder } from "../prompt/builders/AilaLessonPromptBuilder";
+import { CompositeFullQuizServiceBuilder } from "../quiz/fullservices/CompositeFullQuizServiceBuilder";
+import type { FullQuizService } from "../quiz/interfaces";
+import { testRatingSchema } from "../quiz/rerankers/RerankerStructuredOutputSchema";
 import { AilaStreamHandler } from "./AilaStreamHandler";
 import { PatchEnqueuer } from "./PatchEnqueuer";
 import type { Message } from "./types";
@@ -51,7 +55,11 @@ export class AilaChat implements AilaChatService {
   private _iteration: number | undefined;
   private _createdAt: Date | undefined;
   private _persistedChat: AilaPersistedChat | undefined;
-  private readonly _experimentalPatches: ExperimentalPatchDocument[];
+
+  private _experimentalPatches: ExperimentalPatchDocument[];
+  public readonly fullQuizService: FullQuizService;
+
+  // private readonly _experimentalPatches: ExperimentalPatchDocument[];
 
   constructor({
     id,
@@ -82,6 +90,13 @@ export class AilaChat implements AilaChatService {
     this._promptBuilder = promptBuilder ?? new AilaLessonPromptBuilder(aila);
     this._relevantLessons = [];
     this._experimentalPatches = [];
+
+    this.fullQuizService = new CompositeFullQuizServiceBuilder().build({
+      quizRatingSchema: testRatingSchema,
+      quizSelector: "simple",
+      quizReranker: "return-first",
+      quizGenerators: ["basedOnRag"],
+    });
   }
 
   public get aila() {
@@ -387,6 +402,7 @@ export class AilaChat implements AilaChatService {
   public async complete() {
     await this.reportUsageMetrics();
     await fetchExperimentalPatches({
+      fullQuizService: this.fullQuizService,
       lessonPlan: this._aila.lesson.plan,
       llmPatches: extractPatches(this.accumulatedText()).validPatches,
       handlePatch: async (patch) => {

--- a/packages/aila/src/core/quiz/ChoiceModels.ts
+++ b/packages/aila/src/core/quiz/ChoiceModels.ts
@@ -1,0 +1,56 @@
+import { z } from "zod";
+
+// Abstract this to Schema, choice, evaluator functions to make extensible
+// And to be able to use secondary model / LLM to inspect based on justifications.
+
+export const BaseSchema = z.object({
+  // Add any common fields here
+  rating: z.number(),
+});
+
+export type BaseType = z.infer<typeof BaseSchema>;
+
+// Rating Function Type
+export type RatingFunction<T extends BaseType> = (item: T) => number;
+
+export type MaxRatingFunctionApplier<T extends BaseType> = (
+  items: T[],
+  ratingFunction: RatingFunction<T>,
+) => number;
+
+export type RatingFunctionApplier<T extends BaseType> = (
+  items: T[],
+  ratingFunction: RatingFunction<T>,
+) => number[];
+
+// This just applies a rating functon to each item. This is abstracted out to allow for different types of rating functions, i.e you can use a secondary LLM as a rating function.
+export function selectHighestRated<T extends BaseType>(
+  items: T[],
+  ratingFunction: RatingFunction<T>,
+): number {
+  if (items.length === 0) {
+    throw new Error("The input array is empty");
+  }
+
+  // if statement to get around typing bug.
+  let highestRatedIndex = 0;
+  let highestRating = ratingFunction(items[0]!);
+  if (items.length > 0 && items[0] !== null) {
+    for (let i = 1; i < items.length; i++) {
+      const currentRating = ratingFunction(items[i]!);
+      if (currentRating > highestRating) {
+        highestRating = currentRating;
+        highestRatedIndex = i;
+      }
+    }
+  }
+  return highestRatedIndex;
+}
+
+// Used for typing.
+export function ApplyRatingFunction<T extends BaseType>(
+  items: T[],
+  ratingFunction: RatingFunction<T>,
+): number[] {
+  return items.map((item) => ratingFunction(item));
+}

--- a/packages/aila/src/core/quiz/LessonSlugQuizMapping.test.ts
+++ b/packages/aila/src/core/quiz/LessonSlugQuizMapping.test.ts
@@ -1,0 +1,170 @@
+import { ElasticLessonQuizLookup } from "./LessonSlugQuizMapping";
+
+describe("ElasticLessonQuizLookup", () => {
+  let dbLookup: ElasticLessonQuizLookup;
+
+  beforeEach(() => {
+    dbLookup = new ElasticLessonQuizLookup();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("quiz methods", () => {
+    const mockSearchResponse = {
+      hits: {
+        hits: [
+          {
+            _source: {
+              text: {
+                starterQuiz: ["q1", "q2"],
+                exitQuiz: ["q3", "q4"],
+              },
+            },
+          },
+        ],
+      },
+    };
+
+    beforeEach(() => {
+      // @ts-expect-error - Mock the Elasticsearch client search method
+      dbLookup.client = {
+        search: jest.fn().mockResolvedValue(mockSearchResponse),
+      };
+    });
+
+    describe("getStarterQuiz", () => {
+      it("should return starter quiz questions for valid lesson slug", async () => {
+        const result = await dbLookup.getStarterQuiz("test-lesson");
+        expect(result).toEqual(["q1", "q2"]);
+        // @ts-expect-error - Mock the Elasticsearch client search method
+        expect(dbLookup.client.search).toHaveBeenCalledWith({
+          index: "lesson-slug-lookup",
+          query: {
+            bool: {
+              must: [
+                { term: { "metadata.lessonSlug.keyword": "test-lesson" } },
+              ],
+            },
+          },
+        });
+      });
+
+      it("should throw error when no quiz found", async () => {
+        // @ts-expect-error- Mock the Elasticsearch client search method
+        dbLookup.client.search.mockResolvedValueOnce({ hits: { hits: [] } });
+        await expect(dbLookup.getStarterQuiz("non-existent")).rejects.toThrow(
+          "No /starterQuiz found for lesson slug: non-existent",
+        );
+      });
+
+      it("should throw error when quiz data is invalid", async () => {
+        // @ts-expect-error- Mock the Elasticsearch client search method
+        dbLookup.client.search.mockResolvedValueOnce({
+          hits: {
+            hits: [{ _source: { text: { starterQuiz: null } } }],
+          },
+        });
+        await expect(dbLookup.getStarterQuiz("test-lesson")).rejects.toThrow(
+          "Invalid /starterQuiz data for lesson slug: test-lesson",
+        );
+      });
+    });
+
+    describe("getExitQuiz", () => {
+      it("should return exit quiz questions for valid lesson slug", async () => {
+        const result = await dbLookup.getExitQuiz("test-lesson");
+        expect(result).toEqual(["q3", "q4"]);
+        // @ts-expect-error- Mock the Elasticsearch client search method
+        expect(dbLookup.client.search).toHaveBeenCalledWith({
+          index: "lesson-slug-lookup",
+          query: {
+            bool: {
+              must: [
+                { term: { "metadata.lessonSlug.keyword": "test-lesson" } },
+              ],
+            },
+          },
+        });
+      });
+
+      it("should throw error when no quiz found", async () => {
+        // @ts-expect-error- Mock the Elasticsearch client search method
+        dbLookup.client.search.mockResolvedValueOnce({ hits: { hits: [] } });
+        await expect(dbLookup.getExitQuiz("non-existent")).rejects.toThrow(
+          "No /exitQuiz found for lesson slug: non-existent",
+        );
+      });
+
+      it("should throw error when quiz data is invalid", async () => {
+        // @ts-expect-error- Mock the Elasticsearch client search method
+        dbLookup.client.search.mockResolvedValueOnce({
+          hits: {
+            hits: [{ _source: { text: { exitQuiz: null } } }],
+          },
+        });
+        await expect(dbLookup.getExitQuiz("test-lesson")).rejects.toThrow(
+          "Invalid /exitQuiz data for lesson slug: test-lesson",
+        );
+      });
+    });
+
+    describe("hasStarterQuiz", () => {
+      it("should return true when starter quiz exists", async () => {
+        const result = await dbLookup.hasStarterQuiz("test-lesson");
+        expect(result).toBe(true);
+      });
+
+      it("should return false when starter quiz doesn't exist", async () => {
+        // @ts-expect-error- Mock the Elasticsearch client search method
+        dbLookup.client.search.mockResolvedValueOnce({ hits: { hits: [] } });
+        const result = await dbLookup.hasStarterQuiz("non-existent");
+        expect(result).toBe(false);
+      });
+    });
+
+    describe("hasExitQuiz", () => {
+      it("should return true when exit quiz exists", async () => {
+        const result = await dbLookup.hasExitQuiz("test-lesson");
+        expect(result).toBe(true);
+      });
+
+      it("should return false when exit quiz doesn't exist", async () => {
+        // @ts-expect-error- Mock the Elasticsearch client search method
+        dbLookup.client.search.mockResolvedValueOnce({ hits: { hits: [] } });
+        const result = await dbLookup.hasExitQuiz("non-existent");
+        expect(result).toBe(false);
+      });
+    });
+  });
+});
+
+describe("ElasticLessonQuizLookup integrations tests", () => {
+  it("Should pass integration test for starter quiz", async () => {
+    const dbLookup = new ElasticLessonQuizLookup();
+    const result = await dbLookup.getStarterQuiz(
+      "sketching-quadratic-graphs-part-2-61h62d",
+    );
+    expect(result).toEqual([
+      "QUES-EYPJ1-67826",
+      "QUES-KBWC1-67827",
+      "QUES-SLVS1-67828",
+      "QUES-MCWI1-67829",
+      "QUES-HJPP1-67830",
+    ]);
+  });
+  it("Should pass integration test for exit quiz", async () => {
+    const dbLookup = new ElasticLessonQuizLookup();
+    const result = await dbLookup.getExitQuiz(
+      "sketching-quadratic-graphs-part-2-61h62d",
+    );
+    expect(result).toEqual([
+      "QUES-FTIZ1-76446",
+      "QUES-ITJT1-76447",
+      "QUES-YYMU1-76448",
+      "QUES-TTEF1-76449",
+      "QUES-FRFV1-76452",
+    ]);
+  });
+});

--- a/packages/aila/src/core/quiz/LessonSlugQuizMapping.ts
+++ b/packages/aila/src/core/quiz/LessonSlugQuizMapping.ts
@@ -1,0 +1,123 @@
+import { Client } from "@elastic/elasticsearch";
+import { aiLogger } from "@oakai/logger";
+import { z } from "zod";
+
+import type { QuizPath } from "../../protocol/schema";
+import type { LessonSlugQuizLookup, QuizIDSource, QuizSet } from "./interfaces";
+
+const log = aiLogger("aila:quiz");
+
+export abstract class BaseLessonQuizLookup implements LessonSlugQuizLookup {
+  abstract getStarterQuiz(lessonSlug: string): Promise<string[]>;
+  abstract getExitQuiz(lessonSlug: string): Promise<string[]>;
+  abstract hasStarterQuiz(lessonSlug: string): Promise<boolean>;
+  abstract hasExitQuiz(lessonSlug: string): Promise<boolean>;
+}
+
+export class ElasticLessonQuizLookup extends BaseLessonQuizLookup {
+  private readonly client: Client;
+
+  constructor() {
+    super();
+
+    if (
+      !process.env.I_DOT_AI_ELASTIC_CLOUD_ID ||
+      !process.env.I_DOT_AI_ELASTIC_KEY
+    ) {
+      throw new Error(
+        "Environment variables for Elastic Cloud ID and API Key must be set",
+      );
+    }
+
+    this.client = new Client({
+      cloud: {
+        id: process.env.I_DOT_AI_ELASTIC_CLOUD_ID,
+      },
+      auth: {
+        apiKey: process.env.I_DOT_AI_ELASTIC_KEY,
+      },
+    });
+  }
+
+  private async searchQuizByLessonSlug(
+    lessonSlug: string,
+    quizType: QuizPath,
+  ): Promise<string[]> {
+    try {
+      const response = await this.client.search<QuizIDSource>({
+        index: "lesson-slug-lookup",
+        query: {
+          bool: {
+            must: [{ term: { "metadata.lessonSlug.keyword": lessonSlug } }],
+          },
+        },
+      });
+
+      if (!response.hits.hits[0]?._source) {
+        log.error(`No ${quizType} found for lesson slug: ${lessonSlug}. Hit: `);
+        throw new Error(`No ${quizType} found for lesson slug: ${lessonSlug}`);
+      }
+
+      const source = response.hits.hits[0]._source;
+      log.info(`Source: ${JSON.stringify(source)}`);
+
+      // Parse the text field if it's a string
+      const quizData: QuizSet =
+        typeof source.text === "string" ? JSON.parse(source.text) : source.text;
+
+      let quizIds: string[] | null = null;
+      if (quizType === "/starterQuiz") {
+        quizIds = quizData.starterQuiz;
+      } else if (quizType === "/exitQuiz") {
+        quizIds = quizData.exitQuiz;
+      }
+
+      if (!quizIds || !z.array(z.string()).safeParse(quizIds).success) {
+        log.error(
+          `Got invalid ${quizType} data for lesson slug: ${lessonSlug}. Data: ${JSON.stringify(
+            quizData,
+          )}`,
+        );
+        throw new Error(
+          `Invalid ${quizType} data for lesson slug: ${lessonSlug}. Data: ${JSON.stringify(
+            quizData,
+          )}`,
+        );
+      }
+
+      return quizIds;
+    } catch (error) {
+      log.error(
+        `Error fetching ${quizType} for lesson slug ${lessonSlug}:`,
+        error,
+      );
+      throw error;
+    }
+  }
+
+  async getStarterQuiz(lessonSlug: string): Promise<string[]> {
+    return this.searchQuizByLessonSlug(lessonSlug, "/starterQuiz");
+  }
+
+  async getExitQuiz(lessonSlug: string): Promise<string[]> {
+    return this.searchQuizByLessonSlug(lessonSlug, "/exitQuiz");
+  }
+
+  async hasStarterQuiz(lessonSlug: string): Promise<boolean> {
+    try {
+      await this.getStarterQuiz(lessonSlug);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async hasExitQuiz(lessonSlug: string): Promise<boolean> {
+    try {
+      await this.getExitQuiz(lessonSlug);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}

--- a/packages/aila/src/core/quiz/apiCallingUtils.ts
+++ b/packages/aila/src/core/quiz/apiCallingUtils.ts
@@ -1,0 +1,35 @@
+// This is a bodge to not get rate limited. It's a bit of a hack but it works.
+// Realistically we could make a queueing system for this but unsure how that works
+// With vercel serverless functions ect - or wait until openai adds batching support to its
+// Beta chat.
+// Decorates (without experimental decorators) to add a random delay to a function.
+// Adds a random delay to a function
+import { aiLogger } from "@oakai/logger";
+
+const log = aiLogger("aila");
+
+export function withRandomDelay<TArgs extends unknown[], TResult>(
+  fn: (...args: TArgs) => Promise<TResult>,
+  minDelay: number,
+  maxDelay: number,
+): (...args: TArgs) => Promise<TResult> {
+  return async function (...args: TArgs): Promise<TResult> {
+    const delay = Math.floor(
+      Math.random() * (maxDelay - minDelay + 1) + minDelay,
+    );
+    log.info(`Delaying execution for ${delay}ms`);
+    await new Promise((resolve) => setTimeout(resolve, delay));
+    return fn(...args);
+  };
+}
+
+// Example usage:
+// const delayedFetchData = withRandomDelay(fetchData, 1000, 5000);
+
+export async function processArray<T, TResult>(
+  array: T[],
+  asyncFunction: (item: T) => Promise<TResult>,
+): Promise<TResult[]> {
+  const promises = array.map((item) => asyncFunction(item));
+  return Promise.all(promises);
+}

--- a/packages/aila/src/core/quiz/choiceModel.test.ts
+++ b/packages/aila/src/core/quiz/choiceModel.test.ts
@@ -1,0 +1,26 @@
+import { selectHighestRated } from "./ChoiceModels";
+import type { TestRating } from "./rerankers/RerankerStructuredOutputSchema";
+
+const testRatingArray: TestRating[] = [
+  {
+    rating: 0.2,
+    justification: "Justification 1",
+  },
+  {
+    rating: 0.8,
+    justification: "Justification 2",
+  },
+  {
+    rating: 0.5,
+    justification: "Justification 3",
+  },
+];
+
+describe("Tests Simple Rating function", () => {
+  it("it should rate the second index highest", () => {});
+  const highestRatedIndex = selectHighestRated(
+    testRatingArray,
+    (item) => item.rating,
+  );
+  expect(highestRatedIndex).toBe(1);
+});

--- a/packages/aila/src/core/quiz/fixtures/CachedImageQuiz.ts
+++ b/packages/aila/src/core/quiz/fixtures/CachedImageQuiz.ts
@@ -1,0 +1,58 @@
+import type { PatchDocument } from "../../../protocol/jsonPatchProtocol";
+import type { Quiz } from "../../../protocol/schema";
+
+export const cachedQuiz: Quiz = [
+  {
+    question: "How many degrees in 2 right angles?",
+    answers: ["180°"],
+    distractors: ["60°", "90°"],
+  },
+  {
+    question:
+      "Two shapes are {{}} if the only difference between them is their size.",
+    answers: ["similar"],
+    distractors: [
+      "No distractors for short answer",
+      "No distractors for short answer",
+    ],
+  },
+  {
+    question:
+      "A fruit stall is having a sale. It sells cherries in boxes of four pairs. How many cherries are there in six packs? There will be {{ }} in six packs.",
+    answers: ["24"],
+    distractors: [
+      "No distractors for short answer",
+      "No distractors for short answer",
+    ],
+  },
+  {
+    question:
+      "In which image is the circumference labelled with a question mark?",
+    answers: [
+      "![image](http://oaknationalacademy-res.cloudinary.com/image/upload/v1703169784/fg4uyx41rfnksbvav2nh.png)",
+    ],
+    distractors: [
+      "![image](http://oaknationalacademy-res.cloudinary.com/image/upload/v1703163380/pz6cn5k4wmowycnjq5am.png)",
+      "![image](http://oaknationalacademy-res.cloudinary.com/image/upload/v1703169784/mr09mrwkqdtk1dvjdoi0.png)",
+    ],
+  },
+  {
+    question:
+      "Complete the statement. Triangle ABC and triangle XYZ are ____________. ![image](http://oaknationalacademy-res.cloudinary.com/image/upload/v1706110974/fukcqeavzcevgjhmm1n4.png)",
+    answers: ["similar as the three interior angles are the same."],
+    distractors: [
+      "congruent as the three interior angles are all the same.",
+      "neither similar nor congruent.",
+    ],
+  },
+];
+
+export const cachedExitQuizPatch: PatchDocument = {
+  type: "patch",
+  reasoning: "adding maths quiz because i need to teach the kids about this",
+  value: {
+    op: "add",
+    path: "/exitQuiz",
+    value: cachedQuiz,
+  },
+};

--- a/packages/aila/src/core/quiz/fixtures/CircleTheoremsExampleOutput.ts
+++ b/packages/aila/src/core/quiz/fixtures/CircleTheoremsExampleOutput.ts
@@ -1,0 +1,234 @@
+export const CircleTheoremLesson = {
+  basedOn: {
+    id: "Tr9r1RlwSNes3X2ZgRQSi", // This is the corresponsing label in the lesson table for slug reading-timetables-6wwkgt
+    title: "TEST-LESSON-READING-TIMETABLES",
+  },
+  title: "Circle Theorems",
+  subject: "maths",
+  keyStage: "key-stage-4",
+  topic: "Circle Theorems",
+  learningOutcome:
+    "I can identify and apply key circle theorems to solve problems involving angles and arcs.",
+  learningCycles: [
+    "Identify and describe the key circle theorems.",
+    "Apply circle theorems to solve mathematical problems.",
+    "Evaluate the use of different circle theorems in complex scenarios.",
+  ],
+  priorKnowledge: [
+    "Understanding of basic geometric shapes and their properties.",
+    "Familiarity with the concept of a circle, including radius, diameter, and circumference.",
+    "Knowledge of angles and how to measure them.",
+    "Ability to perform basic algebraic manipulations.",
+    "Understanding of congruence and similarity in geometric figures.",
+  ],
+  keyLearningPoints: [
+    "The angle at the centre of a circle is twice the angle at the circumference.",
+    "Angles in the same segment of a circle are equal.",
+    "The opposite angles of a cyclic quadrilateral sum to 180 degrees.",
+    "The angle in a semicircle is a right angle.",
+    "The perpendicular from the centre of a circle to a chord bisects the chord.",
+  ],
+  misconceptions: [
+    {
+      misconception: "The angle at the centre is always 90 degrees",
+      description:
+        "Some pupils may think the angle at the centre is always 90 degrees. Clarify that it depends on the arc size.",
+    },
+    {
+      misconception: "All angles in a circle are equal",
+      description:
+        "Pupils might assume all angles in a circle are equal. Explain that angles vary based on their position and context.",
+    },
+    {
+      misconception: "A diameter bisects all angles",
+      description:
+        "Pupils may believe a diameter bisects all angles. Highlight that it only bisects the circle into two equal arcs.",
+    },
+  ],
+  keywords: [
+    {
+      keyword: "Theorem",
+      definition:
+        "A statement or proposition that can be proven to be true based on previously established statements.",
+    },
+    {
+      keyword: "Chord",
+      definition:
+        "A straight line connecting two points on a circle's circumference.",
+    },
+    { keyword: "Arc", definition: "A part of the circumference of a circle." },
+    {
+      keyword: "Cyclic quadrilateral",
+      definition:
+        "A quadrilateral with all its vertices on the circumference of a circle.",
+    },
+    {
+      keyword: "Congruence",
+      definition: "The quality of being identical in shape and size.",
+    },
+  ],
+  starterQuiz: [
+    {
+      question: "How many degrees in 2 right angles?",
+      answers: ["180°"],
+      distractors: ["60°", "90°"],
+    },
+    {
+      question:
+        "Two shapes are {{}} if the only difference between them is their size.",
+      answers: ["similar"],
+      distractors: [
+        "No distractors for short answer",
+        "No distractors for short answer",
+      ],
+    },
+    {
+      question:
+        "A fruit stall is having a sale. It sells cherries in boxes of four pairs. How many cherries are there in six packs? There will be {{ }} in six packs.",
+      answers: ["24", "twenty four"],
+      distractors: [
+        "No distractors for short answer",
+        "No distractors for short answer",
+      ],
+    },
+    {
+      question:
+        "In which image is the circumference labelled with a question mark?",
+      answers: [
+        "![image](http://oaknationalacademy-res.cloudinary.com/image/upload/v1703169784/fg4uyx41rfnksbvav2nh.png)",
+      ],
+      distractors: [
+        "![image](http://oaknationalacademy-res.cloudinary.com/image/upload/v1703163380/pz6cn5k4wmowycnjq5am.png)",
+        "![image](http://oaknationalacademy-res.cloudinary.com/image/upload/v1703169784/mr09mrwkqdtk1dvjdoi0.png)",
+      ],
+    },
+    {
+      question:
+        "Complete the statement. Triangle ABC and triangle XYZ are ____________. ![image](http://oaknationalacademy-res.cloudinary.com/image/upload/v1706110974/fukcqeavzcevgjhmm1n4.png)",
+      answers: ["similar as the three interior angles are the same."],
+      distractors: [
+        "congruent as the three interior angles are all the same.",
+        "neither similar nor congruent.",
+      ],
+    },
+  ],
+  cycle1: {
+    title: "Identifying Key Circle Theorems",
+    durationInMinutes: 15,
+    explanation: {
+      spokenExplanation: [
+        "Introduce the concept of circle theorems and their importance in geometry.",
+        "Explain that the angle at the centre of a circle is twice the angle at the circumference.",
+        "Describe how angles in the same segment are equal and why this is significant.",
+        "Discuss the properties of a cyclic quadrilateral, noting that opposite angles sum to 180 degrees.",
+        "Highlight that the angle in a semicircle is a right angle.",
+      ],
+      accompanyingSlideDetails:
+        "Diagrams illustrating the angle at the centre and circumference, angles in the same segment, and a cyclic quadrilateral.",
+      imagePrompt: "circle theorems diagrams",
+      slideText:
+        "Key circle theorems include: angle at the centre is twice that at the circumference, angles in the same segment are equal, cyclic quadrilateral angles sum to 180 degrees.",
+    },
+    checkForUnderstanding: [
+      {
+        question:
+          "What is the relationship between the angle at the centre and the angle at the circumference?",
+        answers: [
+          "The angle at the centre is twice the angle at the circumference.",
+        ],
+        distractors: [
+          "The angle at the centre is half the angle at the circumference.",
+          "The angles are equal.",
+        ],
+      },
+      {
+        question: "What is true about angles in the same segment of a circle?",
+        answers: ["They are equal."],
+        distractors: [
+          "They sum to 90 degrees.",
+          "They vary based on position.",
+        ],
+      },
+    ],
+    practice:
+      "Label the diagrams with the correct circle theorems. Use the information provided to identify and annotate each diagram correctly.",
+    feedback:
+      "Model answer: The diagram of the angle at the centre should show it being twice the angle at the circumference. Angles in the same segment should be marked as equal.",
+  },
+  cycle2: {
+    title: "Applying Circle Theorems",
+    durationInMinutes: 15,
+    explanation: {
+      spokenExplanation: [
+        "Discuss how to use circle theorems to find unknown angles and lengths in various geometric problems.",
+        "Provide examples of using the angle at the centre theorem to find missing angles.",
+        "Show how angles in the same segment theorem can be applied to solve problems.",
+        "Demonstrate solving a problem involving opposite angles in a cyclic quadrilateral.",
+        "Illustrate the application of the angle in a semicircle being a right angle.",
+      ],
+      accompanyingSlideDetails:
+        "Example problems illustrating the application of each circle theorem discussed.",
+      imagePrompt: "circle theorems application examples",
+      slideText:
+        "Apply circle theorems to solve problems involving unknown angles and lengths in geometric figures.",
+    },
+    checkForUnderstanding: [
+      {
+        question:
+          "Which theorem helps find missing angles when given the angle at the circumference?",
+        answers: [
+          "The angle at the centre is twice the angle at the circumference.",
+        ],
+        distractors: [
+          "The angle in a semicircle is a right angle.",
+          "Angles in the same segment are equal.",
+        ],
+      },
+      {
+        question:
+          "How can you use the cyclic quadrilateral theorem in solving problems?",
+        answers: ["Opposite angles sum to 180 degrees."],
+        distractors: [
+          "Adjacent angles are equal.",
+          "All angles are 90 degrees.",
+        ],
+      },
+    ],
+    practice:
+      "Solve a series of problems involving circle theorems to find unknown angles and lengths. Use diagrams to support your solutions.",
+    feedback:
+      "Model answer: For each problem, identify the applicable theorem and show step-by-step calculations leading to the solution. Ensure that diagrams are correctly annotated.",
+  },
+  exitQuiz: [
+    {
+      question:
+        "Work out the length of BM. ![image](http://oaknationalacademy-res.cloudinary.com/image/upload/v1707157889/x0zkhtqmat2qjbeykaep.png)",
+      answers: ["12 cm"],
+      distractors: ["18 cm", "24 cm", "6 cm"],
+    },
+    {
+      question:
+        "The diagram shows a circle with centre O and M is the midpoint of chord AB. Which statement is INCORRECT? ![image](http://oaknationalacademy-res.cloudinary.com/image/upload/v1707157891/jzj1whq88imewdz8moar.png)",
+      answers: ["OA=AM"],
+      distractors: ["AM=0.5AB", "AM=BM", "OA=OB"],
+    },
+    {
+      question:
+        "Which circle theorem is being shown in the diagram? ![image](http://oaknationalacademy-res.cloudinary.com/image/upload/v1707163527/nudpmbhfucdchpb2jvvd.png)",
+      answers: ["A"],
+      distractors: ["B", "C", "D"],
+    },
+    {
+      question:
+        "Which circle theorem is being shown in the diagram? ![image](http://oaknationalacademy-res.cloudinary.com/image/upload/v1707163529/szlbxsyihr4oxzt5xll3.png)",
+      answers: ["D"],
+      distractors: ["A", "B", "C"],
+    },
+    {
+      question:
+        "Which circle theorem is being shown in the diagram? ![image](http://oaknationalacademy-res.cloudinary.com/image/upload/v1707163545/dfdqz5vcslzfnxke8j2g.png)",
+      answers: ["B"],
+      distractors: ["A", "C", "D"],
+    },
+  ],
+};

--- a/packages/aila/src/core/quiz/fixtures/cachedQuizRatings.ts
+++ b/packages/aila/src/core/quiz/fixtures/cachedQuizRatings.ts
@@ -1,0 +1,52 @@
+import type { TestRating } from "../rerankers/RerankerStructuredOutputSchema";
+
+// Fixture 1
+const fixture1: TestRating = {
+  rating: 0.9,
+  justification:
+    "### Question 1: How many degrees in 2 right angles?\n1. Relevance to Prior Knowledge: 10\n   - Directly addresses knowledge of angles, specifically right angles mentioned in the prior knowledge.\n2. Alignment with Key Learning Points: 9\n   - Indirectly aligns as it relates to understanding measurement of angles.\n3. Cognitive Level: 9\n   - Simple recall level, appropriate for introductory assessment.\n4. Clarity and Specificity: 10\n   - Clear and unambiguous.\n5. Potential for Insight: 9\n   - Checks basic knowledge of angles effectively.\n   \nOverall rating is high because it efficiently measures the students' understanding of angles, directly relating to prior knowledge. There’s no ambiguity in the question, and it serves as a good starting point for assessing basic understanding.",
+};
+
+// Fixture 2
+const fixture2: TestRating = {
+  rating: 0.7,
+  justification:
+    "### Question 2: What is the capital of France?\n1. Relevance to Prior Knowledge: 8\n   - Common general knowledge question.\n2. Alignment with Key Learning Points: 7\n   - Not directly related to the lesson's key points.\n3. Cognitive Level: 6\n   - Requires recall of factual information.\n4. Clarity and Specificity: 9\n   - Clear and straightforward.\n5. Potential for Insight: 6\n   - Limited insight into deeper understanding.",
+};
+
+// Fixture 3
+const fixture3: TestRating = {
+  rating: 0.5,
+  justification:
+    "### Question 3: Explain the theory of relativity.\n1. Relevance to Prior Knowledge: 5\n   - Advanced topic, not covered in prior lessons.\n2. Alignment with Key Learning Points: 4\n   - Not aligned with current learning objectives.\n3. Cognitive Level: 8\n   - Requires higher-order thinking.\n4. Clarity and Specificity: 5\n   - Complex and potentially confusing.\n5. Potential for Insight: 7\n   - Offers insight into advanced understanding if answered well.",
+};
+
+// Fixture 4
+const fixture4: TestRating = {
+  rating: 0.3,
+  justification:
+    "### Question 4: What is the color of the sky?\n1. Relevance to Prior Knowledge: 3\n   - Too basic for the current level.\n2. Alignment with Key Learning Points: 2\n   - Not relevant to the lesson.\n3. Cognitive Level: 2\n   - Very low cognitive demand.\n4. Clarity and Specificity: 10\n   - Extremely clear.\n5. Potential for Insight: 1\n   - Provides no real insight.",
+};
+
+// Fixture 5
+const fixture5: TestRating = {
+  rating: 0.8,
+  justification:
+    "### Question 5: Solve for x in the equation 2x + 3 = 7.\n1. Relevance to Prior Knowledge: 9\n   - Builds on algebraic concepts previously taught.\n2. Alignment with Key Learning Points: 8\n   - Directly related to current learning objectives.\n3. Cognitive Level: 7\n   - Requires application of knowledge.\n4. Clarity and Specificity: 9\n   - Clear and specific.\n5. Potential for Insight: 8\n   - Good measure of understanding of basic algebra.",
+};
+
+// Fixture 6
+const fixture6: TestRating = {
+  rating: 0.6,
+  justification:
+    "### Question 6: Describe the process of photosynthesis.\n1. Relevance to Prior Knowledge: 6\n   - Partially covered in previous lessons.\n2. Alignment with Key Learning Points: 5\n   - Somewhat related to current objectives.\n3. Cognitive Level: 7\n   - Requires understanding and explanation.\n4. Clarity and Specificity: 6\n   - Moderately clear.\n5. Potential for Insight: 7\n   - Provides insight into understanding of biological processes.",
+};
+
+export const cachedQuizRatings: TestRating[] = [
+  fixture1,
+  fixture2,
+  fixture3,
+  fixture4,
+  fixture5,
+  fixture6,
+];

--- a/packages/aila/src/core/quiz/fullservices/BaseFullQuizService.ts
+++ b/packages/aila/src/core/quiz/fullservices/BaseFullQuizService.ts
@@ -1,0 +1,71 @@
+import { aiLogger } from "@oakai/logger";
+import type { z } from "zod";
+
+import type {
+  AilaRagRelevantLesson,
+  LooseLessonPlan,
+  QuizQuestion,
+} from "../../../protocol/schema";
+import type { BaseSchema, BaseType } from "../ChoiceModels";
+import type {
+  AilaQuizGeneratorService,
+  AilaQuizReranker,
+  FullQuizService,
+  quizPatchType,
+  QuizSelector,
+} from "../interfaces";
+
+const log = aiLogger("aila:quiz");
+
+export abstract class BaseFullQuizService implements FullQuizService {
+  public abstract quizSelector: QuizSelector<BaseType>;
+  public abstract quizReranker: AilaQuizReranker<z.ZodType<BaseType>>;
+  public abstract quizGenerators: AilaQuizGeneratorService[];
+  // TODO: MG - does having ailaRagRelevantLessons as a default parameter work? It feels a bit hacky.
+  public async createBestQuiz(
+    quizType: quizPatchType,
+    lessonPlan: LooseLessonPlan,
+    ailaRagRelevantLessons: AilaRagRelevantLesson[] = [],
+  ): Promise<QuizQuestion[]> {
+    const quizPromises = this.quizGenerators.map((quizGenerator) => {
+      if (quizType === "/starterQuiz") {
+        return quizGenerator.generateMathsStarterQuizPatch(
+          lessonPlan,
+          ailaRagRelevantLessons,
+        );
+      } else if (quizType === "/exitQuiz") {
+        return quizGenerator.generateMathsExitQuizPatch(
+          lessonPlan,
+          ailaRagRelevantLessons,
+        );
+      }
+      throw new Error(`Invalid quiz type: ${quizType as string}`);
+    });
+
+    const quizArrays = await Promise.all(quizPromises);
+    const quizzes = quizArrays.flat();
+    if (!this.quizReranker.ratingSchema) {
+      throw new Error("Reranker rating schema is undefined");
+    }
+    // TODO: GCLOMAX - This is changed to be cached.
+    const quizRankings = await this.quizReranker.evaluateQuizArray(
+      quizzes,
+      lessonPlan,
+      this.quizReranker.ratingSchema,
+      quizType,
+    );
+    // this is hacky, but typescript gets annoyed with the zod and inference stuff.
+    if (!quizRankings[0]) {
+      log.error(
+        `Quiz rankings are undefined. No quiz of quiz type: ${quizType} found for lesson plan: ${lessonPlan.title}`,
+      );
+      return [];
+    }
+    const parsedRankings = quizRankings.map((ranking) =>
+      this.quizReranker.ratingSchema!.parse(ranking),
+    );
+
+    const bestQuiz = this.quizSelector.selectBestQuiz(quizzes, parsedRankings);
+    return bestQuiz;
+  }
+}

--- a/packages/aila/src/core/quiz/fullservices/BasedOnQuizService.test.ts
+++ b/packages/aila/src/core/quiz/fullservices/BasedOnQuizService.test.ts
@@ -1,0 +1,70 @@
+import { aiLogger } from "@oakai/logger";
+
+import type { QuizPath } from "../../../protocol/schema";
+import { CircleTheoremLesson } from "../fixtures/CircleTheoremsExampleOutput";
+import { AilaQuizFactory } from "../generators/AilaQuizGeneratorFactory";
+import { BasedOnQuizService } from "./BasedOnQuizService";
+
+const log = aiLogger("quiz");
+
+describe("BasedOnQuizService", () => {
+  let quizService: BasedOnQuizService;
+
+  beforeEach(() => {
+    quizService = new BasedOnQuizService();
+  });
+
+  it("should initialize with correct dependencies", () => {
+    expect(quizService.quizGenerators).toBeDefined();
+    expect(quizService.quizGenerators.length).toBe(1);
+    expect(quizService.quizReranker).toBeDefined();
+    expect(quizService.quizSelector).toBeDefined();
+  });
+
+  it("should have a basedOnRag quiz generator", () => {
+    const expectedGenerator = AilaQuizFactory.createQuizGenerator("basedOnRag");
+    expect(quizService.quizGenerators[0]).toBeInstanceOf(
+      expectedGenerator.constructor,
+    );
+  });
+
+  describe("createBestQuiz", () => {
+    it("should create a starter quiz", async () => {
+      const quiz = await quizService.createBestQuiz(
+        "/starterQuiz" as QuizPath,
+        CircleTheoremLesson,
+      );
+      log.info("QUIZ BELOW");
+      log.info(JSON.stringify(quiz));
+      expect(quiz).toBeDefined();
+      expect(Array.isArray(quiz)).toBe(true);
+      expect(quiz[0]).toHaveProperty("question");
+      expect(quiz[0]).toHaveProperty("answers");
+      expect(quiz[0]).toHaveProperty("distractors");
+    });
+
+    it("should create an exit quiz", async () => {
+      const quiz = await quizService.createBestQuiz(
+        "/exitQuiz" as QuizPath,
+        CircleTheoremLesson,
+      );
+
+      expect(quiz).toBeDefined();
+      expect(Array.isArray(quiz)).toBe(true);
+      //   Once corrected make it length 6.
+      //   expect(quiz.length).toBe(1);
+      expect(quiz[0]).toHaveProperty("question");
+      expect(quiz[0]).toHaveProperty("answers");
+      expect(quiz[0]).toHaveProperty("distractors");
+    });
+
+    it("should handle invalid quiz paths", async () => {
+      await expect(
+        quizService.createBestQuiz(
+          "/invalidQuiz" as QuizPath,
+          CircleTheoremLesson,
+        ),
+      ).rejects.toThrow();
+    });
+  });
+});

--- a/packages/aila/src/core/quiz/fullservices/BasedOnQuizService.ts
+++ b/packages/aila/src/core/quiz/fullservices/BasedOnQuizService.ts
@@ -1,0 +1,20 @@
+import type { z } from "zod";
+
+import type { BaseSchema, BaseType } from "../ChoiceModels";
+import { AilaQuizFactory } from "../generators/AilaQuizGeneratorFactory";
+import type { AilaQuizGeneratorService } from "../interfaces";
+import type { AilaQuizReranker, QuizSelector } from "../interfaces";
+import { AilaQuizRerankerFactoryImpl } from "../rerankers/AilaQuizRerankerFactory";
+import { QuizSelectorFactoryImpl } from "../selectors/QuizSelectorFactory";
+import { BaseFullQuizService } from "./BaseFullQuizService";
+
+export class BasedOnQuizService extends BaseFullQuizService {
+  public quizGenerators: AilaQuizGeneratorService[] = [
+    AilaQuizFactory.createQuizGenerator("basedOnRag"),
+  ];
+  public quizReranker: AilaQuizReranker<z.ZodType<BaseType>> =
+    new AilaQuizRerankerFactoryImpl().createAilaQuizReranker("return-first");
+
+  public quizSelector: QuizSelector<BaseType> =
+    new QuizSelectorFactoryImpl().createQuizSelector("simple");
+}

--- a/packages/aila/src/core/quiz/fullservices/CompositeFullQuizService.ts
+++ b/packages/aila/src/core/quiz/fullservices/CompositeFullQuizService.ts
@@ -1,0 +1,26 @@
+import type { z } from "zod";
+
+import type { BaseSchema, BaseType } from "../ChoiceModels";
+import type {
+  AilaQuizGeneratorService,
+  AilaQuizReranker,
+  QuizSelector,
+} from "../interfaces";
+import { BaseFullQuizService } from "./BaseFullQuizService";
+
+export class CompositeFullQuizService extends BaseFullQuizService {
+  public quizSelector: QuizSelector<BaseType>;
+  public quizReranker: AilaQuizReranker<z.ZodType<BaseType>>;
+  public quizGenerators: AilaQuizGeneratorService[];
+
+  constructor(
+    generators: AilaQuizGeneratorService[],
+    selector: QuizSelector<BaseType>,
+    reranker: AilaQuizReranker<z.ZodType<BaseType>>,
+  ) {
+    super();
+    this.quizGenerators = generators;
+    this.quizSelector = selector;
+    this.quizReranker = reranker;
+  }
+}

--- a/packages/aila/src/core/quiz/fullservices/CompositeFullQuizServiceBuilder.test.ts
+++ b/packages/aila/src/core/quiz/fullservices/CompositeFullQuizServiceBuilder.test.ts
@@ -1,0 +1,84 @@
+import { aiLogger } from "@oakai/logger";
+
+import type { AilaRagRelevantLesson } from "../../../protocol/schema";
+import { CircleTheoremLesson } from "../fixtures/CircleTheoremsExampleOutput";
+import { testRatingSchema } from "../rerankers/RerankerStructuredOutputSchema";
+import type { QuizBuilderSettings } from "../schema";
+import { CompositeFullQuizServiceBuilder } from "./CompositeFullQuizServiceBuilder";
+
+const log = aiLogger("aila");
+
+describe("CompositeFullQuizServiceBuilder", () => {
+  jest.setTimeout(60000);
+  it("should build a CompositeFullQuizService", () => {
+    const builder = new CompositeFullQuizServiceBuilder();
+    const settings: QuizBuilderSettings = {
+      quizRatingSchema: testRatingSchema,
+      quizSelector: "simple",
+      quizReranker: "return-first",
+      quizGenerators: ["basedOnRag"],
+    };
+    const service = builder.build(settings);
+    expect(service).toBeDefined();
+    expect(service.quizSelector).toBeDefined();
+    expect(service.quizReranker).toBeDefined();
+    expect(service.quizGenerators).toBeDefined();
+    expect(service.quizGenerators.length).toBe(1);
+    expect(service.quizGenerators[0]).toBeDefined();
+  });
+
+  it("Should work with a simple quiz selector", async () => {
+    const builder = new CompositeFullQuizServiceBuilder();
+    const settings: QuizBuilderSettings = {
+      quizRatingSchema: testRatingSchema,
+      quizSelector: "simple",
+      quizReranker: "return-first",
+      quizGenerators: ["basedOnRag"],
+    };
+    const service = builder.build(settings);
+    const quiz = await service.createBestQuiz(
+      "/starterQuiz",
+      CircleTheoremLesson,
+    );
+    expect(quiz).toBeDefined();
+    expect(quiz.length).toBeGreaterThan(0);
+    expect(quiz[0]?.question).toBeDefined();
+    expect(quiz[0]?.answers).toBeDefined();
+    expect(quiz[0]?.distractors).toBeDefined();
+    log.info(JSON.stringify(quiz, null, 2));
+  });
+
+  it("Should work with a rag quiz generator", async () => {
+    const mockRelevantLessons: AilaRagRelevantLesson[] = [
+      { lessonPlanId: "clna7k8j400egp4qxrqmjx0qo", title: "test-title-2" },
+      { lessonPlanId: "clna7k8kq00fip4qxsjvrmykv", title: "test-title-3" },
+      { lessonPlanId: "clna7k8pq00j1p4qxa9euac1c", title: "test-title-4" },
+      { lessonPlanId: "clna7k8zr00qfp4qx44fdvikl", title: "test-title-5" },
+      { lessonPlanId: "clna7k93700sap4qx741wdrz4", title: "test-title-6" },
+      { lessonPlanId: "clna7k98j00vup4qx9nyfjtpm", title: "test-title-7" },
+      { lessonPlanId: "clna7k8zr00qfp4qx44fdvikl", title: "test-title-8" },
+      { lessonPlanId: "clna7k93700sap4qx741wdrz4", title: "test-title-9" },
+      { lessonPlanId: "clna7k98j00vup4qx9nyfjtpm", title: "test-title-10" },
+    ];
+
+    const builder = new CompositeFullQuizServiceBuilder();
+    const settings: QuizBuilderSettings = {
+      quizRatingSchema: testRatingSchema,
+      quizSelector: "simple",
+      quizReranker: "return-first",
+      quizGenerators: ["basedOnRag"],
+    };
+    const service = builder.build(settings);
+    const quiz = await service.createBestQuiz(
+      "/starterQuiz",
+      CircleTheoremLesson,
+      mockRelevantLessons,
+    );
+    expect(quiz).toBeDefined();
+    expect(quiz.length).toBeGreaterThan(0);
+    expect(quiz[0]?.question).toBeDefined();
+    expect(quiz[0]?.answers).toBeDefined();
+    expect(quiz[0]?.distractors).toBeDefined();
+    log.info(JSON.stringify(quiz, null, 2));
+  });
+});

--- a/packages/aila/src/core/quiz/fullservices/CompositeFullQuizServiceBuilder.ts
+++ b/packages/aila/src/core/quiz/fullservices/CompositeFullQuizServiceBuilder.ts
@@ -1,0 +1,40 @@
+import { aiLogger } from "@oakai/logger";
+
+import { AilaQuizFactory } from "../generators/AilaQuizGeneratorFactory";
+import type {
+  AilaQuizGeneratorService,
+  FullQuizService,
+  QuizSelectorFactory,
+} from "../interfaces";
+import { AilaQuizRerankerFactoryImpl } from "../rerankers/AilaQuizRerankerFactory";
+import type { QuizBuilderSettings } from "../schema";
+import { QuizSelectorFactoryImpl } from "../selectors/QuizSelectorFactory";
+import { CompositeFullQuizService } from "./CompositeFullQuizService";
+
+const log = aiLogger("quiz");
+
+export class CompositeFullQuizServiceBuilder {
+  private readonly generatorFactory: AilaQuizFactory = new AilaQuizFactory();
+  private readonly selectorFactory: QuizSelectorFactory =
+    new QuizSelectorFactoryImpl();
+  private readonly rerankerFactory: AilaQuizRerankerFactoryImpl =
+    new AilaQuizRerankerFactoryImpl();
+  public build(settings: QuizBuilderSettings): FullQuizService {
+    const generatorArray: AilaQuizGeneratorService[] = [];
+
+    const selector = this.selectorFactory.createQuizSelector(
+      settings.quizSelector,
+    );
+
+    const reranker = this.rerankerFactory.createAilaQuizReranker(
+      settings.quizReranker,
+    );
+
+    for (const generator of settings.quizGenerators) {
+      generatorArray.push(AilaQuizFactory.createQuizGenerator(generator));
+    }
+
+    log.info("Building Composite full quiz service with settings:", settings);
+    return new CompositeFullQuizService(generatorArray, selector, reranker);
+  }
+}

--- a/packages/aila/src/core/quiz/generators/AilaQuizGeneratorFactory.ts
+++ b/packages/aila/src/core/quiz/generators/AilaQuizGeneratorFactory.ts
@@ -1,0 +1,19 @@
+import type { BaseQuizGenerator } from "./BaseQuizGenerator";
+import { BasedOnRagQuizGenerator } from "./BasedOnRagQuizGenerator";
+
+// Factory class
+
+export class AilaQuizFactory {
+  static createQuizGenerator(
+    type: "rag" | "ml" | "basedOnRag",
+  ): BaseQuizGenerator {
+    switch (type) {
+      case "rag":
+        throw new Error("RAG quiz generator not implemented");
+      case "ml":
+        throw new Error("ML quiz generator not implemented");
+      case "basedOnRag":
+        return new BasedOnRagQuizGenerator();
+    }
+  }
+}

--- a/packages/aila/src/core/quiz/generators/BaseQuizGenerator.ts
+++ b/packages/aila/src/core/quiz/generators/BaseQuizGenerator.ts
@@ -1,0 +1,478 @@
+import { Client } from "@elastic/elasticsearch";
+import type { SearchHitsMetadata } from "@elastic/elasticsearch/lib/api/types";
+import { prisma } from "@oakai/db";
+import { aiLogger } from "@oakai/logger";
+import { CohereClient } from "cohere-ai";
+import type { RerankResponseResultsItem } from "cohere-ai/api/types";
+import { z } from "zod";
+
+import type { JsonPatchDocument } from "../../../protocol/jsonPatchProtocol";
+import {
+  JsonPatchDocumentSchema,
+  PatchQuiz,
+} from "../../../protocol/jsonPatchProtocol";
+import type {
+  AilaRagRelevantLesson,
+  LooseLessonPlan,
+  Quiz,
+  QuizOperationType,
+  QuizPath,
+  QuizQuestion,
+} from "../../../protocol/schema";
+import { QuizQuestionSchema } from "../../../protocol/schema";
+import { ElasticLessonQuizLookup } from "../LessonSlugQuizMapping";
+import type {
+  AilaQuizGeneratorService,
+  CustomHit,
+  CustomSource,
+  LessonSlugQuizLookup,
+  QuizQuestionTextOnlySource,
+  SimplifiedResult,
+} from "../interfaces";
+import { CohereReranker } from "../rerankers";
+import type { SearchResponseBody } from "../types";
+
+const log = aiLogger("aila:quiz");
+
+// Base abstract class
+// Quiz generator takes a lesson plan and returns a quiz object.
+// Quiz rerankers take a lesson plan and returns a list of quiz objects ranked by suitability.
+// Quiz selectors take a list of quiz objects and rankings and select the best one acording to some criteria or logic defined by a rating function.
+export abstract class BaseQuizGenerator implements AilaQuizGeneratorService {
+  protected client: Client;
+  protected cohere: CohereClient;
+  protected rerankService: CohereReranker;
+  protected quizLookup: LessonSlugQuizLookup;
+
+  constructor() {
+    if (
+      !process.env.I_DOT_AI_ELASTIC_CLOUD_ID ||
+      !process.env.I_DOT_AI_ELASTIC_KEY
+    ) {
+      throw new Error(
+        "Environment variables for Elastic Cloud ID and API Key must be set",
+      );
+    }
+    this.client = new Client({
+      cloud: {
+        id: process.env.I_DOT_AI_ELASTIC_CLOUD_ID,
+      },
+
+      auth: {
+        apiKey: process.env.I_DOT_AI_ELASTIC_KEY,
+      },
+    });
+
+    this.cohere = new CohereClient({
+      token: process.env.COHERE_API_KEY as string,
+    });
+
+    // This can be changed to use our hosted models - use this for dev simplicity.
+    this.rerankService = new CohereReranker();
+    this.quizLookup = new ElasticLessonQuizLookup();
+  }
+
+  // The below is overly bloated and a midstep in refactoring.
+  abstract generateMathsStarterQuizPatch(
+    lessonPlan: LooseLessonPlan,
+    ailaRagRelevantLessons?: AilaRagRelevantLesson[],
+  ): Promise<Quiz[]>;
+  abstract generateMathsExitQuizPatch(
+    lessonPlan: LooseLessonPlan,
+    ailaRagRelevantLessons?: AilaRagRelevantLesson[],
+  ): Promise<Quiz[]>;
+
+  public async generateMathsQuizFromRagPlanId(
+    planIds: string,
+  ): Promise<JsonPatchDocument> {
+    const lessonSlugs = await this.getLessonSlugFromPlanId(planIds);
+    const lessonSlugList = lessonSlugs ? [lessonSlugs] : [];
+    const customIds = await this.lessonSlugToQuestionIdSearch(lessonSlugList);
+    const patch = await this.patchFromCustomIDs(customIds);
+    return patch;
+  }
+
+  public async getLessonSlugFromPlanId(planId: string): Promise<string | null> {
+    try {
+      const result = await prisma.lessonPlan.findUnique({
+        where: { id: planId },
+        select: {
+          lesson: true,
+        },
+      });
+
+      if (!result) {
+        log.warn("Lesson plan could not be retrieved for planId: ", planId);
+        return null;
+      }
+      return result?.lesson.slug;
+    } catch (error) {
+      log.error("Error fetching lesson slug:", error);
+      return null;
+    }
+  }
+
+  public async lessonSlugToQuestionIdSearch(
+    lessonSlugs: string[],
+  ): Promise<string[]> {
+    // Converts a lesson slug to a question ID via searching in index
+    try {
+      const response = await this.client.search<CustomSource>({
+        index: "oak-vector",
+        body: {
+          query: {
+            bool: {
+              must: [
+                { exists: { field: "metadata.lessonSlug" } },
+                { exists: { field: "metadata.questionUid" } },
+                {
+                  terms: {
+                    "metadata.lessonSlug.keyword": lessonSlugs,
+                  },
+                },
+              ],
+            },
+          },
+        },
+      });
+
+      return response.hits.hits
+        .map((hit) => hit._source?.metadata.questionUid)
+        .filter((id): id is string => id !== undefined);
+    } catch (error) {
+      log.error("Error searching for questions:", error);
+      return [];
+    }
+  }
+
+  public async lessonSlugToQuestionIdsLookupTable(
+    lessonSlug: string,
+    quizType: QuizPath,
+  ): Promise<string[]> {
+    if (quizType === "/starterQuiz") {
+      return await this.quizLookup.getStarterQuiz(lessonSlug);
+    } else if (quizType === "/exitQuiz") {
+      return await this.quizLookup.getExitQuiz(lessonSlug);
+    }
+    throw new Error("Invalid quiz type");
+  }
+
+  public async patchFromCustomIDs(
+    customIds: string[],
+    quizType: QuizPath = "/starterQuiz",
+  ): Promise<JsonPatchDocument> {
+    // Get the questions by searching for the questions with the custom IDs
+    const quizQuestions: Quiz =
+      await this.questionArrayFromCustomIds(customIds);
+    const patch = this.quizToJsonPatch(quizQuestions, quizType);
+    return patch;
+  }
+  public async questionArrayFromCustomIds(
+    questionUids: string[],
+  ): Promise<QuizQuestion[]> {
+    const response = await this.client.search<QuizQuestionTextOnlySource>({
+      index: "quiz-questions-text-only",
+      body: {
+        query: {
+          bool: {
+            must: [
+              {
+                terms: {
+                  "metadata.questionUid.keyword": questionUids,
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+    if (!response.hits.hits[0]?._source) {
+      log.error("No questions found for questionUids: ", questionUids);
+      return Promise.resolve([]);
+    } else {
+      // Gives us an array of quiz questions or null, which are then filtered out.
+      const filteredQuizQuestions: QuizQuestion[] = response.hits.hits
+        .map((hit) => {
+          if (!hit._source) {
+            log.error("Hit source is undefined");
+            return null;
+          }
+          const quizQuestion = this.parseQuizQuestion(hit._source.text);
+          return quizQuestion;
+        })
+        .filter((item): item is QuizQuestion => item !== null);
+      return Promise.resolve(filteredQuizQuestions);
+    }
+  }
+
+  public async questionArrayFromPlanIdLookUpTable(
+    planId: string,
+    quizType: QuizPath,
+  ): Promise<QuizQuestion[]> {
+    const lessonSlug = await this.getLessonSlugFromPlanId(planId);
+    if (!lessonSlug) {
+      throw new Error("Lesson slug not found for planId: " + planId);
+    }
+    const questionIds = await this.lessonSlugToQuestionIdsLookupTable(
+      lessonSlug,
+      quizType,
+    );
+
+    const quizQuestions = await this.questionArrayFromCustomIds(questionIds);
+    return quizQuestions;
+  }
+
+  public async questionArrayFromPlanId(
+    planId: string,
+    quizType: QuizPath = "/starterQuiz",
+  ): Promise<QuizQuestion[]> {
+    return await this.questionArrayFromPlanIdLookUpTable(planId, quizType);
+  }
+
+  public async searchQuestions<T>(
+    client: Client,
+    index: string,
+    questionUids: string[],
+  ): Promise<SearchResponseBody<T>> {
+    // Retrieves questions by questionUids
+    const response = await client.search<T>({
+      index: index,
+      body: {
+        query: {
+          bool: {
+            must: [
+              {
+                terms: {
+                  "metadata.questionUid.keyword": questionUids,
+                },
+              },
+            ],
+          },
+        },
+      },
+    });
+    return response;
+  }
+  protected unpackLessonPlanForRecommender(
+    lessonPlan: LooseLessonPlan,
+    lessonPlanRerankerFields: string[] = [
+      "title",
+      "topic",
+      "learningOutcome",
+      "keyLearningPoints",
+    ],
+  ): string {
+    const unpackedList: string[] = [];
+
+    for (const field of lessonPlanRerankerFields) {
+      const content = lessonPlan[field as keyof LooseLessonPlan];
+
+      if (Array.isArray(content)) {
+        unpackedList.push(
+          ...content.filter((item): item is string => typeof item === "string"),
+        );
+      } else if (typeof content === "string") {
+        unpackedList.push(content);
+      }
+    }
+    return unpackedList.join("");
+  }
+  protected transformHits(hits: CustomHit[]): SimplifiedResult[] {
+    return hits
+      .map((hit) => {
+        const source = hit._source;
+
+        // Check if the required fields exist
+        if (
+          typeof source.text !== "string" ||
+          typeof source.metadata?.custom_id !== "string"
+        ) {
+          log.warn("Hit is missing required fields:", hit);
+          return null;
+        }
+
+        return {
+          text: source.text,
+          custom_id: source.metadata.custom_id,
+        };
+      })
+      .filter((item): item is SimplifiedResult => item !== null);
+  }
+
+  private processResponse<T extends CustomSource>(
+    response: SearchResponseBody<T>,
+  ) {
+    return response.hits.hits.map((hit) => {
+      if (!hit._source) {
+        log.error("Hit source is undefined");
+        return null;
+      }
+      const parsedQuestion = this.parseQuizQuestion(hit._source.text);
+
+      return {
+        questionUid: hit._source.metadata.questionUid,
+        ...(parsedQuestion
+          ? { quizQuestion: parsedQuestion }
+          : { text: hit._source.text }),
+      };
+    });
+  }
+  // TODO: GCLOMAX abstract this into a search service / class so can easily swap out for hybrid once re-ingested.
+  protected async searchWithBM25(
+    index: string,
+    field: string,
+    query: string,
+    _size: number = 10,
+  ): Promise<SearchHitsMetadata<CustomHit>> {
+    try {
+      log.info(`Searching index: ${index}, field: ${field}, query: ${query}`);
+      const response = await this.client.search<CustomHit>({
+        index: "oak-vector",
+        query: {
+          bool: {
+            must: [{ match: { text: query } }],
+            filter: [{ exists: { field: "metadata.is_question_description" } }],
+          },
+        },
+      });
+
+      if (!response.hits) {
+        throw new Error("No hits property in the search response");
+      }
+
+      return response.hits;
+    } catch (error) {
+      log.error("Error searching Elasticsearch:", error);
+      if (error instanceof Error) {
+        log.error("Error message:", error.message);
+        log.error("Error stack:", error.stack);
+      }
+      throw error;
+    }
+  }
+  // TODO: GCLOMAX abstract this into the reranker service / class so can easily swap out for hybrid once re-ingested.
+  protected async rerankDocuments(
+    query: string,
+    docs: SimplifiedResult[],
+    topN: number = 10,
+  ) {
+    // conforming to https://github.com/cohere-ai/cohere-typescript/blob/2e1c087ed0ec7eacd39ad062f7293fb15e453f33/src/api/client/requests/RerankRequest.ts#L15
+    try {
+      const jsonDocs = docs.map((doc) =>
+        JSON.stringify({
+          text: doc.text,
+          custom_id: doc.custom_id,
+        }),
+      );
+      // this should have na error below - https://github.com/cohere-ai/cohere-typescript/blob/499bde51cee5d1f2ea2068580f938123297515f9/src/api/client/requests/RerankRequest.ts#L31
+      const response = await this.cohere.rerank({
+        model: "rerank-english-v2.0",
+        query: query,
+        documents: jsonDocs,
+        topN: topN,
+        //@ts-expect-error Cohere client has some weirdness - should update version.
+        rankFields: ["text"],
+        returnDocuments: true,
+      });
+
+      log.info("Ranked documents:");
+      log.info(response.results);
+      return response.results;
+    } catch (error) {
+      log.error("Error during reranking:", error);
+      return [];
+    }
+  }
+  protected extractCustomId(doc: RerankResponseResultsItem): string {
+    try {
+      const parsedText = JSON.parse(doc.document?.text || "");
+      if (
+        typeof parsedText !== "object" ||
+        parsedText === null ||
+        !("custom_id" in parsedText)
+      ) {
+        throw new Error("Parsed text is not an object or missing custom_id");
+      }
+
+      throw new Error("Invalid document format");
+    } catch (error) {
+      log.error("Error in extractCustomId:", error);
+      throw new Error("Failed to extract custom_id");
+    }
+  }
+  protected async rerankAndExtractCustomIds(
+    hits: CustomHit[],
+    query: string,
+  ): Promise<string[]> {
+    const simplifiedResults = this.transformHits(hits);
+    const rerankedResults = await this.rerankDocuments(
+      query,
+      simplifiedResults,
+    );
+    return rerankedResults.map(this.extractCustomId);
+  }
+
+  protected async retrieveAndProcessQuestions(
+    customIds: string[],
+  ): Promise<QuizQuestion[]> {
+    const quizQuestions = await this.questionArrayFromCustomIds(customIds);
+    return quizQuestions;
+  }
+
+  protected quizToJsonPatch(
+    quizQuestions: QuizQuestion[],
+    quizType: QuizPath = "/starterQuiz",
+    quizOperationType: QuizOperationType = "add",
+  ): JsonPatchDocument {
+    const quizPatchObject: z.infer<typeof PatchQuiz> = {
+      op: quizOperationType,
+      path: quizType,
+      value: quizQuestions,
+    };
+
+    const result = PatchQuiz.safeParse(quizPatchObject);
+    if (!result.success) {
+      log.error("Failed to validate patch object");
+      log.error("Failed Object: ", JSON.stringify(quizPatchObject, null, 2));
+      log.error("Validation errors:", result.error);
+      throw new Error("Failed to validate patch object");
+    }
+    const patch: JsonPatchDocument = {
+      type: "patch",
+      reasoning:
+        "adding maths quiz because i need to teach the kids about this",
+      value: quizPatchObject,
+    };
+
+    const jsonPatchParseResult = JsonPatchDocumentSchema.safeParse(patch);
+    if (!jsonPatchParseResult.success) {
+      log.error("Failed to validate json patch object");
+      log.error("Validation errors:", jsonPatchParseResult.error);
+      log.error("Failed Object: ", JSON.stringify(patch, null, 2));
+      throw new Error("Failed to validate json patch object");
+    }
+    log.info("MATHS_EXIT_QUIZ_FOLLOWING");
+    log.info("FULL_QUIZ_PATCH: ", patch);
+    return patch;
+  }
+  private parseQuizQuestion(jsonString: string): QuizQuestion | null {
+    try {
+      const data = JSON.parse(jsonString);
+
+      return QuizQuestionSchema.parse(data);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        log.error("Validation error:", error.errors);
+      } else if (error instanceof SyntaxError) {
+        log.error(
+          "OFFENDING JSON STRING: ",
+          JSON.stringify(jsonString, null, 2),
+        );
+        log.error("JSON parsing error:", error.message);
+      } else {
+        log.error("An unexpected error occurred:", error);
+      }
+      return null;
+    }
+  }
+}

--- a/packages/aila/src/core/quiz/generators/BasedOnRagQuizGenerator.test.ts
+++ b/packages/aila/src/core/quiz/generators/BasedOnRagQuizGenerator.test.ts
@@ -1,0 +1,26 @@
+import { aiLogger } from "@oakai/logger";
+
+import type { LooseLessonPlan } from "../../../protocol/schema";
+import { QuizSchema } from "../../../protocol/schema";
+import { CircleTheoremLesson } from "../fixtures/CircleTheoremsExampleOutput";
+import { BasedOnRagQuizGenerator } from "./BasedOnRagQuizGenerator";
+
+const log = aiLogger("aila");
+
+describe("BasedOnRagQuizGenerator", () => {
+  let quizGenerator: BasedOnRagQuizGenerator;
+  let mockLessonPlan: LooseLessonPlan;
+
+  beforeEach(() => {
+    quizGenerator = new BasedOnRagQuizGenerator();
+    mockLessonPlan = CircleTheoremLesson;
+  });
+
+  it("should generate a valid quiz", async () => {
+    const quiz =
+      await quizGenerator.generateMathsStarterQuizPatch(mockLessonPlan);
+    log.info(JSON.stringify(quiz));
+    log.info("QUIZ ABOVE");
+    expect(QuizSchema.safeParse(quiz[0]).success).toBe(true);
+  });
+});

--- a/packages/aila/src/core/quiz/generators/BasedOnRagQuizGenerator.ts
+++ b/packages/aila/src/core/quiz/generators/BasedOnRagQuizGenerator.ts
@@ -1,0 +1,54 @@
+import { aiLogger } from "@oakai/logger";
+
+import type {
+  AilaRagRelevantLesson,
+  LooseLessonPlan,
+  Quiz,
+} from "../../../protocol/schema";
+import { BaseQuizGenerator } from "./BaseQuizGenerator";
+
+const log = aiLogger("aila:quiz");
+
+// RAG-based Quiz Generator
+export class BasedOnRagQuizGenerator extends BaseQuizGenerator {
+  //   This parameter is not used but we keep it for consistency with the other quiz generators
+  async generateMathsStarterQuizPatch(
+    lessonPlan: LooseLessonPlan,
+    _ailaRagRelevantLessons?: AilaRagRelevantLesson[],
+  ): Promise<Quiz[]> {
+    // If quiz is basedOn, give them the default quiz as a starter quiz
+    log.info(
+      "Generating maths starter quiz for lesson plan id:",
+      lessonPlan.basedOn?.id,
+    );
+    if (!lessonPlan.basedOn?.id) {
+      // Generators should return an empty array if they cannot generate a quiz.
+      log.info("Lesson plan basedOn is undefined. Returning empty array.");
+      return [];
+    }
+    return [
+      await this.questionArrayFromPlanId(
+        lessonPlan.basedOn?.id,
+        "/starterQuiz",
+      ),
+    ];
+  }
+
+  async generateMathsExitQuizPatch(
+    lessonPlan: LooseLessonPlan,
+    _ailaRagRelevantLessons?: AilaRagRelevantLesson[],
+  ): Promise<Quiz[]> {
+    // If quiz is basedOn, give them the default quiz as an exit quiz
+    log.info(
+      "Generating maths exit quiz for lesson plan id:",
+      lessonPlan.basedOn?.id,
+    );
+    if (!lessonPlan.basedOn?.id) {
+      log.info("Lesson plan basedOn is undefined. Returning empty array.");
+      return [];
+    }
+    return [
+      await this.questionArrayFromPlanId(lessonPlan.basedOn?.id, "/exitQuiz"),
+    ];
+  }
+}

--- a/packages/aila/src/core/quiz/interfaces.ts
+++ b/packages/aila/src/core/quiz/interfaces.ts
@@ -1,0 +1,190 @@
+import type { RerankResponseResultsItem } from "cohere-ai/api/types";
+import type * as z from "zod";
+
+import type { JsonPatchDocument } from "../../protocol/jsonPatchProtocol";
+import type {
+  AilaRagRelevantLesson,
+  LooseLessonPlan,
+  Quiz,
+  QuizPath,
+  QuizQuestion,
+} from "../../protocol/schema";
+import type {
+  BaseType,
+  MaxRatingFunctionApplier,
+  RatingFunction,
+} from "./ChoiceModels";
+import type {
+  QuizRecommenderType,
+  QuizRerankerType,
+  QuizSelectorType,
+  QuizServiceSettings,
+} from "./schema";
+
+export interface CustomMetadata {
+  questionUid: string;
+  [key: string]: unknown; // Allow for other unknown metadata fields
+}
+
+export interface DocumentRetriever {
+  retrieve(query: string): Promise<Document[]>;
+}
+
+// TODO: GCLOMAX - we need to update the typing on here - do we use both cohere and replicate types?
+// Replicate is just returning json anyway.
+export interface DocumentReranker {
+  rerankDocuments(
+    query: string,
+    docs: SimplifiedResult[],
+    topN: number,
+  ): Promise<RerankResponseResultsItem[]>;
+}
+
+export interface AilaQuizService {
+  generateMathsExitQuizPatch(
+    lessonPlan: LooseLessonPlan,
+  ): Promise<JsonPatchDocument>;
+}
+
+export interface AilaQuizGeneratorService {
+  generateMathsExitQuizPatch(
+    lessonPlan: LooseLessonPlan,
+    relevantLessons?: AilaRagRelevantLesson[],
+  ): Promise<Quiz[]>;
+  generateMathsStarterQuizPatch(
+    lessonPlan: LooseLessonPlan,
+    relevantLessons?: AilaRagRelevantLesson[],
+  ): Promise<Quiz[]>;
+  // invoke(lessonPlan: LooseLessonPlan): Promise<Quiz[]>;
+}
+
+export interface AilaQuizVariantService {
+  rerankService: DocumentReranker;
+  generateMathsStarterQuizPatch(
+    lessonPlan: LooseLessonPlan,
+  ): Promise<JsonPatchDocument>;
+}
+
+export interface AilaQuizReranker<T extends z.ZodType<BaseType>> {
+  rerankQuiz(quizzes: QuizQuestion[][]): Promise<number[]>;
+  evaluateQuizArray(
+    quizzes: QuizQuestion[][],
+    lessonPlan: LooseLessonPlan,
+    ratingSchema: T,
+    quizType: QuizPath,
+  ): Promise<z.infer<T>[]>;
+  cachedEvaluateQuizArray(
+    quizzes: QuizQuestion[][],
+    lessonPlan: LooseLessonPlan,
+    ratingSchema: T,
+    quizType: QuizPath,
+  ): Promise<z.infer<T>[]>;
+  ratingSchema?: T;
+  quizType?: QuizPath;
+  ratingFunction?: RatingFunction<z.infer<T>>;
+}
+
+// TODO: GCLOMAX - make generic by extending BaseType and BaseSchema as <T,U>
+export interface FullQuizService {
+  quizSelector: QuizSelector<BaseType>;
+  quizReranker: AilaQuizReranker<z.ZodType<BaseType>>;
+  quizGenerators: AilaQuizGeneratorService[];
+  createBestQuiz(
+    quizType: quizPatchType,
+    lessonPlan: LooseLessonPlan,
+    ailaRagRelevantLessons?: AilaRagRelevantLesson[],
+  ): Promise<QuizQuestion[]>;
+}
+
+// Separating these out to allow for different types of selectors for different types of rerankers. Abstracting away allows for the LLM to potentially change the answer depending on input.
+export interface QuizSelector<T extends BaseType> {
+  ratingFunction: RatingFunction<T>;
+  maxRatingFunctionApplier: MaxRatingFunctionApplier<T>;
+  selectBestQuiz(
+    quizzes: QuizQuestion[][],
+    ratingsSchemas: T[],
+  ): QuizQuestion[];
+}
+
+export type quizPatchType = "/starterQuiz" | "/exitQuiz";
+
+export interface CustomSource {
+  text: string;
+  metadata: CustomMetadata;
+  [key: string]: unknown; // Allow for other unknown fields at the top level
+}
+
+export interface QuizQuestionTextOnlySource {
+  text: string;
+  metadata: { questionUid: string; lessonSlug: string };
+}
+
+export interface CustomHit {
+  _source: CustomSource;
+}
+
+export interface SimplifiedResult {
+  text: string;
+  custom_id: string;
+}
+
+export interface Document {
+  document: {
+    text: string;
+  };
+  index: number;
+  relevanceScore: number;
+}
+
+export interface SimplifiedResultQuestion {
+  text: string;
+  questionUid: string;
+}
+
+export interface DocumentWrapper {
+  document: Document;
+  index: number;
+  relevanceScore: number;
+}
+
+export interface QuizSet {
+  exitQuiz: string[];
+  starterQuiz: string[];
+}
+
+export interface QuizIDSource {
+  text: QuizSet;
+  metadata: { lessonSlug: string };
+}
+export interface LessonSlugQuizMapping {
+  [lessonSlug: string]: QuizSet;
+}
+
+export interface LessonSlugQuizLookup {
+  getStarterQuiz(lessonSlug: string): Promise<string[]>;
+  getExitQuiz(lessonSlug: string): Promise<string[]>;
+  hasStarterQuiz(lessonSlug: string): Promise<boolean>;
+  hasExitQuiz(lessonSlug: string): Promise<boolean>;
+}
+
+// FACTORIES BELOW
+export interface FullServiceFactory {
+  create(settings: QuizServiceSettings): FullQuizService;
+}
+
+export interface AilaQuizFactory {
+  quizStrategySelector(lessonPlan: LooseLessonPlan): QuizRecommenderType;
+  createQuizRecommender(lessonPlan: LooseLessonPlan): AilaQuizService;
+}
+
+export interface AilaQuizRerankerFactory {
+  createAilaQuizReranker(
+    quizType: QuizRerankerType,
+  ): AilaQuizReranker<z.ZodType<BaseType>>;
+}
+
+export interface QuizSelectorFactory {
+  createQuizSelector<T extends BaseType>(
+    selectorType: QuizSelectorType,
+  ): QuizSelector<T>;
+}

--- a/packages/aila/src/core/quiz/rerankers.ts
+++ b/packages/aila/src/core/quiz/rerankers.ts
@@ -1,0 +1,48 @@
+import { aiLogger } from "@oakai/logger";
+import { CohereClient } from "cohere-ai";
+
+import type { DocumentReranker, SimplifiedResult } from "./interfaces";
+
+const log = aiLogger("quiz");
+
+export class CohereReranker implements DocumentReranker {
+  private readonly cohere: CohereClient;
+
+  constructor() {
+    this.cohere = new CohereClient({
+      token: process.env.COHERE_API_KEY as string,
+    });
+  }
+  public async rerankDocuments(
+    query: string,
+    docs: SimplifiedResult[],
+    topN: number = 10,
+  ) {
+    // add in other reranking methods here.
+    // conforming to https://github.com/cohere-ai/cohere-typescript/blob/2e1c087ed0ec7eacd39ad062f7293fb15e453f33/src/api/client/requests/RerankRequest.ts#L15
+    try {
+      const jsonDocs = docs.map((doc) =>
+        JSON.stringify({
+          text: doc.text,
+          custom_id: doc.custom_id,
+        }),
+      );
+      // this should have na error below - https://github.com/cohere-ai/cohere-typescript/blob/499bde51cee5d1f2ea2068580f938123297515f9/src/api/client/requests/RerankRequest.ts#L31
+      const response = await this.cohere.rerank({
+        model: "rerank-english-v2.0",
+        query: query,
+        documents: jsonDocs,
+        topN: topN,
+        //@ts-expect-error issue with cohere client - will need version bumping in future.
+        rankFields: ["text"],
+        returnDocuments: true,
+      });
+
+      log.info("Ranked documents:", response.results);
+      return response.results;
+    } catch (error) {
+      log.error("Error during reranking:", error);
+      return [];
+    }
+  }
+}

--- a/packages/aila/src/core/quiz/rerankers/AilaQuizReranker.ts
+++ b/packages/aila/src/core/quiz/rerankers/AilaQuizReranker.ts
@@ -1,0 +1,86 @@
+import { aiLogger } from "@oakai/logger";
+import { kv } from "@vercel/kv";
+import { pick } from "remeda";
+import { Md5 } from "ts-md5";
+import type { z } from "zod";
+
+import type {
+  LooseLessonPlan,
+  QuizPath,
+  QuizQuestion,
+} from "../../../protocol/schema";
+import { type BaseType } from "../ChoiceModels";
+// import { evaluateQuiz } from "../OpenAIRanker";
+import type { AilaQuizReranker } from "../interfaces";
+
+const log = aiLogger("aila:quiz");
+export abstract class BasedOnRagAilaQuizReranker<T extends z.ZodType<BaseType>>
+  implements AilaQuizReranker<T>
+{
+  abstract rerankQuiz(quizzes: QuizQuestion[][]): Promise<number[]>;
+  public ratingSchema?: T;
+  public quizType?: QuizPath;
+
+  constructor(ratingSchema?: T, quizType?: QuizPath) {
+    this.ratingSchema = ratingSchema;
+    this.quizType = quizType;
+  }
+
+  public abstract evaluateQuizArray(
+    quizArray: QuizQuestion[][],
+    lessonPlan: LooseLessonPlan,
+    ratingSchema: T,
+    quizType: QuizPath,
+  ): Promise<z.infer<T>[]>;
+
+  public async cachedEvaluateQuizArray(
+    quizArray: QuizQuestion[][],
+    lessonPlan: LooseLessonPlan,
+    ratingSchema: T,
+    quizType: QuizPath,
+  ): Promise<z.infer<T>[]> {
+    const keyPrefix = "aila:quiz:openai:reranker";
+    const lessonPlanRerankerFields = [
+      "title",
+      "topic",
+      "learningOutcome",
+      "keyLearningPoints",
+    ] as const;
+
+    const relevantLessonPlanData = pick(lessonPlan, lessonPlanRerankerFields);
+
+    const hash = Md5.hashStr(
+      JSON.stringify({
+        quizArray,
+        relevantLessonPlanData,
+        ratingSchema,
+        quizType,
+      }),
+    );
+    const cacheKey = `${keyPrefix}:${hash}`;
+
+    try {
+      const cached = await kv.get<z.infer<T>[]>(cacheKey);
+      if (cached) {
+        log.info(`Cache hit for key: ${cacheKey}`);
+        return cached;
+      }
+    } catch (e) {
+      log.error(`Error getting cached value for key: ${cacheKey}`, e);
+      await kv.del(cacheKey);
+    }
+
+    log.info(`Cache miss for key: ${cacheKey}, evaluating for openAI`);
+    const evaluatedQuizzes = await this.evaluateQuizArray(
+      quizArray,
+      lessonPlan,
+      ratingSchema,
+      quizType,
+    );
+
+    await kv.set(cacheKey, evaluatedQuizzes, {
+      ex: 60 * 5,
+    });
+    return evaluatedQuizzes;
+  }
+}

--- a/packages/aila/src/core/quiz/rerankers/AilaQuizRerankerFactory.ts
+++ b/packages/aila/src/core/quiz/rerankers/AilaQuizRerankerFactory.ts
@@ -1,0 +1,22 @@
+import type { z } from "zod";
+
+import type { BaseType } from "../ChoiceModels";
+import type { AilaQuizReranker, AilaQuizRerankerFactory } from "../interfaces";
+import type { QuizRerankerType } from "../schema";
+import { testRatingSchema } from "./RerankerStructuredOutputSchema";
+import { ReturnFirstReranker } from "./ReturnFirstReranker";
+
+export class AilaQuizRerankerFactoryImpl implements AilaQuizRerankerFactory {
+  public createAilaQuizReranker(
+    quizType: QuizRerankerType,
+  ): AilaQuizReranker<z.ZodType<BaseType>> {
+    switch (quizType) {
+      case "schema-reranker":
+        throw new Error(
+          "Schema reranker not implemented import from other branch",
+        );
+      case "return-first":
+        return new ReturnFirstReranker(testRatingSchema, "/starterQuiz");
+    }
+  }
+}

--- a/packages/aila/src/core/quiz/rerankers/QuizRerankerFactory.test.ts
+++ b/packages/aila/src/core/quiz/rerankers/QuizRerankerFactory.test.ts
@@ -1,0 +1,17 @@
+import type { QuizRerankerType } from "../schema";
+import { AilaQuizRerankerFactoryImpl } from "./AilaQuizRerankerFactory";
+import { ReturnFirstReranker } from "./ReturnFirstReranker";
+
+describe("AilaQuizRerankerFactoryImpl", () => {
+  let factory: AilaQuizRerankerFactoryImpl;
+
+  beforeEach(() => {
+    factory = new AilaQuizRerankerFactoryImpl();
+  });
+
+  it("should create a TestSchemaReranker for a given quiz type", () => {
+    const quizType: QuizRerankerType = "return-first";
+    const reranker = factory.createAilaQuizReranker(quizType);
+    expect(reranker).toBeInstanceOf(ReturnFirstReranker);
+  });
+});

--- a/packages/aila/src/core/quiz/rerankers/RerankerStructuredOutputSchema.ts
+++ b/packages/aila/src/core/quiz/rerankers/RerankerStructuredOutputSchema.ts
@@ -1,0 +1,77 @@
+import { z } from "zod";
+
+import { QuizQuestionSchema } from "../../../protocol/schema";
+import type { BaseType } from "../ChoiceModels";
+
+export const ratingAndJustificationSchema = z.object({
+  chainOfThought: z
+    .string()
+    .describe("The chain of thought that led to the rating"),
+  rating: z
+    .number()
+    .describe(
+      "The rating for the given criteria and response taking the chain of thought into account. The rating is a float between 0 and 1.",
+    ),
+});
+
+export const starterQuizQuestionSuitabilityDescriptionSchema = z.object({
+  relevanceToPriorKnowledge: ratingAndJustificationSchema,
+  alignmentWithKeyLearningPoints: ratingAndJustificationSchema,
+  congitiveLevel: ratingAndJustificationSchema,
+  clarityAndSpecificity: ratingAndJustificationSchema,
+  potentialForInsight: ratingAndJustificationSchema,
+  overallSuitability: z
+    .boolean()
+    .describe(
+      "Whether the question is suitable for the lesson plan and should be included in the starter quiz",
+    ),
+  justification: z
+    .string()
+    .describe("Justification for the overall suitability rating"),
+});
+
+export const starterQuizSuitabilitySchema = z.object({
+  consideration: starterQuizQuestionSuitabilityDescriptionSchema,
+  overallSuitability: z
+    .boolean()
+    .describe(
+      "Whether the starter quiz is suitable for the lesson plan and should be included in the lesson",
+    ),
+  justification: z
+    .boolean()
+    .describe("Justification for the overall suitability rating"),
+});
+
+export const testRatingSchema = z.object({
+  rating: z
+    .number()
+    .describe(
+      "The rating for the given criteria and response taking the chain of thought into account. The rating is a float between 0 and 1.",
+    ),
+  justification: z
+    .string()
+    .describe("The chain of thought that led to the rating"),
+}) satisfies z.ZodType<BaseType>;
+
+export type TestRating = z.infer<typeof testRatingSchema>;
+
+export const quizConsiderationSchema = z.object({
+  basedOnId: z
+    .string()
+    .describe(
+      "The id of the lesson plan that this lesson plan is explicitly based on",
+    )
+    .optional(),
+  ragLessonPlanIds: z
+    .array(z.string())
+    .describe(
+      "The ids of the RAG lesson plans that are relevant to this lesson plan",
+    ),
+  mlQuizQuestions: z
+    .array(QuizQuestionSchema)
+    .describe("The questions in the ML quiz"),
+});
+
+export type QuizzesForConsideration = z.infer<typeof quizConsiderationSchema>;
+
+// export const output_option

--- a/packages/aila/src/core/quiz/rerankers/ReturnFirstReranker.test.ts
+++ b/packages/aila/src/core/quiz/rerankers/ReturnFirstReranker.test.ts
@@ -1,0 +1,75 @@
+import type { z } from "zod";
+
+import type { QuizQuestion } from "../../../protocol/schema";
+import { cachedQuiz } from "../fixtures/CachedImageQuiz";
+import { testRatingSchema } from "./RerankerStructuredOutputSchema";
+import { ReturnFirstReranker } from "./ReturnFirstReranker";
+
+describe("ReturnFirstReranker", () => {
+  let reranker: ReturnFirstReranker;
+
+  beforeEach(() => {
+    reranker = new ReturnFirstReranker();
+  });
+
+  describe("rerankQuiz", () => {
+    it("should return [0] even with empty quiz array", async () => {
+      const result = await reranker.rerankQuiz([]);
+      expect(result).toEqual([0]);
+    });
+  });
+
+  describe("evaluateQuizArray", () => {
+    it("should return array of ratings with first item rated 1 and others 0", async () => {
+      const mockQuizzes: QuizQuestion[][] = [cachedQuiz, cachedQuiz];
+
+      const mockLessonPlan = {
+        title: "Test Lesson",
+        content: "Test content",
+      };
+
+      const result = (await reranker.evaluateQuizArray(
+        mockQuizzes,
+        mockLessonPlan,
+        testRatingSchema,
+        "/exitQuiz",
+      )) as unknown as z.infer<typeof testRatingSchema>[];
+
+      expect(result[0]?.rating).toBe(1);
+      expect(result[1]?.rating).toBe(0);
+      console.log(JSON.stringify(result, null, 2));
+    });
+
+    it("should handle empty quiz array", async () => {
+      const mockLessonPlan = {
+        title: "Test Lesson",
+        content: "Test content",
+      };
+
+      const result = await reranker.evaluateQuizArray(
+        [],
+        mockLessonPlan,
+        testRatingSchema,
+        "/exitQuiz",
+      );
+
+      expect(result).toHaveLength(0);
+    });
+
+    it("should populate schema fields correctly", async () => {
+      const mockQuizzes: QuizQuestion[][] = [cachedQuiz, cachedQuiz];
+
+      const mockLessonPlan = {
+        title: "Test Lesson",
+        content: "Test content",
+      };
+
+      const result = await reranker.evaluateQuizArray(
+        mockQuizzes,
+        mockLessonPlan,
+        testRatingSchema,
+        "/exitQuiz",
+      );
+    });
+  });
+});

--- a/packages/aila/src/core/quiz/rerankers/ReturnFirstReranker.ts
+++ b/packages/aila/src/core/quiz/rerankers/ReturnFirstReranker.ts
@@ -1,0 +1,38 @@
+import { generateMock } from "@anatine/zod-mock";
+import type { z } from "zod";
+
+import type {
+  LooseLessonPlan,
+  QuizPath,
+  QuizQuestion,
+} from "../../../protocol/schema";
+import { BasedOnRagAilaQuizReranker } from "./AilaQuizReranker";
+import { testRatingSchema } from "./RerankerStructuredOutputSchema";
+
+// This reranker returns the first quiz in the list. It is used for testing and hacky workarounds.
+// TODO: GCLOMAX - Fix the typing here to be generic.
+export class ReturnFirstReranker extends BasedOnRagAilaQuizReranker<
+  typeof testRatingSchema
+> {
+  public rerankQuiz(quizzes: QuizQuestion[][]): Promise<number[]> {
+    return Promise.resolve([0]);
+  }
+  public evaluateQuizArray(
+    quizzes: QuizQuestion[][],
+    _lessonPlan: LooseLessonPlan,
+    ratingSchema: typeof testRatingSchema,
+    _quizType: QuizPath,
+  ): Promise<z.infer<typeof testRatingSchema>[]> {
+    const output = quizzes.map(() => {
+      const dummySchema = generateMock(testRatingSchema);
+      dummySchema.rating = 0;
+      return dummySchema;
+    });
+
+    if (output[0]) {
+      output[0].rating = 1;
+    }
+
+    return Promise.resolve(output);
+  }
+}

--- a/packages/aila/src/core/quiz/schema.ts
+++ b/packages/aila/src/core/quiz/schema.ts
@@ -1,0 +1,42 @@
+import type { RerankResponseResultsItem } from "cohere-ai/api/types";
+import { z } from "zod";
+
+export type retrievalStrategy = "bm25" | "blended";
+export type rerankerStrategy = "openai" | "elastic" | "blended";
+
+// Generator Types
+export const QuizGeneratorTypeSchema = z.enum(["rag", "ml", "basedOnRag"]);
+export type QuizGeneratorType = z.infer<typeof QuizGeneratorTypeSchema>;
+
+// Reranker Types
+export const QuizRerankerTypeSchema = z.enum([
+  "schema-reranker",
+  "return-first",
+]);
+export type QuizRerankerType = z.infer<typeof QuizRerankerTypeSchema>;
+
+// Strategy Types
+export const RetrievalStrategySchema = z.enum(["bm25", "blended"]);
+export type RetrievalStrategy = z.infer<typeof RetrievalStrategySchema>;
+
+export const RerankerStrategySchema = z.enum(["openai", "elastic", "blended"]);
+export type RerankerStrategy = z.infer<typeof RerankerStrategySchema>;
+
+export const QuizSelectorTypeSchema = z.enum(["simple"]);
+export type QuizSelectorType = z.infer<typeof QuizSelectorTypeSchema>;
+
+export const QuizPatchTypeSchema = z.enum(["/starterQuiz", "/exitQuiz"]);
+export type QuizPatchType = z.infer<typeof QuizPatchTypeSchema>;
+
+export const QuizRecommenderTypeSchema = z.enum(["maths", "default"]);
+export type QuizRecommenderType = z.infer<typeof QuizRecommenderTypeSchema>;
+
+export const QuizServiceSettingsSchema = z.enum(["simple", "demo", "basedOn"]);
+export type QuizServiceSettings = z.infer<typeof QuizServiceSettingsSchema>;
+
+export type QuizBuilderSettings = {
+  quizRatingSchema: z.ZodSchema<unknown>;
+  quizSelector: QuizSelectorType;
+  quizReranker: QuizRerankerType;
+  quizGenerators: QuizGeneratorType[];
+};

--- a/packages/aila/src/core/quiz/selectors/BaseQuizSelector.ts
+++ b/packages/aila/src/core/quiz/selectors/BaseQuizSelector.ts
@@ -1,0 +1,28 @@
+import type { QuizQuestion } from "../../../protocol/schema";
+import type {
+  BaseType,
+  MaxRatingFunctionApplier,
+  RatingFunction,
+} from "../ChoiceModels";
+import type { QuizSelector } from "../interfaces";
+
+export abstract class BaseQuizSelector<T extends BaseType>
+  implements QuizSelector<T>
+{
+  public abstract ratingFunction: RatingFunction<T>;
+  public abstract maxRatingFunctionApplier: MaxRatingFunctionApplier<T>;
+  public selectBestQuiz(
+    quizzes: QuizQuestion[][],
+    ratingsSchemas: T[],
+  ): QuizQuestion[] {
+    const selectedIndex = this.maxRatingFunctionApplier(
+      ratingsSchemas,
+      this.ratingFunction,
+    );
+    const selectedQuiz = quizzes[selectedIndex];
+    if (selectedQuiz === undefined) {
+      throw new Error("Selected quiz is undefined");
+    }
+    return selectedQuiz;
+  }
+}

--- a/packages/aila/src/core/quiz/selectors/QuizSelectorFactory.test.ts
+++ b/packages/aila/src/core/quiz/selectors/QuizSelectorFactory.test.ts
@@ -1,0 +1,18 @@
+import type { QuizSelectorType } from "../schema";
+import { QuizSelectorFactoryImpl } from "./QuizSelectorFactory";
+import { SimpleQuizSelector } from "./SimpleQuizSelector";
+
+describe("QuizSelectorFactoryImpl", () => {
+  let factory: QuizSelectorFactoryImpl;
+
+  beforeEach(() => {
+    factory = new QuizSelectorFactoryImpl();
+  });
+
+  it('should create a SimpleQuizSelector when selectorType is "simple"', () => {
+    const selectorType: QuizSelectorType = "simple";
+    const selector = factory.createQuizSelector(selectorType);
+
+    expect(selector).toBeInstanceOf(SimpleQuizSelector);
+  });
+});

--- a/packages/aila/src/core/quiz/selectors/QuizSelectorFactory.ts
+++ b/packages/aila/src/core/quiz/selectors/QuizSelectorFactory.ts
@@ -1,0 +1,15 @@
+import type { BaseType } from "../ChoiceModels";
+import type { QuizSelector, QuizSelectorFactory } from "../interfaces";
+import type { QuizSelectorType } from "../schema";
+import { SimpleQuizSelector } from "./SimpleQuizSelector";
+
+export class QuizSelectorFactoryImpl implements QuizSelectorFactory {
+  public createQuizSelector<T extends BaseType>(
+    selectorType: QuizSelectorType,
+  ): QuizSelector<T> {
+    switch (selectorType) {
+      case "simple":
+        return new SimpleQuizSelector<T>();
+    }
+  }
+}

--- a/packages/aila/src/core/quiz/selectors/SimpleQuizSelector.test.ts
+++ b/packages/aila/src/core/quiz/selectors/SimpleQuizSelector.test.ts
@@ -1,0 +1,22 @@
+import type { BaseType } from "../ChoiceModels";
+import { cachedQuizRatings } from "../fixtures/cachedQuizRatings";
+import { type TestRating } from "../rerankers/RerankerStructuredOutputSchema";
+import { SimpleQuizSelector } from "./SimpleQuizSelector";
+
+describe("SimpleQuizSelector", () => {
+  interface TestItem extends BaseType {
+    rating: number;
+  }
+
+  const ratings: TestRating[] = cachedQuizRatings;
+
+  it("should use the default rating function to select the highest rated item", () => {
+    const selector = new SimpleQuizSelector<TestRating>();
+    const highestRatedItem = selector.maxRatingFunctionApplier(
+      ratings,
+      selector.ratingFunction,
+    );
+
+    expect(highestRatedItem).toEqual(0);
+  });
+});

--- a/packages/aila/src/core/quiz/selectors/SimpleQuizSelector.ts
+++ b/packages/aila/src/core/quiz/selectors/SimpleQuizSelector.ts
@@ -1,0 +1,11 @@
+import type { BaseType, MaxRatingFunctionApplier } from "../ChoiceModels";
+import { selectHighestRated, type RatingFunction } from "../ChoiceModels";
+import { BaseQuizSelector } from "./BaseQuizSelector";
+
+export class SimpleQuizSelector<
+  T extends BaseType,
+> extends BaseQuizSelector<T> {
+  public ratingFunction: RatingFunction<T> = (item: T) => item.rating;
+  public maxRatingFunctionApplier: MaxRatingFunctionApplier<T> =
+    selectHighestRated;
+}

--- a/packages/aila/src/core/quiz/types.ts
+++ b/packages/aila/src/core/quiz/types.ts
@@ -1,0 +1,4 @@
+import type { Client } from "@elastic/elasticsearch";
+import type { SearchResponse } from "@elastic/elasticsearch/lib/api/types";
+
+export type SearchResponseBody<T = unknown> = SearchResponse<T>;

--- a/packages/aila/src/protocol/jsonPatchProtocol.immutability.test.ts
+++ b/packages/aila/src/protocol/jsonPatchProtocol.immutability.test.ts
@@ -1,0 +1,36 @@
+import invariant from "tiny-invariant";
+
+import {
+  applyLessonPlanPatchImmutable,
+  type JsonPatchDocument,
+} from "./jsonPatchProtocol";
+
+describe("applyLessonPlanPatchImmutable", () => {
+  it("keeps stable object references for keys that haven't changed", () => {
+    const lessonPlan = {
+      learningCycles: [
+        "Identify the key factors that led to the exit of the Romans from Britain",
+      ],
+      subject: "history",
+    };
+    const patch: JsonPatchDocument = {
+      type: "patch",
+      reasoning: "",
+      value: {
+        op: "replace",
+        path: "/subject",
+        value: "geography",
+      },
+    };
+
+    const result = applyLessonPlanPatchImmutable(lessonPlan, patch);
+    invariant(result, "result should not be null");
+
+    // The root object should be changed as a child has changed
+    expect(result).not.toBe(lessonPlan);
+    // Learning cycles haven't changed, so the reference should be the same
+    expect(result.learningCycles).toBe(lessonPlan.learningCycles);
+    // The subject has changed, so should be a new object
+    expect(result.subject).not.toBe(lessonPlan.subject);
+  });
+});

--- a/packages/aila/src/protocol/jsonPatchProtocol.ts
+++ b/packages/aila/src/protocol/jsonPatchProtocol.ts
@@ -3,6 +3,7 @@ import { aiLogger } from "@oakai/logger";
 import * as Sentry from "@sentry/nextjs";
 import type { Operation } from "fast-json-patch";
 import { applyPatch, deepClone, JsonPatchError } from "fast-json-patch";
+import * as immer from "immer";
 import untruncateJson from "untruncate-json";
 import { z } from "zod";
 import zodToJsonSchema from "zod-to-json-schema";
@@ -756,34 +757,44 @@ export function parseMessageParts(content: string): MessagePart[] {
   return messageParts;
 }
 
+const timeOperation = <T>(fn: () => T): T => {
+  const startTime = performance.now();
+  const result = fn();
+  const endTime = performance.now();
+  log.info(`extractPatches took ${endTime - startTime} milliseconds`);
+  return result;
+};
+
 export function extractPatches(edit: string): {
   validPatches: PatchDocument[];
   partialPatches: PatchDocument[];
 } {
-  const parts: MessagePart[] | undefined = parseMessageParts(edit);
+  return timeOperation(() => {
+    const parts: MessagePart[] | undefined = parseMessageParts(edit);
 
-  if (!parts) {
-    // Handle parsing failure
-    throw new Error("Failed to parse the edit content");
-  }
+    if (!parts) {
+      // Handle parsing failure
+      throw new Error("Failed to parse the edit content");
+    }
 
-  const patchMessageParts: MessagePart[] = parts.filter(
-    (p) =>
-      p.document.type === "patch" || p.document.type === "experimentalPatch",
-  );
-  const validPatches: PatchDocument[] = patchMessageParts
-    .filter((p) => !p.isPartial)
-    .map((p) => p.document as PatchDocument);
-  const partialPatches: PatchDocument[] = patchMessageParts
-    .filter((p) => p.isPartial)
-    .map((p) => p.document as PatchDocument);
+    const patchMessageParts: MessagePart[] = parts.filter(
+      (p) =>
+        p.document.type === "patch" || p.document.type === "experimentalPatch",
+    );
+    const validPatches: PatchDocument[] = patchMessageParts
+      .filter((p) => !p.isPartial)
+      .map((p) => p.document as PatchDocument);
+    const partialPatches: PatchDocument[] = patchMessageParts
+      .filter((p) => p.isPartial)
+      .map((p) => p.document as PatchDocument);
 
-  log.info(
-    "Extracted patches",
-    validPatches.map((i) => i.value.path),
-    partialPatches.map((i) => i.value.path),
-  );
-  return { validPatches, partialPatches };
+    // log.info(
+    //   "Extracted patches",
+    //   validPatches.map((i) => i.value.path),
+    //   partialPatches.map((i) => i.value.path),
+    // );
+    return { validPatches, partialPatches };
+  });
 }
 
 // This isValidatePatch function only tells us if it contains an add / replace and a value
@@ -803,7 +814,7 @@ export function applyLessonPlanPatch(
   lessonPlan: LooseLessonPlan,
   command: JsonPatchDocument | ExperimentalPatchDocument,
 ) {
-  log.info("Apply patch", JSON.stringify(command));
+  log.info("Apply patch (old)", JSON.stringify(command));
   let updatedLessonPlan = { ...lessonPlan };
   if (command.type !== "patch" && command.type !== "experimentalPatch") {
     log.error("Invalid patch document type", command.type);
@@ -846,4 +857,52 @@ export function applyLessonPlanPatch(
   }
 
   return updatedLessonPlan;
+}
+
+/**
+ * Applies a patch to a lesson plan, keeping stable object references for keys
+ * that haven't changed
+ */
+export function applyLessonPlanPatchImmutable(
+  lessonPlan: LooseLessonPlan,
+  command: JsonPatchDocument | ExperimentalPatchDocument,
+) {
+  log.info("Apply patch (immutable)", JSON.stringify(command));
+  if (command.type !== "patch" && command.type !== "experimentalPatch") {
+    log.error("Invalid patch document type", command.type);
+    return;
+  }
+  const patchValue = command.value;
+  if (!isValidPatch(patchValue)) {
+    log.error("Invalid patch");
+    return;
+  }
+
+  try {
+    // applyPatch mutates the document being passed in.
+    // Immer applies the mutations to a draft copy of the document and returns
+    // an altered copy of the original with stable references for unchanged values
+    const newLessonPlan = immer.produce(lessonPlan, (draftLessonPlan) => {
+      applyPatch(draftLessonPlan, [patchValue]);
+    });
+
+    // Zod returns a deep-cloned result which we can't use.
+    // We can just rely on the fact that it didn't throw
+    LessonPlanSchemaWhilstStreaming.parse(newLessonPlan);
+
+    return newLessonPlan;
+  } catch (e) {
+    if (e instanceof z.ZodError) {
+      log.error(
+        "Zod Error:",
+        e.errors
+          .map((err) => `${err.path.join(".")}: ${err.message}`)
+          .join(", "),
+      );
+    } else {
+      log.error("Failed to apply patch", patchValue, e);
+    }
+    Sentry.captureException(e, { level: "info" });
+    return;
+  }
 }

--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -427,6 +427,7 @@ export const LessonPlanKeySchema = z.enum([
   "keyStage",
   "subject",
   "topic",
+  "basedOn",
   ...allSectionsInOrder,
 ]);
 

--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -391,8 +391,8 @@ export const CompletedLessonPlanSchema = z.object({
 export type CompletedLessonPlan = z.infer<typeof CompletedLessonPlanSchema>;
 
 export const LessonPlanSchema = CompletedLessonPlanSchema.partial().extend({
-  _experimental_starterQuizMathsV0: QuizOptionalSchema.optional(),
-  _experimental_exitQuizMathsV0: QuizOptionalSchema.optional(),
+  _experimental_starterQuizMathsV0: QuizSchema.optional(),
+  _experimental_exitQuizMathsV0: QuizSchema.optional(),
 });
 
 export const LessonPlanSchemaWhilstStreaming = LessonPlanSchema;

--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -1,4 +1,5 @@
-import dedent from "dedent";
+// import dedent from "dedent";
+import dedent from "ts-dedent";
 import z from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 
@@ -71,6 +72,8 @@ export type MisconceptionsOptional = z.infer<
 
 // ********** QUIZ **********
 
+// Needs to be changed - to adapt for LLM handling.
+
 export const QUIZ_DESCRIPTIONS = {
   question: "The question to be asked in the quiz.",
   answers: "The correct answer. This should be an array of only one item.",
@@ -87,10 +90,11 @@ export const QuizQuestionSchemaWithoutLength = z.object({
   distractors: z.array(z.string()).describe(QUIZ_DESCRIPTIONS.distractors),
 });
 
-export const QuizQuestionSchema = QuizQuestionSchemaWithoutLength.extend({
-  answers: QuizQuestionSchemaWithoutLength.shape.answers.length(1),
-  distractors: QuizQuestionSchemaWithoutLength.shape.distractors.length(2),
-});
+// TODO: MG - Double check this is allowable.
+export const QuizQuestionSchema = QuizQuestionSchemaWithoutLength; //.extend({
+//   answers: QuizQuestionSchemaWithoutLength.shape.answers.length(1),
+//   distractors: QuizQuestionSchemaWithoutLength.shape.distractors.length(2),
+// });
 
 export const QuizQuestionOptionalSchema = QuizQuestionSchema.partial();
 
@@ -494,6 +498,21 @@ export type LessonPlanSectionWhileStreaming =
   | string
   | string[]
   | number;
+
+// These are here due to zod refusing to infer the type of "add"
+export const quizPathSchema = z.union([
+  z.literal("/starterQuiz"),
+  z.literal("/exitQuiz"),
+]);
+
+export type QuizPath = z.infer<typeof quizPathSchema>;
+
+export const quizOperationTypeSchema = z.union([
+  z.literal("add"),
+  z.literal("replace"),
+]);
+
+export type QuizOperationType = z.infer<typeof quizOperationTypeSchema>;
 
 export const CompletedLessonPlanSchemaWithoutLength = z.object({
   title: LessonTitleSchema,

--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -494,3 +494,24 @@ export type LessonPlanSectionWhileStreaming =
   | string
   | string[]
   | number;
+
+export const CompletedLessonPlanSchemaWithoutLength = z.object({
+  title: LessonTitleSchema,
+  keyStage: KeyStageSchema,
+  subject: SubjectSchema,
+  topic: TopicSchema,
+  learningOutcome: LearningOutcomeSchema,
+  learningCycles: LearningCyclesSchema,
+  priorKnowledge: PriorKnowledgeSchema,
+  keyLearningPoints: KeyLearningPointsSchema,
+  misconceptions: MisconceptionsSchemaWithoutLength,
+  keywords: KeywordsSchemaWithoutLength,
+  starterQuiz: QuizSchemaWithoutLength.describe(
+    LESSON_PLAN_DESCRIPTIONS.starterQuiz,
+  ),
+  cycle1: CycleSchemaWithoutLength.describe("The first learning cycle"),
+  cycle2: CycleSchemaWithoutLength.describe("The second learning cycle"),
+  cycle3: CycleSchemaWithoutLength.describe("The third learning cycle"),
+  exitQuiz: QuizSchemaWithoutLength.describe(LESSON_PLAN_DESCRIPTIONS.exitQuiz),
+  additionalMaterials: AdditionalMaterialsSchema,
+});

--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -407,6 +407,29 @@ export type LooseLessonPlan = z.infer<typeof LessonPlanSchemaWhilstStreaming>;
 
 export type LessonPlanKey = keyof typeof CompletedLessonPlanSchema.shape;
 
+export const allSectionsInOrder = [
+  "learningOutcome",
+  "learningCycles",
+  "priorKnowledge",
+  "keyLearningPoints",
+  "misconceptions",
+  "keywords",
+  "starterQuiz",
+  "cycle1",
+  "cycle2",
+  "cycle3",
+  "exitQuiz",
+  "additionalMaterials",
+] as const;
+
+export const LessonPlanKeySchema = z.enum([
+  "title",
+  "keyStage",
+  "subject",
+  "topic",
+  ...allSectionsInOrder,
+]);
+
 export const LessonPlanJsonSchema = zodToJsonSchema(
   CompletedLessonPlanSchema,
   "lessonPlanSchema",

--- a/packages/api/src/router/generations.ts
+++ b/packages/api/src/router/generations.ts
@@ -383,7 +383,9 @@ export const generationRouter = router({
         await feedbackModel.recordUserTweak(
           tweakedItem.lastGenerationId,
           sessionId,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           tweakedItem.value,
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           tweakedItem.originalValue,
         );
       } catch (err) {

--- a/packages/core/src/rag/types.ts
+++ b/packages/core/src/rag/types.ts
@@ -1,4 +1,5 @@
 import type { KeyStage, LessonPlan, Subject } from "@prisma/client";
+import { z } from "zod";
 
 export interface FilterOptions {
   key_stage_id?: object;
@@ -13,14 +14,37 @@ export interface LessonPlanWithPartialLesson extends LessonPlan {
   };
 }
 
+// Keep the flexible type for LangChain compatibility
 export type SimilarityResultWithScore = [
   // eslint-disable-next-line @typescript-eslint/consistent-type-imports
-  import("@langchain/core/documents").DocumentInterface<
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    Record<string, any>
-  >,
+  import("@langchain/core/documents").DocumentInterface,
   number,
 ];
+
+// Add a more specific type for after validation
+export type SimilarityResultWithScoreAndMetadata = [
+  // eslint-disable-next-line @typescript-eslint/consistent-type-imports
+  import("@langchain/core/documents").DocumentInterface<{
+    id: string;
+    lesson_plan_id: string;
+  }>,
+  number,
+];
+
+const MetadataSchema = z.object({
+  id: z.string(),
+  lesson_plan_id: z.string(),
+});
+
+const DocumentSchema = z.object({
+  pageContent: z.string(),
+  metadata: MetadataSchema,
+});
+
+export const SimilarityResultWithScoreSchema = z.tuple([
+  DocumentSchema,
+  z.number(),
+]);
 
 export interface KeyStageAndSubject {
   keyStage?: KeyStage;

--- a/packages/core/src/utils/moderation.ts
+++ b/packages/core/src/utils/moderation.ts
@@ -108,6 +108,7 @@ export function checkEnglishLanguageScores(
  */
 const censor = new TextCensor();
 const matcher = new RegExpMatcher({
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   ...englishDataset.build(),
   ...englishRecommendedTransformers,
   whitelistedTerms: ["Oral tradition", "Language analysis", "analysis"],
@@ -130,8 +131,11 @@ type ProfanityResult = [true, string] | [false, null];
 export function detectProfanity(userInput: string[]): ProfanityResult {
   const inputText = userInput.join(" | ");
 
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   if (matcher.hasMatch(inputText)) {
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const allMatches = matcher.getAllMatches(inputText);
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     const censoredResult = censor.applyTo(inputText, allMatches);
     return [true, censoredResult];
   }

--- a/packages/db/scripts/processing/update_clerk_users.ts
+++ b/packages/db/scripts/processing/update_clerk_users.ts
@@ -67,7 +67,6 @@ async function updateAllUsers() {
   let offset = 0;
   let resultsCount = 0;
 
-  // eslint-disable-next-line no-constant-condition
   while (true) {
     const data = await getUsersBatch({
       limit,

--- a/packages/eslint-config/src/index.mjs
+++ b/packages/eslint-config/src/index.mjs
@@ -30,6 +30,7 @@ const packages = [
   { dir: 'packages/core' },
   { dir: 'packages/api' },
   { dir: 'packages/aila' },
+  { dir: 'packages/rag' },
 ];
 
 const packageConfigs = packages.map(pkg => ({

--- a/packages/ingest/package.json
+++ b/packages/ingest/package.json
@@ -17,7 +17,8 @@
     "clean": "rm -rf .turbo node_modules",
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
-    "ingest": "pnpm with-env ts-node --compiler-options {\\\"module\\\":\\\"CommonJS\\\"} ./src/index.ts",
+    "single-lesson-dry": "pnpm with-env tsx ./src/singleLessonDryRun.ts",
+    "ingest": "pnpm with-env tsx ./src/index.ts",
     "with-env": "dotenv -e ../../.env --",
     "test": "pnpm with-env jest --colors --config jest.config.mjs",
     "test:seq": "pnpm with-env jest --colors --config jest.config.mjs --verbose --runInBand",
@@ -33,9 +34,12 @@
     "@oakai/logger": "*",
     "@oakai/rag": "*",
     "@paralleldrive/cuid2": "^2.2.2",
+    "@types/yargs": "^17.0.33",
     "csv-parser": "^3.0.0",
     "graphql-request": "^6.1.0",
+    "tsx": "^4.16.0",
     "webvtt-parser": "^2.2.0",
+    "yargs": "^17.7.2",
     "zod": "3.23.8"
   },
   "devDependencies": {

--- a/packages/ingest/src/captions/getCaptionsByFileName.ts
+++ b/packages/ingest/src/captions/getCaptionsByFileName.ts
@@ -1,7 +1,12 @@
 import { Storage } from "@google-cloud/storage";
 import { aiLogger } from "@oakai/logger";
 import type { Cue } from "webvtt-parser";
-import { WebVTTParser } from "webvtt-parser";
+import * as WebVTTModule from "webvtt-parser";
+
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-expect-error
+const WebVTTParser = WebVTTModule.default
+  .WebVTTParser as typeof WebVTTModule.WebVTTParser;
 
 const log = aiLogger("ingest");
 

--- a/packages/ingest/src/fixtures/userPrompt.txt
+++ b/packages/ingest/src/fixtures/userPrompt.txt
@@ -1,7 +1,7 @@
 I would like to generate a lesson plan with the title "Abolitionist movements in Britain", subject "history" and key stage "ks3".
 
 
-The lesson is intended for Year 8.
+The lesson is intended for the following UK school year: Year 8.
 
 
 The lesson has the following transcript which is a recording of the lesson being delivered by a teacher.
@@ -15,12 +15,12 @@ These are the captions
 </lesson-transcript>
 
 
-One ore more of the learning cycles could be guided by the following:
+The lesson's learningOutcome should match the following text exactly:
 
 - I can explain British campaigns for abolition of slavery and the Haitian Revolution's role in strengthening these movements. 
 
 
-The lesson should include the following key learning points. Include these in the lesson plan:
+The lesson's keyLearningPoints should match exactly this list of key learning points:
 
 - In 1772 it was established that slavery went against English law and many people felt uneasy about Britain's role in it.
 - People in Britain began to criticise the conditions on slave ships across the 'Middle Passage' to the Americas.
@@ -29,12 +29,12 @@ The lesson should include the following key learning points. Include these in th
 - The Haitian Revolution created fear amongst British plantation owners about similar uprisings across the Caribbean.
 
 
-The lesson should include the following misconceptions. Include these in the lesson plan:
+The lesson's misconceptions should match exactly this list of misconception/description pairs:
 
 - **Misconception**: Abolition of slavery in Britain and its colonies was a response to a single event., **Description**: Abolition of slavery in Britain and its colonies was a response to a number of events and an ever-growing public demand for change.
 
 
-The lesson should include the following keywords. Include these in the lesson plan:
+The lesson's keywords should match exactly this list of keyword/definition pairs:
 
 - **habeas corpus**: English law declaring detention or imprisonment as illegal if you have not committed a crime
 - **massacre**: when many people are killed purposely in a violent manner
@@ -42,11 +42,11 @@ The lesson should include the following keywords. Include these in the lesson pl
 - **intolerable**: being unable to bear an experience any longer
 
 
-The lesson should include the following starter quiz questions. Include them within the lesson plan's starter quiz:
+The lesson should include the following starter quiz questions. Include them UNEDITED within the lesson plan's starter quiz:
 
 [{"question":"After Toussaint L'Ouverture was captured and transported back to France where he faced imprisonment and death, who took over the resistance in Saint-Domingue against France?","answers":["Jean-Jacques Dessalines"],"distractors":["Charles Leclerc","Napoleon Bonaparte","General Maitland"]},{"question":"What did Toussaint L’Ouverture do when he learned of Napoleon’s plan to reinstate slavery in 1802?","answers":["He declared a new constitution for Saint-Domingue and prepared for independence."],"distractors":["He declared a new slavery law for Saint-Domingue.","He became an enemy of Napoleon and declared independence for Haiti.","He asked Britain for military assistance."]},{"question":"What nationality were the portion of Leclerc's troops who switched sides to fight for the rebels against France?","answers":["Polish"],"distractors":["British","German","French","Spanish"]}]
 
 
-The lesson should include the following exit quiz questions. Include them within the lesson plan's exit quiz:
+The lesson should include the following exit quiz questions. Include them UNEDITED within the lesson plan's exit quiz:
 
 [{"question":"What was the proof for the British public that life for enslaved people was horrific?","answers":["revolts spreading around European colonies in the Caribbean","the Zong massacre","Olaudah Equiano's autobiography"],"distractors":["the direct experiences that members of the British public had of enslavement","slave-owners' testimony"]},{"question":"What term is used to refer to the fundamental right in English law that prevents people from unlawful imprisonment?","answers":["habeas corpus"],"distractors":["carpe diem","veni vidi vici","pro bono"]},{"question":"In what year did the Zong Massacre occur?","answers":["1781"],"distractors":["1681","1881","1981"]}]

--- a/packages/ingest/src/generate-lesson-plans/user-prompt-parts/exitQuiz.promptPart.ts
+++ b/packages/ingest/src/generate-lesson-plans/user-prompt-parts/exitQuiz.promptPart.ts
@@ -6,7 +6,7 @@ export function exitQuizPromptPart(rawLesson: RawLesson) {
 
   const exitQuizQuestions = exitQuiz ? transformQuiz(exitQuiz) : [];
   return exitQuizQuestions.length
-    ? `The lesson should include the following exit quiz questions. Include them within the lesson plan's exit quiz:
+    ? `The lesson should include the following exit quiz questions. Include them UNEDITED within the lesson plan's exit quiz:
 
 ${JSON.stringify(exitQuizQuestions)}`
     : null;

--- a/packages/ingest/src/generate-lesson-plans/user-prompt-parts/keyLearningPoints.promptPart.ts
+++ b/packages/ingest/src/generate-lesson-plans/user-prompt-parts/keyLearningPoints.promptPart.ts
@@ -5,7 +5,7 @@ export const keyLearningPointsPromptPart = ({
   keyLearningPoints,
 }: RawLesson) =>
   keyLearningPoints?.length
-    ? `The lesson should include the following key learning points. Include these in the lesson plan:
+    ? `The lesson's keyLearningPoints should match exactly this list of key learning points:
 
 ${toMarkdownList(keyLearningPoints, (k) => k.keyLearningPoint)}`
     : null;

--- a/packages/ingest/src/generate-lesson-plans/user-prompt-parts/keywords.promptPart.ts
+++ b/packages/ingest/src/generate-lesson-plans/user-prompt-parts/keywords.promptPart.ts
@@ -3,7 +3,7 @@ import { toMarkdownList } from "./toMarkdownList";
 
 export const lessonKeywordsPromptPart = ({ lessonKeywords }: RawLesson) =>
   lessonKeywords?.length
-    ? `The lesson should include the following keywords. Include these in the lesson plan:
+    ? `The lesson's keywords should match exactly this list of keyword/definition pairs:
 
 ${toMarkdownList(lessonKeywords, getKeywordText)}`
     : null;

--- a/packages/ingest/src/generate-lesson-plans/user-prompt-parts/learningOutcome.promptPart.ts
+++ b/packages/ingest/src/generate-lesson-plans/user-prompt-parts/learningOutcome.promptPart.ts
@@ -2,7 +2,7 @@ import type { RawLesson } from "../../zod-schema/zodSchema";
 
 export const learningOutcomePromptPart = ({ pupilLessonOutcome }: RawLesson) =>
   pupilLessonOutcome
-    ? `One ore more of the learning cycles could be guided by the following:
+    ? `The lesson's learningOutcome should match the following text exactly:
 
 - ${pupilLessonOutcome}`
     : null;

--- a/packages/ingest/src/generate-lesson-plans/user-prompt-parts/misconceptions.promptPart.ts
+++ b/packages/ingest/src/generate-lesson-plans/user-prompt-parts/misconceptions.promptPart.ts
@@ -5,7 +5,7 @@ export const misconceptionsPromptPart = ({
   misconceptionsAndCommonMistakes,
 }: RawLesson) =>
   misconceptionsAndCommonMistakes?.length
-    ? `The lesson should include the following misconceptions. Include these in the lesson plan:
+    ? `The lesson's misconceptions should match exactly this list of misconception/description pairs:
 
 ${toMarkdownList(misconceptionsAndCommonMistakes, misconceptionText)}`
     : null;

--- a/packages/ingest/src/generate-lesson-plans/user-prompt-parts/starterQuiz.promptPart.ts
+++ b/packages/ingest/src/generate-lesson-plans/user-prompt-parts/starterQuiz.promptPart.ts
@@ -6,7 +6,7 @@ export function starterQuizPromptPart(rawLesson: RawLesson) {
 
   const starterQuizQuestions = starterQuiz ? transformQuiz(starterQuiz) : [];
   return starterQuizQuestions.length
-    ? `The lesson should include the following starter quiz questions. Include them within the lesson plan's starter quiz:
+    ? `The lesson should include the following starter quiz questions. Include them UNEDITED within the lesson plan's starter quiz:
 
 ${JSON.stringify(starterQuizQuestions)}`
     : null;

--- a/packages/ingest/src/generate-lesson-plans/user-prompt-parts/year.promptPart.ts
+++ b/packages/ingest/src/generate-lesson-plans/user-prompt-parts/year.promptPart.ts
@@ -1,4 +1,6 @@
 import type { RawLesson } from "../../zod-schema/zodSchema";
 
 export const yearPromptPart = ({ yearTitle }: RawLesson) =>
-  yearTitle ? `The lesson is intended for ${yearTitle}.` : null;
+  yearTitle
+    ? `The lesson is intended for the following UK school year: ${yearTitle}.`
+    : null;

--- a/packages/ingest/src/import-lessons/graphql/query.ts
+++ b/packages/ingest/src/import-lessons/graphql/query.ts
@@ -1,12 +1,32 @@
 import { gql } from "graphql-request";
 
+export type QueryWhere = {
+  videoTitle?: {
+    _is_null?: boolean;
+  };
+  isLegacy?: {
+    _is_null?: boolean;
+  };
+  lessonSlug?: {
+    _eq?: string;
+  };
+};
+export type QueryVariables = {
+  limit: number;
+  offset: number;
+  where: QueryWhere;
+};
 export const query = gql`
-  query OakLessons($limit: Int!, $offset: Int!) {
+  query OakLessons(
+    $limit: Int!
+    $offset: Int!
+    $where: published_mv_lesson_openapi_1_1_0_bool_exp!
+  ) {
     lessons: published_mv_lesson_openapi_1_1_0(
       limit: $limit
       offset: $offset
       distinct_on: lessonSlug
-      where: { videoTitle: { _is_null: false }, isLegacy: { _eq: false } }
+      where: $where
     ) {
       oakLessonId: lessonId
       lessonSlug

--- a/packages/ingest/src/import-lessons/importLessons.ts
+++ b/packages/ingest/src/import-lessons/importLessons.ts
@@ -6,7 +6,7 @@ import { getDataHash } from "../utils/getDataHash";
 import type { RawLesson } from "../zod-schema/zodSchema";
 import { RawLessonSchema } from "../zod-schema/zodSchema";
 import { graphqlClient } from "./graphql/client";
-import { query } from "./graphql/query";
+import { query, type QueryVariables } from "./graphql/query";
 
 const log = aiLogger("ingest");
 
@@ -28,13 +28,21 @@ export async function importLessons({
   const variables = {
     limit,
     offset,
+    where: {
+      videoTitle: {
+        _is_null: false,
+      },
+      isLegacy: {
+        _is_null: false,
+      },
+    },
   };
 
   while (true) {
-    const lessonData = await graphqlClient.request<{ lessons: unknown[] }>(
-      query,
-      variables,
-    );
+    const lessonData = await graphqlClient.request<
+      { lessons: unknown[] },
+      QueryVariables
+    >(query, variables);
 
     const parsedLessons: RawLesson[] = [];
 

--- a/packages/ingest/src/import-lessons/importLessonsFromOakDB.ts
+++ b/packages/ingest/src/import-lessons/importLessonsFromOakDB.ts
@@ -6,7 +6,7 @@ import { getDataHash } from "../utils/getDataHash";
 import type { RawLesson } from "../zod-schema/zodSchema";
 import { RawLessonSchema } from "../zod-schema/zodSchema";
 import { graphqlClient } from "./graphql/client";
-import { query } from "./graphql/query";
+import { query, type QueryVariables } from "./graphql/query";
 
 type ImportLessonsFromOakDBProps = {
   ingestId: string;
@@ -31,11 +31,19 @@ export async function importLessonsFromOakDB({
     const variables = {
       limit: perPage,
       offset,
+      where: {
+        videoTitle: {
+          _is_null: false,
+        },
+        isLegacy: {
+          _is_null: false,
+        },
+      },
     };
-    const lessonData = await graphqlClient.request<{ lessons: unknown[] }>(
-      query,
-      variables,
-    );
+    const lessonData = await graphqlClient.request<
+      { lessons: unknown[] },
+      QueryVariables
+    >(query, variables);
 
     const parsedLessons: RawLesson[] = [];
 

--- a/packages/ingest/src/singleLessonDryRun.ts
+++ b/packages/ingest/src/singleLessonDryRun.ts
@@ -1,0 +1,131 @@
+import { CompletedLessonPlanSchemaWithoutLength } from "@oakai/aila/src/protocol/schema";
+import { aiLogger } from "@oakai/logger";
+import fs from "node:fs";
+import path from "node:path";
+import { zodResponseFormat } from "openai/helpers/zod.mjs";
+import { dirname } from "path";
+import { fileURLToPath } from "url";
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+
+import { getCaptionsByFileName } from "./captions/getCaptionsByFileName";
+import { getCaptionsFileNameForLesson } from "./captions/getCaptionsFileNameForLesson";
+import { getSystemPrompt } from "./generate-lesson-plans/getSystemPrompt";
+import { getUserPrompt } from "./generate-lesson-plans/getUserPrompt";
+import { graphqlClient } from "./import-lessons/graphql/client";
+import {
+  query,
+  type QueryVariables,
+  type QueryWhere,
+} from "./import-lessons/graphql/query";
+import { openai } from "./openai-batches/openai";
+import { type RawLesson, RawLessonSchema } from "./zod-schema/zodSchema";
+
+const argv = await yargs(hideBin(process.argv))
+  .option("slug", {
+    alias: "s",
+    type: "string",
+    description: "Lesson slug",
+    demandOption: true,
+  })
+  .help().argv;
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+
+const log = aiLogger("ingest");
+
+void singleLessonDryRun();
+
+async function singleLessonDryRun() {
+  try {
+    const rawLesson = await fetchAndParseLesson();
+    const fileName = getCaptionsFileNameForLesson({
+      videoTitle: rawLesson.videoTitle,
+    });
+    const { caption: captions } = await getCaptionsByFileName(fileName);
+
+    const systemPrompt = getSystemPrompt({ rawLesson });
+    const userPrompt = getUserPrompt({
+      rawLesson,
+      sourcePartsToInclude: "all",
+      captions,
+    });
+
+    const responseFormat = zodResponseFormat(
+      CompletedLessonPlanSchemaWithoutLength,
+      "lesson_plan",
+    );
+
+    const completion = await openai.beta.chat.completions.parse({
+      model: "gpt-4o-2024-08-06",
+      temperature: 0.7,
+      messages: [
+        { role: "system", content: systemPrompt },
+        {
+          role: "user",
+          content: userPrompt,
+        },
+      ],
+      response_format: responseFormat,
+    });
+
+    const lessonPlan = completion?.choices?.[0]?.message.parsed;
+
+    if (!lessonPlan) {
+      log.error(completion);
+      throw new Error("Failed to generate lesson plan");
+    }
+
+    const DIR = path.join(__dirname, `_data/output/${rawLesson.lessonSlug}`);
+
+    // make a folder for the lesson
+    fs.mkdirSync(DIR, { recursive: true });
+    // make a file for the lesson
+    fs.writeFileSync(
+      path.join(DIR, `lesson.json`),
+      JSON.stringify(rawLesson, null, 2),
+    );
+    // make a file for each prompt
+    fs.writeFileSync(path.join(DIR, `systemPrompt.txt`), systemPrompt);
+    fs.writeFileSync(path.join(DIR, `userPrompt.txt`), userPrompt);
+    // make a file for the lesson plan
+    fs.writeFileSync(
+      path.join(DIR, `lessonPlan.json`),
+      JSON.stringify(lessonPlan, null, 2),
+    );
+  } catch (cause) {
+    log.error(cause);
+    throw new Error("Single lesson dry run failed", { cause });
+  }
+}
+
+async function fetchAndParseLesson(): Promise<RawLesson> {
+  const where: QueryWhere = {
+    videoTitle: {
+      _is_null: false,
+    },
+    isLegacy: {
+      _is_null: false,
+    },
+    lessonSlug: {
+      _eq: argv.slug,
+    },
+  };
+  const lessonData = await graphqlClient.request<
+    { lessons: unknown[] },
+    QueryVariables
+  >(query, { limit: 1, offset: 0, where });
+
+  const [lesson] = lessonData.lessons;
+
+  if (!lesson) {
+    throw new Error("Lesson not found");
+  }
+
+  try {
+    return RawLessonSchema.parse(lesson);
+  } catch (cause) {
+    throw new Error("Failed to parse lesson", { cause });
+  }
+}

--- a/packages/ingest/tsconfig.json
+++ b/packages/ingest/tsconfig.json
@@ -9,6 +9,7 @@
     "types": ["jest"],
     "allowImportingTsExtensions": true,
     "moduleDetection": "force",
-    "baseUrl": "./src"
+    "baseUrl": "./src",
+    "allowSyntheticDefaultImports": true
   }
 }

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -14,7 +14,7 @@ const debugBase = debug("ai");
 // By default debug logs to stderr, we want to use stdout
 debugBase.log = console.log.bind(console);
 
-type ChildKey =
+export type LoggerKey =
   | "admin"
   | "aila"
   | "aila:analytics"
@@ -88,7 +88,7 @@ const errorLogger =
  * const log = aiLogger("db");
  * log.info("Hello world");
  */
-export function aiLogger(childKey: ChildKey) {
+export function aiLogger(childKey: LoggerKey) {
   const debugLogger = debugBase.extend(childKey);
 
   const tableLogger = (tabularData: unknown[], columns?: string[]) => {

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -31,6 +31,7 @@ export type LoggerKey =
   | "aila:stream"
   | "aila:rag"
   | "aila:testing"
+  | "aila:quiz"
   | "aila:experimental-patches"
   | "analytics"
   | "app"

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -53,6 +53,7 @@ export type LoggerKey =
   | "inngest"
   | "judgements"
   | "lessons"
+  | "lessons:store"
   | "middleware:auth"
   | "moderation"
   | "prompts"

--- a/packages/rag/jest.config.mjs
+++ b/packages/rag/jest.config.mjs
@@ -6,13 +6,11 @@ const config = {
       {
         tsconfig: "tsconfig.test.json",
         useESM: true,
+        isolatedModules: true,
       },
     ],
   },
   preset: "ts-jest/presets/default-esm",
-  moduleNameMapper: {
-    "^(\\.{1,2}/.*)\\.js$": "$1",
-  },
   extensionsToTreatAsEsm: [".ts"],
   testEnvironment: "setup-polly-jest/jest-environment-node",
   testMatch: ["**/*.test.ts"],
@@ -21,4 +19,4 @@ const config = {
   resetMocks: true,
 };
 
-module.exports = config;
+export default config;

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
     "with-env": "dotenv -e ../../.env --",
-    "test": "pnpm with-env jest --colors --config jest.config.js"
+    "test": "pnpm with-env jest --colors --config jest.config.mjs"
   },
   "prettier": "@oakai/prettier-config",
   "dependencies": {

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -16,7 +16,7 @@
   "prettier": "@oakai/prettier-config",
   "dependencies": {
     "@anatine/zod-mock": "^3.13.4",
-    "@faker-js/faker": "^9.3.0",
+    "@faker-js/faker": "^9.4.0",
     "@oakai/core": "*",
     "@oakai/db": "*",
     "@oakai/logger": "*",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,9 +477,18 @@ importers:
       '@ai-sdk/openai':
         specifier: ^0.0.55
         version: 0.0.55(zod@3.23.8)
+      '@anatine/zod-mock':
+        specifier: ^3.13.4
+        version: 3.13.4(@faker-js/faker@9.4.0)(zod@3.23.8)
       '@clerk/nextjs':
         specifier: 5.7.2
         version: 5.7.2(next@14.2.21)(react-dom@18.2.0)(react@18.2.0)
+      '@elastic/elasticsearch':
+        specifier: ^8.13.1
+        version: 8.13.1
+      '@faker-js/faker':
+        specifier: ^9.4.0
+        version: 9.4.0
       '@oakai/core':
         specifier: '*'
         version: link:../core
@@ -959,10 +968,10 @@ importers:
     dependencies:
       '@anatine/zod-mock':
         specifier: ^3.13.4
-        version: 3.13.4(@faker-js/faker@9.3.0)(zod@3.23.8)
+        version: 3.13.4(@faker-js/faker@9.4.0)(zod@3.23.8)
       '@faker-js/faker':
-        specifier: ^9.3.0
-        version: 9.3.0
+        specifier: ^9.4.0
+        version: 9.4.0
       '@oakai/core':
         specifier: '*'
         version: link:../core
@@ -1123,13 +1132,13 @@ packages:
       '@jridgewell/gen-mapping': 0.3.5
       '@jridgewell/trace-mapping': 0.3.25
 
-  /@anatine/zod-mock@3.13.4(@faker-js/faker@9.3.0)(zod@3.23.8):
+  /@anatine/zod-mock@3.13.4(@faker-js/faker@9.4.0)(zod@3.23.8):
     resolution: {integrity: sha512-yO/KeuyYsEDCTcQ+7CiRuY3dnafMHIZUMok6Ci7aERRCTQ+/XmsiPk/RnMx5wlLmWBTmX9kw+PavbMsjM+sAJA==}
     peerDependencies:
       '@faker-js/faker': ^7.0.0 || ^8.0.0
       zod: ^3.21.4
     dependencies:
-      '@faker-js/faker': 9.3.0
+      '@faker-js/faker': 9.4.0
       randexp: 0.5.3
       zod: 3.23.8
     dev: false
@@ -3591,6 +3600,30 @@ packages:
     resolution: {integrity: sha512-d5RjycE+MObE/hU+8OM5Zp4VjTwiPLRa8299fj7muOmR16fb942z8byoMbCErnGh0lBevvgkGrLclQDvINbIyg==}
     dev: false
 
+  /@elastic/elasticsearch@8.13.1:
+    resolution: {integrity: sha512-2G4Vu6OHw4+XTrp7AGIcOEezpPEoVrWg2JTK1v/exEKSLYquZkUdd+m4yOL3/UZ6bTj7hmXwrmYzW76BnLCkJQ==}
+    engines: {node: '>=18'}
+    dependencies:
+      '@elastic/transport': 8.4.1
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@elastic/transport@8.4.1:
+    resolution: {integrity: sha512-/SXVuVnuU5b4dq8OFY4izG+dmGla185PcoqgK6+AJMpmOeY1QYVNbWtCwvSvoAANN5D/wV+EBU8+x7Vf9EphbA==}
+    engines: {node: '>=16'}
+    dependencies:
+      debug: 4.3.7(supports-color@5.5.0)
+      hpagent: 1.2.0
+      ms: 2.1.3
+      secure-json-parse: 2.7.0
+      tslib: 2.8.1
+      undici: 5.28.4
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
   /@emnapi/runtime@1.3.1:
     resolution: {integrity: sha512-kEBmG8KyqtxJZv+ygbEim+KCGtIq1fC22Ms3S4ziXmYKm8uyoLX0MHONVKwp+9opg390VaKRNt4a7A9NwmpNhw==}
     requiresBuild: true
@@ -3891,8 +3924,8 @@ packages:
       marked: 12.0.2
     dev: true
 
-  /@faker-js/faker@9.3.0:
-    resolution: {integrity: sha512-r0tJ3ZOkMd9xsu3VRfqlFR6cz0V/jFYRswAIpC+m/DIfAUXq7g8N7wTAlhSANySXYGKzGryfDXwtwsY8TxEIDw==}
+  /@faker-js/faker@9.4.0:
+    resolution: {integrity: sha512-85+k0AxaZSTowL0gXp8zYWDIrWclTbRPg/pm/V0dSFZ6W6D4lhcG3uuZl4zLsEKfEvs69xDbLN2cHQudwp95JA==}
     engines: {node: '>=18.0.0', npm: '>=9.0.0'}
     dev: false
 
@@ -21749,7 +21782,7 @@ packages:
   /rxjs@7.8.1:
     resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
     dependencies:
-      tslib: 2.7.0
+      tslib: 2.8.1
 
   /safe-array-concat@1.1.0:
     resolution: {integrity: sha512-ZdQ0Jeb9Ofti4hbt5lX3T2JcAamT9hfzYU1MNB+z/jaEbB6wfFfPIR/zEORmZqobkCCJhSjodobH6WHNmJ97dg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -880,15 +880,24 @@ importers:
       '@paralleldrive/cuid2':
         specifier: ^2.2.2
         version: 2.2.2
+      '@types/yargs':
+        specifier: ^17.0.33
+        version: 17.0.33
       csv-parser:
         specifier: ^3.0.0
         version: 3.0.0
       graphql-request:
         specifier: ^6.1.0
         version: 6.1.0(graphql@16.9.0)
+      tsx:
+        specifier: ^4.16.0
+        version: 4.16.0
       webvtt-parser:
         specifier: ^2.2.0
         version: 2.2.0
+      yargs:
+        specifier: ^17.7.2
+        version: 17.7.2
       zod:
         specifier: 3.23.8
         version: 3.23.8
@@ -5115,7 +5124,7 @@ packages:
       '@types/istanbul-lib-coverage': 2.0.6
       '@types/istanbul-reports': 3.0.4
       '@types/node': 20.17.9
-      '@types/yargs': 17.0.32
+      '@types/yargs': 17.0.33
       chalk: 4.1.2
 
   /@jridgewell/gen-mapping@0.3.3:
@@ -6771,8 +6780,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-alert-dialog@1.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-A6Kh23qZDLy3PSU4bh2UJZznOrUdHImIXqF8YtUa6CN73f8EOO9XlXSCd9IHyPvIquTaa/kwaSWzZTtUvgXVGw==}
+  /@radix-ui/react-alert-dialog@1.1.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-1Y2sI17QzSZP58RjGtrklfSGIf3AF7U/HkD3aAcAnhOUJrm7+7GG1wRDFaUlSe0nW5B/t4mYd/+7RNbP2Wexug==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -6787,7 +6796,7 @@ packages:
       '@radix-ui/primitive': 1.1.1
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-context': 1.1.1(@types/react@18.2.57)(react@18.2.0)
-      '@radix-ui/react-dialog': 1.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-dialog': 1.1.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-slot': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@types/react': 18.2.57
@@ -7009,8 +7018,8 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@radix-ui/react-context-menu@2.2.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-ap4wdGwK52rJxGkwukU1NrnEodsUFQIooANKu+ey7d6raQ2biTcEf8za1zr0mgFHieevRTB2nK4dJeN8pTAZGQ==}
+  /@radix-ui/react-context-menu@2.2.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-MY5PFCwo/ICaaQtpQBQ0g19AyjzI0mhz+a2GUWA2pJf4XFkvglAdcgDV2Iqm+lLbXn8hb+6rbLgcmRtc6ImPvg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7024,7 +7033,7 @@ packages:
     dependencies:
       '@radix-ui/primitive': 1.1.1
       '@radix-ui/react-context': 1.1.1(@types/react@18.2.57)(react@18.2.0)
-      '@radix-ui/react-menu': 2.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-menu': 2.1.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-callback-ref': 1.1.0(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.2.57)(react@18.2.0)
@@ -7061,8 +7070,8 @@ packages:
       react: 18.2.0
     dev: false
 
-  /@radix-ui/react-dialog@1.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-Ur7EV1IwQGCyaAuyDRiOLA5JIUZxELJljF+MbM/2NC0BYwfuRrbpS30BiQBJrVruscgUkieKkqXYDOoByaxIoA==}
+  /@radix-ui/react-dialog@1.1.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-LaO3e5h/NOEL4OfXjxD43k9Dx+vn+8n+PCFt6uhX/BADFflllyv3WJG6rgvvSVBxpTch938Qq/LGc2MMxipXPw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7077,7 +7086,7 @@ packages:
       '@radix-ui/primitive': 1.1.1
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-context': 1.1.1(@types/react@18.2.57)(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.3(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-focus-scope': 1.1.1(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-id': 1.1.0(@types/react@18.2.57)(react@18.2.0)
@@ -7146,8 +7155,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-dismissable-layer@1.1.3(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-onrWn/72lQoEucDmJnr8uczSNTujT0vJnA/X5+3AkChVPowr8n1yvIKIabhWyMQeMvvmdpsvcyDqx3X1LEXCPg==}
+  /@radix-ui/react-dismissable-layer@1.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-XDUI0IVYVSwjMXxM6P4Dfti7AH+Y4oS/TB+sglZ/EXc7cqLwGAmp1NlMrcUjj7ks6R5WTZuWKv44FBbLpwU3sA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7170,8 +7179,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-dropdown-menu@2.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-iXU1Ab5ecM+yEepGAWK8ZhMyKX4ubFdCNtol4sT9D0OVErG9PNElfx3TQhjw7n7BC5nFVz68/5//clWy+8TXzA==}
+  /@radix-ui/react-dropdown-menu@2.1.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-50ZmEFL1kOuLalPKHrLWvPFMons2fGx9TqQCWlPwDVpbAnaUJ1g4XNcKqFNMQymYU0kKWR4MDDi+9vUQBGFgcQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7187,7 +7196,7 @@ packages:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-context': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-id': 1.1.0(@types/react@18.2.57)(react@18.2.0)
-      '@radix-ui/react-menu': 2.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-menu': 2.1.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-primitive': 2.0.1(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-use-controllable-state': 1.1.0(@types/react@18.2.57)(react@18.2.0)
       '@types/react': 18.2.57
@@ -7256,8 +7265,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-hover-card@1.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-QSUUnRA3PQ2UhvoCv3eYvMnCAgGQW+sTu86QPuNb+ZMi+ZENd6UWpiXbcWDQ4AEaKF9KKpCHBeaJz9Rw6lRlaQ==}
+  /@radix-ui/react-hover-card@1.1.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-0jPlX3ZrUIhtMAY0m1SBn1koI4Yqsizq2UwdUiQF1GseSZLZBPa6b8tNS+m32K94Yb4wxtWFSQs85wujQvwahg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7272,7 +7281,7 @@ packages:
       '@radix-ui/primitive': 1.1.1
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-context': 1.1.1(@types/react@18.2.57)(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.3(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-popper': 1.2.1(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-portal': 1.1.3(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-presence': 1.1.2(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
@@ -7341,8 +7350,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-menu@2.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-BnOgVoL6YYdHAG6DtXONaR29Eq4nvbi8rutrV/xlr3RQCMMb3yqP85Qiw/3NReozrSW+4dfLkK+rc1hb4wPU/A==}
+  /@radix-ui/react-menu@2.1.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-uH+3w5heoMJtqVCgYOtYVMECk1TOrkUn0OG0p5MqXC0W2ppcuVeESbou8PTHoqAjbdTEK19AGXBWcEtR5WpEQg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7359,7 +7368,7 @@ packages:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-context': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-direction': 1.1.0(@types/react@18.2.57)(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.3(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-focus-scope': 1.1.1(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-id': 1.1.0(@types/react@18.2.57)(react@18.2.0)
@@ -7378,8 +7387,8 @@ packages:
       react-remove-scroll: 2.6.2(@types/react@18.2.57)(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-popover@1.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-aUACAkXx8LaFymDma+HQVji7WhvEhpFJ7+qPz17Nf4lLZqtreGOFRiNQWQmhzp7kEWg9cOyyQJpdIMUMPc/CPw==}
+  /@radix-ui/react-popover@1.1.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-YXkTAftOIW2Bt3qKH8vYr6n9gCkVrvyvfiTObVjoHVTHnNj26rmvO87IKa3VgtgCjb8FAQ6qOjNViwl+9iIzlg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7394,7 +7403,7 @@ packages:
       '@radix-ui/primitive': 1.1.1
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-context': 1.1.1(@types/react@18.2.57)(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.3(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-focus-scope': 1.1.1(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-id': 1.1.0(@types/react@18.2.57)(react@18.2.0)
@@ -7682,8 +7691,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-select@2.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-pOkb2u8KgO47j/h7AylCj7dJsm69BXcjkrvTqMptFqsE2i0p8lHkfgneXKjAgPzBMivnoMyt8o4KiV4wYzDdyQ==}
+  /@radix-ui/react-select@2.1.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-eVV7N8jBXAXnyrc+PsOF89O9AfVgGnbLxUtBb0clJ8y8ENMWLARGMI/1/SBRLz7u4HqxLgN71BJ17eono3wcjA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7701,7 +7710,7 @@ packages:
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-context': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-direction': 1.1.0(@types/react@18.2.57)(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.3(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-focus-guards': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-focus-scope': 1.1.1(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-id': 1.1.0(@types/react@18.2.57)(react@18.2.0)
@@ -7886,8 +7895,8 @@ packages:
       react-dom: 18.2.0(react@18.2.0)
     dev: false
 
-  /@radix-ui/react-tooltip@1.1.6(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
-    resolution: {integrity: sha512-TLB5D8QLExS1uDn7+wH/bjEmRurNMTzNrtq7IjaS4kjion9NtzsTGkvR5+i7yc9q01Pi2KMM2cN3f8UG4IvvXA==}
+  /@radix-ui/react-tooltip@1.1.7(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0):
+    resolution: {integrity: sha512-ss0s80BC0+g0+Zc53MvilcnTYSOi4mSuFWBPYPuTOFGjx+pUU+ZrmamMNwS56t8MTFlniA5ocjd4jYm/CdhbOg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7902,7 +7911,7 @@ packages:
       '@radix-ui/primitive': 1.1.1
       '@radix-ui/react-compose-refs': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-context': 1.1.1(@types/react@18.2.57)(react@18.2.0)
-      '@radix-ui/react-dismissable-layer': 1.1.3(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-dismissable-layer': 1.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-id': 1.1.0(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-popper': 1.2.1(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-portal': 1.1.3(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
@@ -8167,27 +8176,27 @@ packages:
       '@radix-ui/colors': 2.0.1
       '@radix-ui/primitive': 1.1.1
       '@radix-ui/react-accessible-icon': 1.1.1(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-alert-dialog': 1.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-alert-dialog': 1.1.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-aspect-ratio': 1.1.1(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-avatar': 1.1.2(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-checkbox': 1.1.3(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-context-menu': 2.2.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-dialog': 1.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-context-menu': 2.2.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-dialog': 1.1.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-direction': 1.1.0(@types/react@18.2.57)(react@18.2.0)
-      '@radix-ui/react-dropdown-menu': 2.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-dropdown-menu': 2.1.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-form': 0.1.1(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-hover-card': 1.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-popover': 1.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-hover-card': 1.1.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-popover': 1.1.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-portal': 1.1.3(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-radio-group': 1.2.2(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-scroll-area': 1.2.2(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-select': 2.1.4(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-select': 2.1.5(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-separator': 1.1.1(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-slider': 1.2.2(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-slot': 1.1.1(@types/react@18.2.57)(react@18.2.0)
       '@radix-ui/react-switch': 1.1.2(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-tabs': 1.1.2(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
-      '@radix-ui/react-tooltip': 1.1.6(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
+      '@radix-ui/react-tooltip': 1.1.7(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@radix-ui/react-visually-hidden': 1.1.1(@types/react-dom@18.2.19)(@types/react@18.2.57)(react-dom@18.2.0)(react@18.2.0)
       '@types/react': 18.2.57
       '@types/react-dom': 18.2.19
@@ -10094,8 +10103,8 @@ packages:
   /@types/yargs-parser@21.0.3:
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}
 
-  /@types/yargs@17.0.32:
-    resolution: {integrity: sha512-xQ67Yc/laOG5uMfX/093MRlGGCIBzZMarVa+gfNKJxWAIgykYpVGkBdbqEzGDDfCrVUj6Hiff4mTZ5BA6TmAog==}
+  /@types/yargs@17.0.33:
+    resolution: {integrity: sha512-WpxBCKWPLr4xSsHgz511rFJAM+wS28w2zEO1QDNY5zM/S8ok70NNfztH0xwhqKyaK0OHCbN98LDAZuy1ctxDkA==}
     dependencies:
       '@types/yargs-parser': 21.0.3
 
@@ -13854,10 +13863,6 @@ packages:
       '@esbuild/win32-arm64': 0.21.5
       '@esbuild/win32-ia32': 0.21.5
       '@esbuild/win32-x64': 0.21.5
-
-  /escalade@3.1.1:
-    resolution: {integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==}
-    engines: {node: '>=6'}
 
   /escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
@@ -24696,7 +24701,7 @@ packages:
     engines: {node: '>=12'}
     dependencies:
       cliui: 8.0.1
-      escalade: 3.1.1
+      escalade: 3.2.0
       get-caller-file: 2.0.5
       require-directory: 2.1.1
       string-width: 4.2.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -182,6 +182,9 @@ importers:
       '@trpc/server':
         specifier: 10.45.2
         version: 10.45.2
+      '@types/object-hash':
+        specifier: ^3.0.6
+        version: 3.0.6
       '@types/ramda':
         specifier: ^0.30.2
         version: 0.30.2
@@ -3339,7 +3342,7 @@ packages:
       '@clerk/shared': 2.9.0(react-dom@18.2.0)(react@18.2.0)
       '@clerk/types': 4.25.0
       crypto-js: 4.2.0
-      next: 14.2.21(react-dom@18.2.0)(react@18.2.0)
+      next: 14.2.21(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.47.2)(react-dom@18.2.0)(react@18.2.0)
       react: 18.2.0
       react-dom: 18.2.0(react@18.2.0)
       server-only: 0.0.1
@@ -9962,6 +9965,10 @@ packages:
 
   /@types/normalize-package-data@2.4.2:
     resolution: {integrity: sha512-lqa4UEhhv/2sjjIQgjX8B+RBjj47eo0mzGasklVJ78UKGQY1r0VpB9XHDaZZO9qzEFDdy4MrXLuEaSmPrPSe/A==}
+    dev: false
+
+  /@types/object-hash@3.0.6:
+    resolution: {integrity: sha512-fOBV8C1FIu2ELinoILQ+ApxcUKz4ngq+IWUYrxSGjXzzjUALijilampwkMgEtJ+h2njAW3pi853QpzNVCHB73w==}
     dev: false
 
   /@types/pako@1.0.7:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -525,6 +525,9 @@ importers:
       dotenv-cli:
         specifier: ^6.0.0
         version: 6.0.0
+      immer:
+        specifier: ^10.1.1
+        version: 10.1.1
       jsonrepair:
         specifier: ^3.8.0
         version: 3.8.0
@@ -15885,6 +15888,10 @@ packages:
 
   /immediate@3.0.6:
     resolution: {integrity: sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==}
+    dev: false
+
+  /immer@10.1.1:
+    resolution: {integrity: sha512-s2MPrmjovJcoMaHtx6K11Ra7oD05NT97w1IC5zpMkT6Atjr7H8LjaDd81iIxUYpMKSRRNMJE703M1Fhr/TctHw==}
     dev: false
 
   /immutable@3.7.6:

--- a/turbo.json
+++ b/turbo.json
@@ -112,6 +112,7 @@
     "GOOGLE_SLIDES_*",
     "HELICONE_*",
     "HUBSPOT_ACCESS_TOKEN",
+    "I_DOT_AI_ELASTIC_*",
     "INGEST_OPENAI_API_KEY",
     "INNGEST_*",
     "KV_*",


### PR DESCRIPTION
## Description

## Enhancements & Features
- **Add feature to define prompt via URL** [#491](https://github.com/oaknational/oak-ai-lesson-assistant/pull/491)
- **Support for dry run ingestion (single mode)** [#501](https://github.com/oaknational/oak-ai-lesson-assistant/pull/501)
- **Admin button to reverse safety violations** [#497](https://github.com/oaknational/oak-ai-lesson-assistant/pull/497)
- **Implement maths logic based on recommender** [#490](https://github.com/oaknational/oak-ai-lesson-assistant/pull/490)
- **Refetch lesson plan when streaming completes** [#529](https://github.com/oaknational/oak-ai-lesson-assistant/pull/529)

## Fixes
- **Add message queueing to chat store** [#517](https://github.com/oaknational/oak-ai-lesson-assistant/pull/517)
- **Include `basedOn` field in `LessonPlanKeySchema`** [#531](https://github.com/oaknational/oak-ai-lesson-assistant/pull/531)

## Refactoring
- **Improve logging: store changes by key** [#516](https://github.com/oaknational/oak-ai-lesson-assistant/pull/516)
- **Wrap AILA Zustand state in context** [#523](https://github.com/oaknational/oak-ai-lesson-assistant/pull/523)
- **Initial lesson plan store (not yet rendered)** [#525](https://github.com/oaknational/oak-ai-lesson-assistant/pull/525)

## Chores & Maintenance
- **Fix remaining linting errors** [#512](https://github.com/oaknational/oak-ai-lesson-assistant/pull/512)
- **Remove unnecessary `await` from archive finalization** [#521](https://github.com/oaknational/oak-ai-lesson-assistant/pull/521)
- **Update SonarQube action in GitHub workflows** [#527](https://github.com/oaknational/oak-ai-lesson-assistant/pull/527)

