### PR TITLE
fix: maths lesson plan overrides

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.tsx
@@ -143,21 +143,8 @@ export const LessonPlanDisplay = ({
   documentContainerRef,
   showLessonMobile,
 }: LessonPlanDisplayProps) => {
-  const lessonPlanFromStore = useLessonPlanStore((state) => state.lessonPlan);
+  const lessonPlan = useLessonPlanStore((state) => state.lessonPlan);
   const lastModeration = useModerationStore((state) => state.lastModeration);
-
-  const lessonPlan = useMemo(
-    () => ({
-      ...lessonPlanFromStore,
-      starterQuiz:
-        lessonPlanFromStore._experimental_starterQuizMathsV0 ??
-        lessonPlanFromStore.starterQuiz,
-      exitQuiz:
-        lessonPlanFromStore._experimental_exitQuizMathsV0 ??
-        lessonPlanFromStore.exitQuiz,
-    }),
-    [lessonPlanFromStore],
-  );
 
   const { userHasCancelledAutoScroll } =
     useDetectScrollOverride(documentContainerRef);

--- a/apps/nextjs/src/components/AppComponents/Chat/lesson-plan-section/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/lesson-plan-section/index.tsx
@@ -7,7 +7,10 @@ import styled from "styled-components";
 import { Icon } from "@/components/Icon";
 import LoadingWheel from "@/components/LoadingWheel";
 import { useLessonPlanStore } from "@/stores/AilaStoresProvider";
-import { sectionStatusSelector } from "@/stores/lessonPlanStore/selectors";
+import {
+  lessonPlanSectionSelector,
+  sectionStatusSelector,
+} from "@/stores/lessonPlanStore/selectors";
 
 import Skeleton from "../../common/Skeleton";
 import { LessonPlanSectionContent } from "../drop-down-section/lesson-plan-section-content";
@@ -27,7 +30,7 @@ export const LessonPlanSection = ({
   showLessonMobile,
   setSectionRef,
 }: LessonPlanSectionProps) => {
-  const section = useLessonPlanStore((state) => state.lessonPlan[sectionKey]);
+  const section = useLessonPlanStore(lessonPlanSectionSelector(sectionKey));
   const status = useLessonPlanStore(sectionStatusSelector(sectionKey));
 
   const sectionRef = useRef(null);

--- a/apps/nextjs/src/stores/lessonPlanStore/selectors.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/selectors.ts
@@ -1,6 +1,30 @@
-import type { LessonPlanKey } from "@oakai/aila/src/protocol/schema";
+import type {
+  LessonPlanKey,
+  LooseLessonPlan,
+} from "@oakai/aila/src/protocol/schema";
 
 import type { LessonPlanStore } from "./index";
+
+const sectionKeyOverrides = {
+  starterQuiz: "_experimental_starterQuizMathsV0",
+  exitQuiz: "_experimental_exitQuizMathsV0",
+} as const;
+
+export const lessonPlanSectionSelector = (sectionKey: LessonPlanKey) => {
+  return (
+    state: LessonPlanStore,
+  ): LooseLessonPlan[LessonPlanKey] | undefined => {
+    if (sectionKey === "starterQuiz" || sectionKey === "exitQuiz") {
+      const overiddenSection =
+        state.lessonPlan[sectionKeyOverrides[sectionKey]];
+      if (overiddenSection) {
+        return overiddenSection;
+      }
+    }
+
+    return state.lessonPlan[sectionKey];
+  };
+};
 
 type SectionStatus = "empty" | "streaming" | "loaded";
 


### PR DESCRIPTION
In recent changes to lesson plan rendering we stopped passing the lessonPlan into section components with prop drilling, and moved instead to fetching each section from the lesson plan store. This broke the experimental lesson plan functionality which was replacing lesson plan sections in LessonPlanDisplay
