### PR TITLE
chore: move remaining lint warnings to errors

### DIFF
--- a/apps/nextjs/src/app/aila/[id]/page.tsx
+++ b/apps/nextjs/src/app/aila/[id]/page.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useUser } from "@clerk/nextjs";
-
 import ChatPageContents from "../page-contents";
 
 interface ChatPageProps {
@@ -11,7 +9,6 @@ interface ChatPageProps {
 }
 
 export default function ChatPage({ params }: Readonly<ChatPageProps>) {
-  const user = useUser();
   const { id } = params;
   // For local development so that we can warm up the server
   if (id === "health") {

--- a/apps/nextjs/src/app/aila/page.tsx
+++ b/apps/nextjs/src/app/aila/page.tsx
@@ -14,7 +14,7 @@ interface IndexPageProps {
   };
 }
 
-export default async function IndexPage({ searchParams }: IndexPageProps) {
+export default function IndexPage({ searchParams }: IndexPageProps) {
   const clerkAuthentication = auth();
   const { userId }: { userId: string | null } = clerkAuthentication;
   if (!userId) {

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-left-hand-side.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-left-hand-side.tsx
@@ -1,6 +1,5 @@
 import { Flex } from "@radix-ui/themes";
 
-import { useDemoUser } from "@/components/ContextProviders/Demo";
 import { useDemoLocking } from "@/hooks/useDemoLocking";
 
 import ChatLhsHeader from "./chat-lhs-header";

--- a/apps/nextjs/src/stores/chatStore/index.ts
+++ b/apps/nextjs/src/stores/chatStore/index.ts
@@ -18,7 +18,7 @@ const log = aiLogger("chat:store");
 
 export type AiSdkActions = {
   stop: () => void;
-  reload: () => void;
+  reload: () => Promise<string | null | undefined>;
   append: (
     message: AiMessage | CreateMessage,
     chatRequestOptions?: ChatRequestOptions | undefined,
@@ -78,8 +78,8 @@ export const createChatStore = (initialValues: Partial<ChatStore> = {}) => {
     // From AI SDK
     aiSdkActions: {
       stop: () => {},
-      reload: () => {},
-      append: async () => Promise.resolve(""),
+      reload: () => Promise.resolve(null),
+      append: () => Promise.resolve(""),
     },
 
     // Setters

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleExecuteQueuedAction.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleExecuteQueuedAction.ts
@@ -29,7 +29,7 @@ export function handleExecuteQueuedAction(
           role: "user",
         });
       } else if (actionToExecute === "regenerate") {
-        aiSdkActions.reload();
+        void aiSdkActions.reload();
       } else {
         void aiSdkActions.append({
           content: actionToExecute,

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleScrollToBottom.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleScrollToBottom.ts
@@ -5,7 +5,6 @@ import type { ChatStore } from "../index";
 const log = aiLogger("chat:store");
 
 export const handleScrollToBottom =
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   (set: (partial: Partial<ChatStore>) => void, get: () => ChatStore) => () => {
     const { chatAreaRef } = get();
     if (!chatAreaRef?.current) {

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleStreamingFinished.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleStreamingFinished.ts
@@ -1,7 +1,6 @@
 import type { ChatStore } from "../index";
 
 export const handleStreamingFinished =
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   (set: (partial: Partial<ChatStore>) => void, get: () => ChatStore) => () => {
     get().scrollToBottom();
 

--- a/packages/eslint-config/src/rules.mjs
+++ b/packages/eslint-config/src/rules.mjs
@@ -2,17 +2,6 @@ import tsEslint from '@typescript-eslint/eslint-plugin';
 
 const typescript = tsEslint.configs.recommended;
 
-// These are rules that are currently set to "warn"
-// But should be set to "error" once we fix all the existing issues
-const rulesToMoveToError = {
-  "@typescript-eslint/no-unsafe-return": "warn",
-  "@typescript-eslint/no-misused-promises": "warn",
-  "@typescript-eslint/no-unsafe-argument": "warn",
-  "@typescript-eslint/no-floating-promises": "warn",
-  "@typescript-eslint/no-unsafe-member-access": "warn",
-  "@typescript-eslint/no-redundant-type-constituents": "warn",       
-}
-
 const rulesToDecideOn = {
   "@typescript-eslint/no-unsafe-assignment": "off", // this rule is buggy and is causing a lot of false positives
   "@typescript-eslint/no-unsafe-call": "off", // this rule is buggy and is causing a lot of false positives
@@ -22,7 +11,6 @@ const rulesToDecideOn = {
 /** @type {Partial<Record<string, import('@typescript-eslint/utils/ts-eslint').SharedConfig.RuleEntry>>} */
 export const rules = {
   ...typescript.rules,
-  ...rulesToMoveToError,
   ...rulesToDecideOn,
   "@typescript-eslint/prefer-nullish-coalescing": "warn",
   "@typescript-eslint/no-unsafe-enum-comparison": "error",
@@ -36,7 +24,7 @@ export const rules = {
     allowTernary: true,
     allowTaggedTemplates: true,
   }],
-  "@typescript-eslint/require-await": "warn",  
+  "@typescript-eslint/require-await": "warn",
   "@typescript-eslint/unbound-method": "off",
   "@typescript-eslint/restrict-template-expressions": "error",
   "@typescript-eslint/await-thenable": "error",
@@ -44,6 +32,12 @@ export const rules = {
     allowExpressions: true,
     allowTypedFunctionExpressions: true,
   }],
+  "@typescript-eslint/no-unsafe-return": "error",
+  "@typescript-eslint/no-misused-promises": "error",
+  "@typescript-eslint/no-unsafe-argument": "error",
+  "@typescript-eslint/no-floating-promises": "error",
+  "@typescript-eslint/no-unsafe-member-access": "error",
+  "@typescript-eslint/no-redundant-type-constituents": "error",
 
   // Import plugin rules
   "import/no-cycle": ["warn", { maxDepth: Infinity }],

--- a/packages/ingest/src/captions/getCaptionsByFileName.ts
+++ b/packages/ingest/src/captions/getCaptionsByFileName.ts
@@ -4,7 +4,7 @@ import type { Cue } from "webvtt-parser";
 import * as WebVTTModule from "webvtt-parser";
 
 const WebVTTParser =
-  // @ts-expect-error import issue: TO doesn't think .default exists
+  // @ts-expect-error import issue: TS doesn't think .default exists
   // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
   WebVTTModule.default.WebVTTParser as typeof WebVTTModule.WebVTTParser;
 

--- a/packages/ingest/src/captions/getCaptionsByFileName.ts
+++ b/packages/ingest/src/captions/getCaptionsByFileName.ts
@@ -3,10 +3,10 @@ import { aiLogger } from "@oakai/logger";
 import type { Cue } from "webvtt-parser";
 import * as WebVTTModule from "webvtt-parser";
 
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-expect-error
-const WebVTTParser = WebVTTModule.default
-  .WebVTTParser as typeof WebVTTModule.WebVTTParser;
+const WebVTTParser =
+  // @ts-expect-error import issue: TO doesn't think .default exists
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+  WebVTTModule.default.WebVTTParser as typeof WebVTTModule.WebVTTParser;
 
 const log = aiLogger("ingest");
 

--- a/packages/rag/lib/search/search.test.ts
+++ b/packages/rag/lib/search/search.test.ts
@@ -85,6 +85,7 @@ describe.skip("vectorSearch", () => {
       filters: mockFilters,
     });
 
+    // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
     expect((mockPrisma.$queryRaw as jest.Mock).mock.calls[0][0][0]).toEqual(
       expect.stringContaining("SELECT"),
     );


### PR DESCRIPTION
Stef and Joe did some great work with our eslint rules, but some rules were hard to fix while we had the moving target of work in other branches. This PR brings the remaining warning rules into the errors list