### PR TITLE
fix: handle AilaThreatDetectionError in aila plugins

### DIFF
--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -111,11 +111,7 @@ export class AilaStreamHandler {
         error: e,
         type: e?.constructor?.name,
       });
-      if (e instanceof AilaThreatDetectionError) {
-        log.info("Handling threat detection error");
-        await this._chat.generationFailed(e);
-        throw e;
-      }
+      await this._chat.generationFailed(e);
       await this.handleStreamError(e);
       log.info("Stream error", e, this._chat.iteration, this._chat.id);
     } finally {


### PR DESCRIPTION
## Description

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to https://oak-ai-lesson-assistant-4unpfs3a1.vercel-preview.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
