### PR TITLE
refactor: bundle store actions under a single key

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/AiSdk.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/AiSdk.tsx
@@ -1,5 +1,4 @@
-import type React from "react";
-import { useEffect, useState } from "react";
+import { useEffect } from "react";
 import { toast } from "react-hot-toast";
 
 import { generateMessageId } from "@oakai/aila/src/helpers/chat/generateMessageId";
@@ -13,7 +12,12 @@ import { useChatStoreAiSdkSync } from "src/stores/chatStore/hooks/useChatStoreAi
 import { useLessonPlanStoreAiSdkSync } from "src/stores/lessonPlanStore/hooks/useLessonPlanStoreAiSdkSync";
 
 import useAnalytics from "@/lib/analytics/useAnalytics";
-import { useChatStore, useLessonPlanStore } from "@/stores/AilaStoresProvider";
+import {
+  useChatActions,
+  useChatStore,
+  useLessonPlanActions,
+  useLessonPlanStore,
+} from "@/stores/AilaStoresProvider";
 
 import { findMessageIdFromContent } from "./Chat/utils";
 import { isAccountLocked } from "./chat-message/protocol";
@@ -43,14 +47,11 @@ function useActionMessages() {
 
 export function AiSdk({ id }: Readonly<AiSdkProps>) {
   const path = usePathname();
-  const [hasFinished, setHasFinished] = useState(true);
 
   const initialMessages = useChatStore((state) => state.initialMessages);
   const lessonPlan = useLessonPlanStore((state) => state.lessonPlan);
-  const streamingFinished = useChatStore((state) => state.streamingFinished);
-  const scrollToBottom = useChatStore((state) => state.scrollToBottom);
-  const messageStarted = useLessonPlanStore((state) => state.messageStarted);
-  const messageFinished = useLessonPlanStore((state) => state.messageFinished);
+  const chatActions = useChatActions();
+  const lessonPlanActions = useLessonPlanActions();
 
   // TODO: move to chat store
   const { invokeActionMessages } = useActionMessages();
@@ -75,7 +76,7 @@ export function AiSdk({ id }: Readonly<AiSdkProps>) {
       },
     },
     fetch(input: RequestInfo | URL, init?: RequestInit | undefined) {
-      messageStarted();
+      lessonPlanActions.messageStarted();
       return fetch(input, init);
     },
     onError(error) {
@@ -83,20 +84,15 @@ export function AiSdk({ id }: Readonly<AiSdkProps>) {
         extra: { originalError: error },
       });
       log.error("UseChat error", { error, messages });
-      setHasFinished(true);
     },
     onResponse(response) {
       log.info("Chat: On Response");
 
       // TODO: create onResponse handler in store and call from there
-      scrollToBottom();
+      chatActions.scrollToBottom();
 
       if (response.status === 401) {
         toast.error(response.statusText);
-        setHasFinished(true);
-      }
-      if (hasFinished) {
-        setHasFinished(false);
       }
       if (!path?.includes("chat/[id]")) {
         window.history.pushState({}, "", `/aila/${id}`);
@@ -110,9 +106,8 @@ export function AiSdk({ id }: Readonly<AiSdkProps>) {
 
       invokeActionMessages(response.content);
 
-      setHasFinished(true);
-      streamingFinished();
-      messageFinished();
+      chatActions.streamingFinished();
+      lessonPlanActions.messageFinished();
     },
   });
 

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import type {
   BasedOnOptional,
@@ -14,6 +14,7 @@ import {
   useChatStore,
   useModerationStore,
   useLessonPlanStore,
+  useLessonPlanActions,
 } from "@/stores/AilaStoresProvider";
 import { slugToSentenceCase } from "@/utils/toSentenceCase";
 
@@ -54,9 +55,7 @@ const useSectionScrolling = ({
   userHasCancelledAutoScroll: boolean;
 }) => {
   const scrollToSection = useLessonPlanStore((state) => state.scrollToSection);
-  const setScrollToSection = useLessonPlanStore(
-    (state) => state.setScrollToSection,
-  );
+  const { setScrollToSection } = useLessonPlanActions();
   const lastScrollToSectionRef = useRef<LessonPlanKey | null>(null);
 
   useEffect(() => {

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-panel.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-panel.tsx
@@ -6,7 +6,11 @@ import { PromptForm } from "@/components/AppComponents/Chat/prompt-form";
 import { useLessonPlanTracking } from "@/lib/analytics/lessonPlanTrackingContext";
 import useAnalytics from "@/lib/analytics/useAnalytics";
 import { useSidebar } from "@/lib/hooks/use-sidebar";
-import { useChatStore, useLessonPlanStore } from "@/stores/AilaStoresProvider";
+import {
+  useChatActions,
+  useChatStore,
+  useLessonPlanStore,
+} from "@/stores/AilaStoresProvider";
 import { canAppendSelector } from "@/stores/chatStore/selectors";
 
 import ChatPanelDisclaimer from "./chat-panel-disclaimer";
@@ -23,10 +27,9 @@ function LockedPromptForm() {
 
 export function ChatPanel({ isDemoLocked }: Readonly<ChatPanelProps>) {
   const input = useChatStore((state) => state.input);
-  const setInput = useChatStore((state) => state.setInput);
+  const { setInput, append } = useChatActions();
   const id = useLessonPlanStore((state) => state.id);
 
-  const append = useChatStore((state) => state.append);
   const shouldAllowUserInput = useChatStore(canAppendSelector);
 
   const hasMessages = useChatStore(

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-quick-buttons.tsx
@@ -5,7 +5,11 @@ import { findLast } from "remeda";
 import { Icon } from "@/components/Icon";
 import { useLessonPlanTracking } from "@/lib/analytics/lessonPlanTrackingContext";
 import useAnalytics from "@/lib/analytics/useAnalytics";
-import { useChatStore, useLessonPlanStore } from "@/stores/AilaStoresProvider";
+import {
+  useChatActions,
+  useChatStore,
+  useLessonPlanStore,
+} from "@/stores/AilaStoresProvider";
 import type { AilaStreamingStatus } from "@/stores/chatStore";
 import { canAppendSelector } from "@/stores/chatStore/selectors";
 
@@ -45,8 +49,7 @@ const QuickActionButtons = () => {
   const lessonPlanTracking = useLessonPlanTracking();
   const { setDialogWindow } = useDialog();
   const queuedUserAction = useChatStore((state) => state.queuedUserAction);
-  const append = useChatStore((state) => state.append);
-  const stop = useChatStore((state) => state.stop);
+  const { append, stop } = useChatActions();
   const id = useLessonPlanStore((state) => state.id);
 
   const ailaStreamingStatus = useChatStore(

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/action-button-wrapper.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/action-button-wrapper.tsx
@@ -5,7 +5,11 @@ import type { LessonPlanSectionWhileStreaming } from "@oakai/aila/src/protocol/s
 import { OakBox } from "@oaknational/oak-components";
 import type { AilaUserModificationAction } from "@prisma/client";
 
-import { useChatStore, useLessonPlanStore } from "@/stores/AilaStoresProvider";
+import {
+  useChatActions,
+  useChatStore,
+  useLessonPlanStore,
+} from "@/stores/AilaStoresProvider";
 import { trpc } from "@/utils/trpc";
 
 import ActionButton from "./action-button";
@@ -49,7 +53,7 @@ const ActionButtonWrapper = ({
     useState<FeedbackOption<AilaUserModificationAction> | null>(null);
 
   const id = useLessonPlanStore((state) => state.id);
-  const append = useChatStore((state) => state.append);
+  const { append } = useChatActions();
   const { mutateAsync } = trpc.chat.chatFeedback.modifySection.useMutation();
 
   const messages = useChatStore((state) => state.stableMessages);

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/LessonPlanProgressDropdown.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/LessonPlanProgressDropdown.tsx
@@ -4,15 +4,17 @@ import * as DropdownMenu from "@radix-ui/react-dropdown-menu";
 import { Flex } from "@radix-ui/themes";
 
 import { Icon } from "@/components/Icon";
-import { useChatStore, useLessonPlanStore } from "@/stores/AilaStoresProvider";
+import {
+  useChatStore,
+  useLessonPlanActions,
+  useLessonPlanStore,
+} from "@/stores/AilaStoresProvider";
 
 import { useProgressForDownloads } from "../Chat/hooks/useProgressForDownloads";
 
 export const LessonPlanProgressDropdown: React.FC = () => {
   const lessonPlan = useLessonPlanStore((state) => state.lessonPlan);
-  const setScrollToSection = useLessonPlanStore(
-    (state) => state.setScrollToSection,
-  );
+  const { setScrollToSection } = useLessonPlanActions();
   const isStreaming = useChatStore(
     (state) => state.ailaStreamingStatus !== "Idle",
   );

--- a/apps/nextjs/src/stores/AilaStoresProvider.tsx
+++ b/apps/nextjs/src/stores/AilaStoresProvider.tsx
@@ -73,9 +73,9 @@ export const AilaStoresProvider: React.FC<AilaStoresProviderProps> = ({
     if (haveInitialized.current) {
       return;
     }
-    void stores.chat.getState().fetchInitialMessages();
-    void stores.lessonPlan.getState().refetch();
-    void stores.moderation.getState().fetchModerations();
+    void stores.chat.getState().actions.fetchInitialMessages();
+    void stores.lessonPlan.getState().actions.refetch();
+    void stores.moderation.getState().actions.fetchModerations();
     haveInitialized.current = true;
   }, [stores.lessonPlan, id, stores.moderation, stores.chat]);
 
@@ -83,10 +83,12 @@ export const AilaStoresProvider: React.FC<AilaStoresProviderProps> = ({
     const unsubscribe = stores.chat.subscribe((state, prevState) => {
       const streamingStatus = state.ailaStreamingStatus;
       if (streamingStatus !== prevState.ailaStreamingStatus) {
-        stores.chat.getState().ailaStreamingStatusUpdated(streamingStatus);
+        stores.chat
+          .getState()
+          .actions.ailaStreamingStatusUpdated(streamingStatus);
         stores.moderation
           .getState()
-          .ailaStreamingStatusUpdated(streamingStatus);
+          .actions.ailaStreamingStatusUpdated(streamingStatus);
       }
     });
     return () => {
@@ -109,6 +111,15 @@ export const useChatStore = <T,>(selector: (store: ChatState) => T) => {
   return useStore(context.chat, selector);
 };
 
+// Actions are stable so we can bundle them up to be easier to use
+export const useChatActions = () => {
+  const context = useContext(AilaStoresContext);
+  if (!context) {
+    throw new Error("Missing AilaStoresProvider");
+  }
+  return useStore(context.chat, (state) => state.actions);
+};
+
 export const useModerationStore = <T,>(
   selector: (store: ModerationState) => T,
 ) => {
@@ -119,6 +130,15 @@ export const useModerationStore = <T,>(
   return useStore(context.moderation, selector);
 };
 
+// Actions are stable so we can bundle them up to be easier to use
+export const useModerationActions = () => {
+  const context = useContext(AilaStoresContext);
+  if (!context) {
+    throw new Error("Missing AilaStoresProvider");
+  }
+  return useStore(context.moderation, (state) => state.actions);
+};
+
 export const useLessonPlanStore = <T,>(
   selector: (store: LessonPlanState) => T,
 ) => {
@@ -127,4 +147,13 @@ export const useLessonPlanStore = <T,>(
     throw new Error("Missing AilaStoresProvider");
   }
   return useStore(context.lessonPlan, selector);
+};
+
+// Actions are stable so we can bundle them up to be easier to use
+export const useLessonPlanActions = () => {
+  const context = useContext(AilaStoresContext);
+  if (!context) {
+    throw new Error("Missing AilaStoresProvider");
+  }
+  return useStore(context.lessonPlan, (state) => state.actions);
 };

--- a/apps/nextjs/src/stores/chatStore/__tests__/executeQueuedActions.test.tsx
+++ b/apps/nextjs/src/stores/chatStore/__tests__/executeQueuedActions.test.tsx
@@ -23,7 +23,7 @@ describe("Chat Store executeQueuedAction", () => {
     });
     const initialState = store.getState();
 
-    store.getState().executeQueuedAction();
+    store.getState().actions.executeQueuedAction();
 
     const newState = store.getState();
 
@@ -40,7 +40,7 @@ describe("Chat Store executeQueuedAction", () => {
     const initialState = store.getState();
     store.setState({ queuedUserAction: "continue" });
 
-    store.getState().executeQueuedAction();
+    store.getState().actions.executeQueuedAction();
 
     const newState = store.getState();
     expect(store.getState().queuedUserAction).toBeNull();
@@ -58,7 +58,7 @@ describe("Chat Store executeQueuedAction", () => {
     const initialState = store.getState();
     store.setState({ queuedUserAction: "regenerate" });
 
-    store.getState().executeQueuedAction();
+    store.getState().actions.executeQueuedAction();
 
     const newState = store.getState();
     expect(store.getState().queuedUserAction).toBeNull();
@@ -74,7 +74,7 @@ describe("Chat Store executeQueuedAction", () => {
     const customMessage = "Hello, world!";
     store.setState({ queuedUserAction: customMessage });
 
-    store.getState().executeQueuedAction();
+    store.getState().actions.executeQueuedAction();
 
     const newState = store.getState();
     expect(store.getState().queuedUserAction).toBeNull();
@@ -91,7 +91,7 @@ describe("Chat Store executeQueuedAction", () => {
     });
     const initialState = store.getState();
     store.setState({ queuedUserAction: "continue" });
-    store.getState().executeQueuedAction();
+    store.getState().actions.executeQueuedAction();
     expect(store.getState().queuedUserAction).toBeNull();
     expect(mockAiSdkActions.append).toHaveBeenCalledWith({
       content: "Continue",
@@ -99,7 +99,7 @@ describe("Chat Store executeQueuedAction", () => {
     });
 
     store.setState({ queuedUserAction: "regenerate" });
-    store.getState().executeQueuedAction();
+    store.getState().actions.executeQueuedAction();
     const newState = store.getState();
     expect(store.getState().queuedUserAction).toBeNull();
     expect(mockAiSdkActions.reload).toHaveBeenCalled();

--- a/apps/nextjs/src/stores/chatStore/__tests__/handleAppend.test.ts
+++ b/apps/nextjs/src/stores/chatStore/__tests__/handleAppend.test.ts
@@ -22,7 +22,7 @@ describe("handleAppend", () => {
       aiSdkActions: mockAiSdkActions as unknown as AiSdkActions,
     });
 
-    store.getState().append("Hello");
+    store.getState().actions.append("Hello");
 
     expect(mockAiSdkActions.append).not.toHaveBeenCalled();
   });
@@ -33,7 +33,7 @@ describe("handleAppend", () => {
       aiSdkActions: mockAiSdkActions as unknown as AiSdkActions,
     });
 
-    store.getState().append("Hello");
+    store.getState().actions.append("Hello");
 
     expect(store.getState().queuedUserAction).toBe("Hello");
     expect(mockAiSdkActions.append).not.toHaveBeenCalled();
@@ -45,7 +45,7 @@ describe("handleAppend", () => {
       aiSdkActions: mockAiSdkActions as unknown as AiSdkActions,
     });
 
-    store.getState().append("Hello");
+    store.getState().actions.append("Hello");
 
     expect(mockAiSdkActions.append).toHaveBeenCalledWith({
       content: "Hello",

--- a/apps/nextjs/src/stores/chatStore/__tests__/handleStop.test.ts
+++ b/apps/nextjs/src/stores/chatStore/__tests__/handleStop.test.ts
@@ -21,7 +21,7 @@ describe("handleStop", () => {
       queuedUserAction: "Some action",
       aiSdkActions: mockAiSdkActions as unknown as AiSdkActions,
     });
-    store.getState().stop();
+    store.getState().actions.stop();
 
     expect(store.getState().queuedUserAction).toBeNull();
     expect(mockAiSdkActions.stop).not.toHaveBeenCalled();
@@ -31,7 +31,7 @@ describe("handleStop", () => {
     const store = createChatStore(id, getStore, trpcUtils, {
       aiSdkActions: mockAiSdkActions as unknown as AiSdkActions,
     });
-    store.getState().stop();
+    store.getState().actions.stop();
 
     expect(mockAiSdkActions.stop).toHaveBeenCalled();
   });

--- a/apps/nextjs/src/stores/chatStore/__tests__/setMessages.test.ts
+++ b/apps/nextjs/src/stores/chatStore/__tests__/setMessages.test.ts
@@ -102,14 +102,14 @@ describe("Chat Store setMessages", () => {
     const store = setupStore();
 
     expect(() => {
-      store.getState().setMessages([], true);
+      store.getState().actions.setMessages([], true);
     }).toThrow();
   });
 
   test("expected state when there no messages, loading false", () => {
     const store = setupStore();
     const initialState = store.getState();
-    store.getState().setMessages([], false);
+    store.getState().actions.setMessages([], false);
     const newState = store.getState();
 
     expect(newState.streamingMessage).toBe(null);
@@ -125,7 +125,7 @@ describe("Chat Store setMessages", () => {
 
     store
       .getState()
-      .setMessages(messageStates.streamingMessage as AiMessage[], true);
+      .actions.setMessages(messageStates.streamingMessage as AiMessage[], true);
 
     const newState = store.getState();
 
@@ -141,7 +141,10 @@ describe("Chat Store setMessages", () => {
 
     store
       .getState()
-      .setMessages(messageStates.stableAndStreaming as AiMessage[], true);
+      .actions.setMessages(
+        messageStates.stableAndStreaming as AiMessage[],
+        true,
+      );
 
     const newState = store.getState();
 
@@ -156,7 +159,7 @@ describe("Chat Store setMessages", () => {
     const store = setupStore();
     store
       .getState()
-      .setMessages(messageStates.stableMessages as AiMessage[], true);
+      .actions.setMessages(messageStates.stableMessages as AiMessage[], true);
 
     const newState = store.getState();
     expect(newState.stableMessages.length).toBe(
@@ -170,7 +173,7 @@ describe("Chat Store setMessages", () => {
     const store = setupStore();
     store
       .getState()
-      .setMessages(messageStates.userRequest as AiMessage[], false);
+      .actions.setMessages(messageStates.userRequest as AiMessage[], false);
 
     const newState = store.getState();
 
@@ -206,7 +209,7 @@ describe("Chat Store setMessages", () => {
     const store = setupStore();
     store
       .getState()
-      .setMessages(messageStates.streamingMessage as AiMessage[], true);
+      .actions.setMessages(messageStates.streamingMessage as AiMessage[], true);
 
     const newState = store.getState();
     expect(newState.streamingMessage?.parts).toBeDefined();
@@ -219,13 +222,13 @@ describe("Chat Store setMessages", () => {
     const store = setupStore();
     store
       .getState()
-      .setMessages(messageStates.stableMessages as AiMessage[], true);
+      .actions.setMessages(messageStates.stableMessages as AiMessage[], true);
 
     const initialState = store.getState();
 
     store
       .getState()
-      .setMessages(messageStates.stableMessages as AiMessage[], true);
+      .actions.setMessages(messageStates.stableMessages as AiMessage[], true);
 
     const newState = store.getState();
 
@@ -240,11 +243,11 @@ describe("Chat Store setMessages", () => {
     store.subscribe((state) => renderSpy(state.stableMessages));
     store
       .getState()
-      .setMessages(messageStates.stableMessages as AiMessage[], true);
+      .actions.setMessages(messageStates.stableMessages as AiMessage[], true);
     const initialState = store.getState();
     store
       .getState()
-      .setMessages(messageStates.stableMessages as AiMessage[], true);
+      .actions.setMessages(messageStates.stableMessages as AiMessage[], true);
     const newState = store.getState();
     expect(renderSpy).toHaveBeenCalledTimes(2);
     expect(newState.stableMessages).toBe(initialState.stableMessages);
@@ -254,12 +257,12 @@ describe("Chat Store setMessages", () => {
     const store = setupStore();
     store
       .getState()
-      .setMessages(messageStates.stableMessages as AiMessage[], true);
+      .actions.setMessages(messageStates.stableMessages as AiMessage[], true);
     expect(store.getState().ailaStreamingStatus).toBe("Moderating");
 
     store
       .getState()
-      .setMessages(messageStates.userRequest as AiMessage[], false);
+      .actions.setMessages(messageStates.userRequest as AiMessage[], false);
     expect(store.getState().ailaStreamingStatus).toBe("Idle");
   });
 });

--- a/apps/nextjs/src/stores/chatStore/hooks/useChatStoreAiSdkSync.ts
+++ b/apps/nextjs/src/stores/chatStore/hooks/useChatStoreAiSdkSync.ts
@@ -7,7 +7,7 @@ import type {
   Message,
 } from "ai";
 
-import { useChatStore } from "@/stores/AilaStoresProvider";
+import { useChatActions } from "@/stores/AilaStoresProvider";
 
 export const useChatStoreAiSdkSync = (
   messages: AiMessage[],
@@ -19,8 +19,7 @@ export const useChatStoreAiSdkSync = (
   ) => Promise<string | null | undefined>,
   reload: () => Promise<string | null | undefined>,
 ) => {
-  const setMessages = useChatStore((state) => state.setMessages);
-  const setAiSdkActions = useChatStore((state) => state.setAiSdkActions);
+  const { setMessages, setAiSdkActions } = useChatActions();
 
   useEffect(() => {
     setMessages(messages, isLoading);

--- a/apps/nextjs/src/stores/chatStore/index.ts
+++ b/apps/nextjs/src/stores/chatStore/index.ts
@@ -45,21 +45,23 @@ export const createChatStore = (
       append: () => Promise.resolve(""),
     },
 
-    // Setters
-    setAiSdkActions: (aiSdkActions) => set({ aiSdkActions }),
-    setLessonPlan: (lessonPlan) => set({ lessonPlan }),
-    setInput: (input) => set({ input }),
-    setChatAreaRef: (ref) => set({ chatAreaRef: ref }),
+    actions: {
+      // Setters
+      setAiSdkActions: (aiSdkActions) => set({ aiSdkActions }),
+      setLessonPlan: (lessonPlan) => set({ lessonPlan }),
+      setInput: (input) => set({ input }),
+      setChatAreaRef: (ref) => set({ chatAreaRef: ref }),
 
-    // Action functions
-    executeQueuedAction: handleExecuteQueuedAction(set, get),
-    append: handleAppend(set, get),
-    stop: handleStop(set, get),
-    setMessages: handleSetMessages(getStore, set, get),
-    streamingFinished: handleStreamingFinished(set, get),
-    scrollToBottom: handleScrollToBottom(set, get),
-    fetchInitialMessages: handleFetchInitialMessages(set, get, trpcUtils),
-    ailaStreamingStatusUpdated: handleAilaStreamingStatusUpdated(set, get),
+      // Action functions
+      executeQueuedAction: handleExecuteQueuedAction(set, get),
+      append: handleAppend(set, get),
+      stop: handleStop(set, get),
+      setMessages: handleSetMessages(getStore, set, get),
+      streamingFinished: handleStreamingFinished(set, get),
+      scrollToBottom: handleScrollToBottom(set, get),
+      fetchInitialMessages: handleFetchInitialMessages(set, get, trpcUtils),
+      ailaStreamingStatusUpdated: handleAilaStreamingStatusUpdated(set, get),
+    },
 
     ...initialValues,
   }));

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleAilaStreamingStatusUpdated.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleAilaStreamingStatusUpdated.ts
@@ -9,6 +9,6 @@ export const handleAilaStreamingStatusUpdated =
   (set: ChatSetter, get: ChatGetter) =>
   (streamingStatus: AilaStreamingStatus) => {
     if (streamingStatus === "Idle" && get().queuedUserAction) {
-      void get().executeQueuedAction();
+      void get().actions.executeQueuedAction();
     }
   };

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleFetchInitialMessages.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleFetchInitialMessages.ts
@@ -32,7 +32,7 @@ export const handleFetchInitialMessages =
 
       if (startingMessage) {
         log.info("Appending starting message");
-        get().append(startingMessage);
+        get().actions.append(startingMessage);
       }
       log.info(`Set initial messages for AI SDK from DB`);
     } catch (err) {

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleSetMessages.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleSetMessages.ts
@@ -2,7 +2,6 @@ import invariant from "tiny-invariant";
 
 import type { GetStore } from "@/stores/AilaStoresProvider";
 
-import type { AilaStreamingStatus } from "..";
 import { calculateStreamingStatus } from "../actions/calculateStreamingStatus";
 import { getNextStableMessages, parseStreamingMessage } from "../parsing";
 import type { ChatSetter, ChatGetter, AiMessage } from "../types";

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleStreamingFinished.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleStreamingFinished.ts
@@ -2,5 +2,5 @@ import type { ChatSetter, ChatGetter } from "../types";
 
 export const handleStreamingFinished =
   (set: ChatSetter, get: ChatGetter) => () => {
-    get().scrollToBottom();
+    get().actions.scrollToBottom();
   };

--- a/apps/nextjs/src/stores/chatStore/types.ts
+++ b/apps/nextjs/src/stores/chatStore/types.ts
@@ -39,21 +39,23 @@ export type ChatState = {
   // From AI SDK
   aiSdkActions: AiSdkActions;
 
-  // Setters
-  setLessonPlan: (lessonPlan: LooseLessonPlan) => void;
-  setAiSdkActions: (actions: AiSdkActions) => void;
-  setMessages: (messages: AiMessage[], isLoading: boolean) => void;
-  setInput: (input: string) => void;
-  setChatAreaRef: (ref: React.RefObject<HTMLDivElement>) => void;
+  actions: {
+    // Setters
+    setLessonPlan: (lessonPlan: LooseLessonPlan) => void;
+    setAiSdkActions: (actions: AiSdkActions) => void;
+    setMessages: (messages: AiMessage[], isLoading: boolean) => void;
+    setInput: (input: string) => void;
+    setChatAreaRef: (ref: React.RefObject<HTMLDivElement>) => void;
 
-  // Action functions
-  executeQueuedAction: () => void;
-  append: (message: string) => void;
-  stop: () => void;
-  streamingFinished: () => void;
-  scrollToBottom: () => void;
-  fetchInitialMessages: () => Promise<void>;
-  ailaStreamingStatusUpdated: (streamingStatus: AilaStreamingStatus) => void;
+    // Action functions
+    executeQueuedAction: () => void;
+    append: (message: string) => void;
+    stop: () => void;
+    streamingFinished: () => void;
+    scrollToBottom: () => void;
+    fetchInitialMessages: () => Promise<void>;
+    ailaStreamingStatusUpdated: (streamingStatus: AilaStreamingStatus) => void;
+  };
 };
 
 export type ParsedMessage = AiMessage & {

--- a/apps/nextjs/src/stores/lessonPlanStore/hooks/useLessonPlanStoreAiSdkSync.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/hooks/useLessonPlanStoreAiSdkSync.ts
@@ -1,13 +1,13 @@
 import { useEffect } from "react";
 
-import { useLessonPlanStore } from "@/stores/AilaStoresProvider";
+import { useLessonPlanActions } from "@/stores/AilaStoresProvider";
 import type { AiMessage } from "@/stores/chatStore/types";
 
 export const useLessonPlanStoreAiSdkSync = (
   messages: AiMessage[],
   isLoading: boolean,
 ) => {
-  const messagesUpdated = useLessonPlanStore((state) => state.messagesUpdated);
+  const { messagesUpdated } = useLessonPlanActions();
 
   useEffect(() => {
     messagesUpdated(messages);

--- a/apps/nextjs/src/stores/lessonPlanStore/index.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/index.ts
@@ -46,27 +46,29 @@ export const createLessonPlanStore = ({
 
     ...initialPerMessageState,
 
-    // Setters
-    setScrollToSection: (sectionKey) => set({ scrollToSection: sectionKey }),
+    actions: {
+      // Setters
+      setScrollToSection: (sectionKey) => set({ scrollToSection: sectionKey }),
 
-    // Action functions
-    messageStarted: () => {
-      log.info("Message started");
-      set({
-        isAcceptingChanges: true,
-        lastLessonPlan: get().lessonPlan,
-      });
+      // Action functions
+      messageStarted: () => {
+        log.info("Message started");
+        set({
+          isAcceptingChanges: true,
+          lastLessonPlan: get().lessonPlan,
+        });
+      },
+      messagesUpdated: handleMessagesUpdated(set, get),
+      messageFinished: () => {
+        log.info("Message finished");
+        set({ isAcceptingChanges: false, ...initialPerMessageState });
+        handleTrackingEvents(lessonPlanTracking, getStore, get);
+        // TODO: should we refetch when we start moderating?
+        void handleRefetch(set, get, trpcUtils)();
+      },
+      refetch: handleRefetch(set, get, trpcUtils),
+      resetStore: () => set({ lessonPlan: {} }),
     },
-    messagesUpdated: handleMessagesUpdated(set, get),
-    messageFinished: () => {
-      log.info("Message finished");
-      set({ isAcceptingChanges: false, ...initialPerMessageState });
-      handleTrackingEvents(lessonPlanTracking, getStore, get);
-      // TODO: should we refetch when we start moderating?
-      void handleRefetch(set, get, trpcUtils)();
-    },
-    refetch: handleRefetch(set, get, trpcUtils),
-    resetStore: () => set({ lessonPlan: {} }),
 
     ...initialValues,
   }));

--- a/apps/nextjs/src/stores/lessonPlanStore/types.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/types.ts
@@ -20,15 +20,17 @@ export type LessonPlanState = {
   isShared: boolean;
   scrollToSection: LessonPlanKey | null;
 
-  // setters
-  setScrollToSection: (sectionKey: LessonPlanKey | null) => void;
+  actions: {
+    // setters
+    setScrollToSection: (sectionKey: LessonPlanKey | null) => void;
 
-  // actions
-  messageStarted: () => void;
-  messagesUpdated: (messages: AiMessage[]) => void;
-  messageFinished: () => void;
-  refetch: () => Promise<void>;
-  resetStore: () => void;
+    // actions
+    messageStarted: () => void;
+    messagesUpdated: (messages: AiMessage[]) => void;
+    messageFinished: () => void;
+    refetch: () => Promise<void>;
+    resetStore: () => void;
+  };
 };
 
 export type LessonPlanSetter = StoreApi<LessonPlanState>["setState"];

--- a/apps/nextjs/src/stores/moderationStore/actionFunctions/handleAilaStreamingStatus.ts
+++ b/apps/nextjs/src/stores/moderationStore/actionFunctions/handleAilaStreamingStatus.ts
@@ -11,6 +11,6 @@ export const handleAilaStreamingStatusUpdated =
   (set: ModerationSetter, get: ModerationGetter) =>
   (streamingStatus: AilaStreamingStatus) => {
     if (streamingStatus === "Idle") {
-      void get().fetchModerations();
+      void get().actions.fetchModerations();
     }
   };

--- a/apps/nextjs/src/stores/moderationStore/actionFunctions/handleFetchModeration.tsx
+++ b/apps/nextjs/src/stores/moderationStore/actionFunctions/handleFetchModeration.tsx
@@ -13,7 +13,7 @@ export const handleFetchModerations = (
   trpcUtils: TrpcUtils,
 ) => {
   return async () => {
-    const { updateModerationState, id } = get();
+    const { actions, id } = get();
 
     set({
       isModerationsLoading: true,
@@ -23,7 +23,7 @@ export const handleFetchModerations = (
         await trpcUtils.chat.appSessions.getModerations.fetch({
           id,
         });
-      updateModerationState(fetchedModerations);
+      actions.updateModerationState(fetchedModerations);
     } catch (error) {
       log.error("Error fetching moderation", error);
       Sentry.captureException(error);

--- a/apps/nextjs/src/stores/moderationStore/actionFunctions/handleToxicModeration.tsx
+++ b/apps/nextjs/src/stores/moderationStore/actionFunctions/handleToxicModeration.tsx
@@ -13,6 +13,6 @@ export const handleToxicModeration =
   ) =>
   (mod: PersistedModerationBase | null) => {
     set({ toxicModeration: mod });
-    getStore("chat").setMessages([], false);
-    getStore("lessonPlan").resetStore();
+    getStore("chat").actions.setMessages([], false);
+    getStore("lessonPlan").actions.resetStore();
   };

--- a/apps/nextjs/src/stores/moderationStore/actionFunctions/handleUpdateModerationState.tsx
+++ b/apps/nextjs/src/stores/moderationStore/actionFunctions/handleUpdateModerationState.tsx
@@ -19,7 +19,7 @@ export const handleUpdateModerationState = (
     });
 
     if (toxicMod) {
-      get().updateToxicModeration(lastMod);
+      get().actions.updateToxicModeration(lastMod);
     }
   };
 };

--- a/apps/nextjs/src/stores/moderationStore/index.ts
+++ b/apps/nextjs/src/stores/moderationStore/index.ts
@@ -31,25 +31,28 @@ export const createModerationStore = ({
     toxicModeration: null,
     lastModeration: null,
 
-    setLastModeration: (mod) => set({ lastModeration: mod }),
-    setIsModerationsLoading: (isModerationsLoading) =>
-      set({ isModerationsLoading }),
+    actions: {
+      setLastModeration: (mod) => set({ lastModeration: mod }),
+      setIsModerationsLoading: (isModerationsLoading) =>
+        set({ isModerationsLoading }),
 
-    updateToxicModeration: handleToxicModeration(getStore, set, get),
-    updateModerationState: handleUpdateModerationState(set, get),
+      updateToxicModeration: handleToxicModeration(getStore, set, get),
+      updateModerationState: handleUpdateModerationState(set, get),
 
-    fetchModerations: handleFetchModerations(set, get, trpcUtils),
+      fetchModerations: handleFetchModerations(set, get, trpcUtils),
 
-    clearModerations: () => {
-      set({
-        moderations: [],
-        isModerationsLoading: null,
-        toxicInitialModeration: null,
-        toxicModeration: null,
-        lastModeration: null,
-      });
+      clearModerations: () => {
+        set({
+          moderations: [],
+          isModerationsLoading: null,
+          toxicInitialModeration: null,
+          toxicModeration: null,
+          lastModeration: null,
+        });
+      },
+      ailaStreamingStatusUpdated: handleAilaStreamingStatusUpdated(set, get),
     },
-    ailaStreamingStatusUpdated: handleAilaStreamingStatusUpdated(set, get),
+
     ...initialValues,
   }));
   logStoreUpdates(moderationStore, "moderation:store");

--- a/apps/nextjs/src/stores/moderationStore/types.ts
+++ b/apps/nextjs/src/stores/moderationStore/types.ts
@@ -12,14 +12,16 @@ export type ModerationState = {
   toxicModeration: PersistedModerationBase | null;
   lastModeration: PersistedModerationBase | null;
 
-  updateToxicModeration: (mod: PersistedModerationBase | null) => void;
-  setLastModeration: (mod: PersistedModerationBase | null) => void;
-  setIsModerationsLoading: (isModerationsLoading: boolean) => void;
-  updateModerationState: (mods?: Moderation[]) => void;
-  fetchModerations: () => Promise<void>;
+  actions: {
+    updateToxicModeration: (mod: PersistedModerationBase | null) => void;
+    setLastModeration: (mod: PersistedModerationBase | null) => void;
+    setIsModerationsLoading: (isModerationsLoading: boolean) => void;
+    updateModerationState: (mods?: Moderation[]) => void;
+    fetchModerations: () => Promise<void>;
 
-  clearModerations: () => void;
-  ailaStreamingStatusUpdated: (streamingStatus: AilaStreamingStatus) => void;
+    clearModerations: () => void;
+    ailaStreamingStatusUpdated: (streamingStatus: AilaStreamingStatus) => void;
+  };
 };
 
 export type ModerationGetter = StoreApi<ModerationState>["getState"];


### PR DESCRIPTION
Following this recommendation: https://tkdodo.eu/blog/working-with-zustand#separate-actions-from-state

Actions don't ever update so we don't need to split them up into individual hooks to reduce renders. Being able to grab all the actions for a store can save us boilerplate

There is a small caveat to this approach: calls like `stores.chat.getState().actions.fetchInitialMessages();` are a bit longer with `.actions` in there, but we generally shouldn't be calling into stores like that too much so it could be some helpful friction

## Description

- Move all store actions into an `actions` object
- Add actions hook for each store
- Remove unused `hasFinished` useState
