### PR TITLE
fix: initial state being called twice

### DIFF
--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -83,7 +83,6 @@ export class AilaStreamHandler {
       await this.checkForThreats();
       this.logStreamingStep("Check for threats complete");
 
-      await this._chat.handleSettingInitialState();
       log.info("Setting initial state");
       await this._chat.handleSettingInitialState();
       this.logStreamingStep("Handle initial state complete");


### PR DESCRIPTION
## Description

- await this._chat.handleSettingInitialState(); was being called twice in the stream handler