### PR TITLE
fix: use type key rather than response for llmMesage

### DIFF
--- a/packages/core/src/prompts/lesson-assistant/parts/protocol.ts
+++ b/packages/core/src/prompts/lesson-assistant/parts/protocol.ts
@@ -1,6 +1,7 @@
 import type { TemplateProps } from "..";
 
-const responseFormatWithStructuredOutputs = "{\"response\":\"llmMessage\", patches:[{},{}...], prompt:{}}";
+const responseFormatWithStructuredOutputs =
+  '{"type":"llmMessage", patches:[{},{}...], prompt:{}}';
 const responseFormatWithoutStructuredOutputs = `A series of JSON documents separated using the JSON Text Sequences specification, where each row is separated by the ␞ character and ends with a new line character.
 Your response should be a series of patches followed by one and only one prompt to the user.`;
 


### PR DESCRIPTION
## Description

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to {deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
