### PR TITLE
fix: use llmMessage JSON schema in prompt

### DIFF
--- a/packages/aila/src/protocol/jsonPatchProtocol.ts
+++ b/packages/aila/src/protocol/jsonPatchProtocol.ts
@@ -472,19 +472,6 @@ export const JsonPatchDocumentJsonSchema = zodToJsonSchema(
   "patchDocumentSchema",
 );
 
-export const LLMResponseSchema = z.discriminatedUnion("type", [
-  PatchDocumentSchema,
-  PromptDocumentSchema,
-  StateDocumentSchema,
-  CommentDocumentSchema,
-  ErrorDocumentSchema,
-]);
-
-export const LLMResponseJsonSchema = zodToJsonSchema(
-  LLMResponseSchema,
-  "llmResponseSchema",
-);
-
 export const MessagePartDocumentSchema = z.discriminatedUnion("type", [
   ModerationDocumentSchema,
   ErrorDocumentSchema,
@@ -574,6 +561,15 @@ const LLMMessageSchemaWhileStreaming = z.object({
   prompt: TextDocumentSchema.optional(),
   status: z.literal("complete").optional(),
 });
+
+export const LLMResponseSchema = z.discriminatedUnion("type", [
+  LLMMessageSchema,
+]);
+
+export const LLMResponseJsonSchema = zodToJsonSchema(
+  LLMResponseSchema,
+  "llmResponseSchema",
+);
 
 function tryParseJson(str: string): {
   parsed: { type: string } | null;


### PR DESCRIPTION
On a local branch I accidentally disabled structured outputs and I found that the LLM message was in the wrong structure. Specifically, the "prompt" key in the llmMessage type was this shape:

```
  message: "Are the learning outcome and learning cycles appropriate for...",
  type: "text"
```

When it should have been

```
  value: "Are the learning outcome and learning cycles appropriate for...",
  type: "text"
```

This is because we were providing the schema for old parts in the prompt:

```
  Patch
  Prompt
  State
  Comment
  Error
```

Because there wasn't a schema for `LLMMessage`, it tried the structure of the `Prompt` part

## Description

- Replace old part types in the schema with the LLMMessage part schema
