### PR TITLE
feat: record THREAT in the database rather than HELICONE

### DIFF
--- a/apps/nextjs/src/app/api/chat/webActionsPlugin.test.ts
+++ b/apps/nextjs/src/app/api/chat/webActionsPlugin.test.ts
@@ -144,7 +144,7 @@ describe("onStreamError", () => {
     expect(recordViolation).toHaveBeenCalledWith(
       "user_abc",
       "CHAT_MESSAGE",
-      "HELICONE",
+      "THREAT",
       "CHAT_SESSION",
       "chat_abc",
     );

--- a/apps/nextjs/src/app/api/chat/webActionsPlugin.test.ts
+++ b/apps/nextjs/src/app/api/chat/webActionsPlugin.test.ts
@@ -118,7 +118,7 @@ describe("webActionsPlugin", () => {
 });
 
 describe("onStreamError", () => {
-  it("should record a safety violation when a helicone error is encountered", async () => {
+  it("should record a safety violation when a threat error is encountered", async () => {
     const recordViolation = jest.fn();
     const safetyViolations = jest.fn().mockImplementation(() => ({
       recordViolation,

--- a/packages/aila/src/utils/moderation/moderationErrorHandling.ts
+++ b/packages/aila/src/utils/moderation/moderationErrorHandling.ts
@@ -24,7 +24,7 @@ export async function handleThreatDetectionError(
   SafetyViolations = defaultSafetyViolations,
 ): Promise<ErrorDocument | ActionDocument> {
   await safelyReportAnalyticsEvent({
-    eventName: "helicone_threat_detected",
+    eventName: "threat_detected",
     userId,
     payload: {
       chat_id: chatId,
@@ -37,7 +37,7 @@ export async function handleThreatDetectionError(
     await safetyViolations.recordViolation(
       userId,
       "CHAT_MESSAGE",
-      "HELICONE",
+      "THREAT",
       "CHAT_SESSION",
       chatId,
     );

--- a/packages/db/prisma/migrations/20250310114619_add_threat_to_safety_violation_source/migration.sql
+++ b/packages/db/prisma/migrations/20250310114619_add_threat_to_safety_violation_source/migration.sql
@@ -1,0 +1,2 @@
+-- AlterEnum
+ALTER TYPE "public"."SafetyViolationSource" ADD VALUE 'THREAT';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -845,6 +845,7 @@ enum SafetyViolationSource {
   HELICONE
   OPENAI
   MODERATION
+  THREAT
 
   @@schema("public")
 }


### PR DESCRIPTION
## Description

- This attributes detected threats as THREAT the safety violation source column in the DB, rather than HELICONE
- Updates the name of the analytics event to be threat_detected instead of helicone_threat_detected
- No user-facing changes
- Migration is required
