### PR TITLE
chore: bump Prettier to 3.5.3

### DIFF
--- a/packages/eslint-config/package.json
+++ b/packages/eslint-config/package.json
@@ -27,10 +27,10 @@
     "eslint-plugin-storybook": "^0.11.1",
     "eslint-plugin-turbo": "^2.3.3",
     "globals": "^15.13.0",
-    "prettier": "^3.4.1",
     "ts-node": "^10.9.2",
     "typescript": "5.7.2"
   },
+  "prettier": "@oakai/prettier-config",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/prettier-config/package.json
+++ b/packages/prettier-config/package.json
@@ -4,11 +4,8 @@
   "main": "index.mjs",
   "devDependencies": {
     "@trivago/prettier-plugin-sort-imports": "^4.3.0",
-    "prettier": "^3.4.1",
+    "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.9"
-  },
-  "peerDependencies": {
-    "prettier": "^3.1.1"
   },
   "type": "module"
 }


### PR DESCRIPTION
## Description

- Updates prettier to latest: 3.5.3
- Removes duplicate imports of Prettier
- Ensures all packages use the customer Prettier config
- No user-facing change

