### PR TITLE
feat: report linting issues for touched files on the PR as a comment (WIP)

### DIFF
--- a/.github/scripts/post-lint-comment.ts
+++ b/.github/scripts/post-lint-comment.ts
@@ -1,20 +1,24 @@
-import * as fs from 'fs';
-import * as core from '@actions/core';
-import * as github from '@actions/github';
+import * as core from "@actions/core";
+import * as github from "@actions/github";
+import * as fs from "fs";
 
 /**
  * Finds an existing bot comment with the specified content
  */
-async function findExistingComment(octokit: ReturnType<typeof github.getOctokit>, context: typeof github.context): Promise<{ id: number } | undefined> {
+async function findExistingComment(
+  octokit: ReturnType<typeof github.getOctokit>,
+  context: typeof github.context,
+): Promise<{ id: number } | undefined> {
   const { data: comments } = await octokit.rest.issues.listComments({
     issue_number: context.issue.number,
     owner: context.repo.owner,
     repo: context.repo.repo,
   });
 
-  return comments.find(comment => 
-    comment?.user?.type === 'Bot' && 
-    comment?.body?.includes('ESLint Diff Results')
+  return comments.find(
+    (comment) =>
+      comment?.user?.type === "Bot" &&
+      comment?.body?.includes("ESLint Diff Results"),
   );
 }
 
@@ -27,8 +31,8 @@ async function postLintComment(reportPath: string): Promise<void> {
       throw new Error(`Report file not found: ${reportPath}`);
     }
 
-    const commentBody = fs.readFileSync(reportPath, 'utf8');
-    const token = core.getInput('github-token');
+    const commentBody = fs.readFileSync(reportPath, "utf8");
+    const token = core.getInput("github-token");
     const octokit = github.getOctokit(token);
     const context = github.context;
 
@@ -39,20 +43,20 @@ async function postLintComment(reportPath: string): Promise<void> {
         comment_id: botComment.id,
         owner: context.repo.owner,
         repo: context.repo.repo,
-        body: commentBody
+        body: commentBody,
       });
-      console.log('Updated existing PR comment');
+      console.log("Updated existing PR comment");
     } else {
       await octokit.rest.issues.createComment({
         issue_number: context.issue.number,
         owner: context.repo.owner,
         repo: context.repo.repo,
-        body: commentBody
+        body: commentBody,
       });
-      console.log('Created new PR comment');
+      console.log("Created new PR comment");
     }
   } catch (error) {
-    console.error('Error posting PR comment:', error);
+    console.error("Error posting PR comment:", error);
     core.setFailed(`Failed to post PR comment: ${error}`);
   }
 }
@@ -61,16 +65,16 @@ async function postLintComment(reportPath: string): Promise<void> {
 if (require.main === module) {
   const args = process.argv.slice(2);
   if (args.length < 1) {
-    console.error('Usage: ts-node post-lint-comment.ts <report-file>');
+    console.error("Usage: ts-node post-lint-comment.ts <report-file>");
     process.exit(1);
   }
-  
+
   const reportPath = args[0];
-  
-  postLintComment(reportPath).catch(error => {
-    console.error('Unhandled error:', error);
+
+  postLintComment(reportPath).catch((error) => {
+    console.error("Unhandled error:", error);
     process.exit(1);
   });
 }
 
-export { postLintComment }; 
+export { postLintComment };

--- a/.github/scripts/post-lint-comment.ts
+++ b/.github/scripts/post-lint-comment.ts
@@ -1,0 +1,76 @@
+import * as fs from 'fs';
+import * as core from '@actions/core';
+import * as github from '@actions/github';
+
+/**
+ * Finds an existing bot comment with the specified content
+ */
+async function findExistingComment(octokit: ReturnType<typeof github.getOctokit>, context: typeof github.context): Promise<{ id: number } | undefined> {
+  const { data: comments } = await octokit.rest.issues.listComments({
+    issue_number: context.issue.number,
+    owner: context.repo.owner,
+    repo: context.repo.repo,
+  });
+
+  return comments.find(comment => 
+    comment?.user?.type === 'Bot' && 
+    comment?.body?.includes('ESLint Diff Results')
+  );
+}
+
+/**
+ * Posts or updates a PR comment with the lint results
+ */
+async function postLintComment(reportPath: string): Promise<void> {
+  try {
+    if (!fs.existsSync(reportPath)) {
+      throw new Error(`Report file not found: ${reportPath}`);
+    }
+
+    const commentBody = fs.readFileSync(reportPath, 'utf8');
+    const token = core.getInput('github-token');
+    const octokit = github.getOctokit(token);
+    const context = github.context;
+
+    const botComment = await findExistingComment(octokit, context);
+
+    if (botComment) {
+      await octokit.rest.issues.updateComment({
+        comment_id: botComment.id,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        body: commentBody
+      });
+      console.log('Updated existing PR comment');
+    } else {
+      await octokit.rest.issues.createComment({
+        issue_number: context.issue.number,
+        owner: context.repo.owner,
+        repo: context.repo.repo,
+        body: commentBody
+      });
+      console.log('Created new PR comment');
+    }
+  } catch (error) {
+    console.error('Error posting PR comment:', error);
+    core.setFailed(`Failed to post PR comment: ${error}`);
+  }
+}
+
+// When run directly from command line
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (args.length < 1) {
+    console.error('Usage: ts-node post-lint-comment.ts <report-file>');
+    process.exit(1);
+  }
+  
+  const reportPath = args[0];
+  
+  postLintComment(reportPath).catch(error => {
+    console.error('Unhandled error:', error);
+    process.exit(1);
+  });
+}
+
+export { postLintComment }; 

--- a/.github/scripts/process-lint-diff.ts
+++ b/.github/scripts/process-lint-diff.ts
@@ -1,5 +1,5 @@
-import * as fs from 'fs';
-import * as path from 'path';
+import * as fs from "fs";
+import * as path from "path";
 
 interface ESLintMessage {
   ruleId: string;
@@ -28,54 +28,63 @@ interface ESLintResult {
  */
 function processLintResults(inputFile: string, outputFile: string): void {
   try {
-    const results: ESLintResult[] = JSON.parse(fs.readFileSync(inputFile, 'utf8'));
-    
+    const results: ESLintResult[] = JSON.parse(
+      fs.readFileSync(inputFile, "utf8"),
+    );
+
     let markdown = "## ESLint Diff Results\n\n";
-    
+
     const errorCount = results.reduce((sum, file) => sum + file.errorCount, 0);
-    const warningCount = results.reduce((sum, file) => sum + file.warningCount, 0);
-    
+    const warningCount = results.reduce(
+      (sum, file) => sum + file.warningCount,
+      0,
+    );
+
     if (errorCount === 0 && warningCount === 0) {
       markdown += "✅ No new lint issues found!\n";
     } else {
       markdown += `⚠️ Found **${errorCount} errors** and **${warningCount} warnings** in files changed by this PR.\n\n`;
-      
+
       // Group by file
       const fileIssues: Record<string, ESLintMessage[]> = {};
-      results.forEach(file => {
+      results.forEach((file) => {
         if (file.messages.length > 0) {
           fileIssues[file.filePath] = file.messages;
         }
       });
-      
+
       // Generate details for each file with issues
-      Object.keys(fileIssues).forEach(filePath => {
+      Object.keys(fileIssues).forEach((filePath) => {
         const fileName = path.basename(filePath);
         markdown += `### ${fileName}\n\n`;
-        
+
         const issues = fileIssues[filePath];
-        const table = ["| Line | Column | Severity | Message | Rule |", "|------|--------|----------|---------|------|"];
-        
-        issues.forEach(issue => {
+        const table = [
+          "| Line | Column | Severity | Message | Rule |",
+          "|------|--------|----------|---------|------|",
+        ];
+
+        issues.forEach((issue) => {
           const severity = issue.severity === 2 ? "🔴 Error" : "🟡 Warning";
-          table.push(`| ${issue.line} | ${issue.column} | ${severity} | ${issue.message} | ${issue.ruleId} |`);
+          table.push(
+            `| ${issue.line} | ${issue.column} | ${severity} | ${issue.message} | ${issue.ruleId} |`,
+          );
         });
-        
+
         markdown += table.join("\n") + "\n\n";
       });
-      
+
       markdown += "Please fix these issues before merging this PR.";
     }
-    
+
     fs.writeFileSync(outputFile, markdown);
     console.log(`Report written to ${outputFile}`);
-    
+
     // Output counts for GitHub Actions
     console.log(`::set-output name=error_count::${errorCount}`);
     console.log(`::set-output name=warning_count::${warningCount}`);
-    
   } catch (error) {
-    console.error('Error processing lint results:', error);
+    console.error("Error processing lint results:", error);
     process.exit(1);
   }
 }
@@ -84,14 +93,16 @@ function processLintResults(inputFile: string, outputFile: string): void {
 if (require.main === module) {
   const args = process.argv.slice(2);
   if (args.length < 2) {
-    console.error('Usage: ts-node process-lint-diff.ts <input-json-file> <output-markdown-file>');
+    console.error(
+      "Usage: ts-node process-lint-diff.ts <input-json-file> <output-markdown-file>",
+    );
     process.exit(1);
   }
-  
+
   const inputFile = args[0];
   const outputFile = args[1];
-  
+
   processLintResults(inputFile, outputFile);
 }
 
-export { processLintResults }; 
+export { processLintResults };

--- a/.github/scripts/process-lint-diff.ts
+++ b/.github/scripts/process-lint-diff.ts
@@ -1,0 +1,97 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+interface ESLintMessage {
+  ruleId: string;
+  severity: number;
+  message: string;
+  line: number;
+  column: number;
+  nodeType?: string;
+  messageId?: string;
+  endLine?: number;
+  endColumn?: number;
+}
+
+interface ESLintResult {
+  filePath: string;
+  messages: ESLintMessage[];
+  errorCount: number;
+  warningCount: number;
+  fixableErrorCount: number;
+  fixableWarningCount: number;
+  source?: string;
+}
+
+/**
+ * Processes ESLint diff results and generates a markdown report
+ */
+function processLintResults(inputFile: string, outputFile: string): void {
+  try {
+    const results: ESLintResult[] = JSON.parse(fs.readFileSync(inputFile, 'utf8'));
+    
+    let markdown = "## ESLint Diff Results\n\n";
+    
+    const errorCount = results.reduce((sum, file) => sum + file.errorCount, 0);
+    const warningCount = results.reduce((sum, file) => sum + file.warningCount, 0);
+    
+    if (errorCount === 0 && warningCount === 0) {
+      markdown += "✅ No new lint issues found!\n";
+    } else {
+      markdown += `⚠️ Found **${errorCount} errors** and **${warningCount} warnings** in files changed by this PR.\n\n`;
+      
+      // Group by file
+      const fileIssues: Record<string, ESLintMessage[]> = {};
+      results.forEach(file => {
+        if (file.messages.length > 0) {
+          fileIssues[file.filePath] = file.messages;
+        }
+      });
+      
+      // Generate details for each file with issues
+      Object.keys(fileIssues).forEach(filePath => {
+        const fileName = path.basename(filePath);
+        markdown += `### ${fileName}\n\n`;
+        
+        const issues = fileIssues[filePath];
+        const table = ["| Line | Column | Severity | Message | Rule |", "|------|--------|----------|---------|------|"];
+        
+        issues.forEach(issue => {
+          const severity = issue.severity === 2 ? "🔴 Error" : "🟡 Warning";
+          table.push(`| ${issue.line} | ${issue.column} | ${severity} | ${issue.message} | ${issue.ruleId} |`);
+        });
+        
+        markdown += table.join("\n") + "\n\n";
+      });
+      
+      markdown += "Please fix these issues before merging this PR.";
+    }
+    
+    fs.writeFileSync(outputFile, markdown);
+    console.log(`Report written to ${outputFile}`);
+    
+    // Output counts for GitHub Actions
+    console.log(`::set-output name=error_count::${errorCount}`);
+    console.log(`::set-output name=warning_count::${warningCount}`);
+    
+  } catch (error) {
+    console.error('Error processing lint results:', error);
+    process.exit(1);
+  }
+}
+
+// When run directly from command line
+if (require.main === module) {
+  const args = process.argv.slice(2);
+  if (args.length < 2) {
+    console.error('Usage: ts-node process-lint-diff.ts <input-json-file> <output-markdown-file>');
+    process.exit(1);
+  }
+  
+  const inputFile = args[0];
+  const outputFile = args[1];
+  
+  processLintResults(inputFile, outputFile);
+}
+
+export { processLintResults }; 

--- a/.github/workflows/lint-diff.yml
+++ b/.github/workflows/lint-diff.yml
@@ -1,0 +1,75 @@
+name: Lint Diff
+
+on:
+  pull_request:
+    branches: ["*"]
+
+jobs:
+  lint-diff:
+    name: Check for new lint errors
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repo
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # Need full history for diff
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8
+
+      - name: Setup Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: "pnpm"
+
+      - name: Install deps (with cache)
+        run: pnpm install
+
+      - name: Prisma generate (no engine)
+        run: pnpm turbo db-generate:no-engine --cache-dir=".turbo"
+
+      - name: Run ESLint diff check
+        id: lint-diff
+        continue-on-error: true
+        run: |
+          # Get the base branch (usually main)
+          BASE_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+          if [[ "$GITHUB_EVENT_NAME" == "pull_request" ]]; then
+            BASE_BRANCH="origin/${{ github.base_ref }}"
+          fi
+
+          # Create a directory for the output
+          mkdir -p ./lint-results
+
+          # Run ESLint with diff plugin and output to JSON
+          echo "Running ESLint diff against $BASE_BRANCH..."
+          pnpm eslint --plugin diff --ext .js,.jsx,.ts,.tsx --format json --diff="$BASE_BRANCH" . > ./lint-results/eslint-diff.json || true
+
+          # Process the results using our TypeScript script
+          OUTPUT=$(pnpm tsx .github/actions/scripts/process-lint-diff.ts ./lint-results/eslint-diff.json ./lint-results/comment.md)
+
+          # Extract the error and warning counts from the output
+          ERROR_COUNT=$(echo "$OUTPUT" | grep "::set-output name=error_count::" | cut -d':' -f3)
+          WARNING_COUNT=$(echo "$OUTPUT" | grep "::set-output name=warning_count::" | cut -d':' -f3)
+
+          # Set outputs for use in later steps
+          echo "error_count=${ERROR_COUNT:-0}" >> $GITHUB_OUTPUT
+          echo "warning_count=${WARNING_COUNT:-0}" >> $GITHUB_OUTPUT
+
+          # Check if there are any errors and fail if so
+          if [ "${ERROR_COUNT:-0}" -gt 0 ] || [ "${WARNING_COUNT:-0}" -gt 0 ]; then
+            exit 1
+          fi
+
+      - name: Comment on PR with lint results
+        if: always() && (steps.lint-diff.outputs.error_count != '0' || steps.lint-diff.outputs.warning_count != '0')
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { postLintComment } = require(`${process.env.GITHUB_WORKSPACE}/.github/actions/scripts/post-lint-comment.ts`);
+            await postLintComment('./lint-results/comment.md');

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -42,4 +42,4 @@ jobs:
         run: pnpm manypkg check
 
       - name: Check formatting with Prettier
-        run: pnpm prettier
+        run: pnpm prettier || (echo "::error::Formatting issues detected! Run 'pnpm prettier:fix' to fix them" && exit 1)


### PR DESCRIPTION
## Description

We lint our PRs to ensure that we aren't introducing problems, but there isn't a good feedback loop because we have some rules set to warn.

That means it's hard to see if we are introducing new "warn" issues.

This PR adds an extra linting diff check, which just runs linting on touched files relating to the PR.

It should mean we can at least see on a PR if there are linting warnings, and if we adopt a rule that if we touch a file, we fix the linting... we might be able to keep the linting warnings down?