### PR TITLE
chore: allow _ prefix for unused variables

### DIFF
--- a/packages/eslint-config/src/index.mjs
+++ b/packages/eslint-config/src/index.mjs
@@ -15,7 +15,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 
 import { ignores } from "./ignores.mjs";
-import { rules } from "./rules.mjs";
+import { rules, javascriptRules } from "./rules.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);
@@ -115,6 +115,9 @@ const config = [
         console: "readonly",
       },
     },
+    rules: {
+      ...javascriptRules,
+    },
   },
   {
     files: ["**/*.{js,mjs}"],
@@ -139,6 +142,7 @@ const config = [
       "@typescript-eslint/no-require-imports": "off",
       "import/no-commonjs": "off",
       "@typescript-eslint/ban-ts-comment": "off",
+      ...javascriptRules,
     },
   },
   ...packageConfigs,

--- a/packages/eslint-config/src/rules.mjs
+++ b/packages/eslint-config/src/rules.mjs
@@ -7,6 +7,20 @@ const rulesToDecideOn = {
   "@typescript-eslint/no-unsafe-call": "off", // this rule is buggy and is causing a lot of false positives
 };
 
+// Define JavaScript-specific rules to avoid duplication
+export const javascriptRules = {
+  "no-unused-vars": [
+    "warn",
+    {
+      argsIgnorePattern: "^_",
+      caughtErrors: "all",
+      caughtErrorsIgnorePattern: "^_",
+      destructuredArrayIgnorePattern: "^_",
+      varsIgnorePattern: "^_",
+    },
+  ],
+};
+
 // @ts-check
 /** @type {Partial<Record<string, import('@typescript-eslint/utils/ts-eslint').SharedConfig.RuleEntry>>} */
 export const rules = {
@@ -18,7 +32,16 @@ export const rules = {
   "@typescript-eslint/consistent-type-imports": "warn",
   "@typescript-eslint/comma-dangle": "off",
   "@typescript-eslint/no-duplicate-enum-values": "off",
-  "@typescript-eslint/no-unused-vars": "warn",
+  "@typescript-eslint/no-unused-vars": [
+    "warn",
+    {
+      argsIgnorePattern: "^_",
+      caughtErrors: "all",
+      caughtErrorsIgnorePattern: "^_",
+      destructuredArrayIgnorePattern: "^_",
+      varsIgnorePattern: "^_",
+    },
+  ],
   "@typescript-eslint/no-unused-expressions": [
     "warn",
     {


### PR DESCRIPTION
## Description

- This adds an eslint rule to allow _ as a prefix for unused variables in various situations
- This can be helpful while developing a feature