### PR TITLE
feat: prettier enforce import order

### DIFF
--- a/apps/nextjs/.storybook/decorators/AnalyticsDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/AnalyticsDecorator.tsx
@@ -4,8 +4,8 @@ import type { Decorator } from "@storybook/react";
 import { fn } from "@storybook/test";
 
 import {
-  analyticsContext,
   type AnalyticsContext,
+  analyticsContext,
 } from "../../src/components/ContextProviders/AnalyticsProvider";
 
 declare module "@storybook/csf" {

--- a/apps/nextjs/.storybook/decorators/StoreDecorator.tsx
+++ b/apps/nextjs/.storybook/decorators/StoreDecorator.tsx
@@ -8,14 +8,14 @@ import {
   AilaStoresContext,
   buildStoreGetter,
 } from "@/stores/AilaStoresProvider";
-import { createChatStore, type ChatState } from "@/stores/chatStore";
+import { type ChatState, createChatStore } from "@/stores/chatStore";
 import {
-  createLessonPlanStore,
   type LessonPlanState,
+  createLessonPlanStore,
 } from "@/stores/lessonPlanStore";
 import {
-  createModerationStore,
   type ModerationState,
+  createModerationStore,
 } from "@/stores/moderationStore";
 import { type TrpcUtils } from "@/utils/trpc";
 

--- a/apps/nextjs/.storybook/main.ts
+++ b/apps/nextjs/.storybook/main.ts
@@ -1,5 +1,5 @@
 import type { StorybookConfig } from "@storybook/nextjs";
-import { join, dirname, resolve } from "path";
+import { dirname, join, resolve } from "path";
 import webpack from "webpack";
 
 process.env.NEXT_PUBLIC_DEBUG = process.env.DEBUG;

--- a/apps/nextjs/.storybook/preview.tsx
+++ b/apps/nextjs/.storybook/preview.tsx
@@ -7,11 +7,11 @@ import "@fontsource/lexend/700.css";
 import "@fontsource/lexend/800.css";
 import "@fontsource/lexend/900.css";
 import { OakThemeProvider, oakDefaultTheme } from "@oaknational/oak-components";
-import type { Preview, Decorator } from "@storybook/react";
+import type { Decorator, Preview } from "@storybook/react";
 import {
+  MswParameters,
   initialize as initializeMsw,
   mswLoader,
-  MswParameters,
 } from "msw-storybook-addon";
 
 import { TooltipProvider } from "../src/components/AppComponents/Chat/ui/tooltip";

--- a/apps/nextjs/src/ai-apps/common/parseLocalStorageData.ts
+++ b/apps/nextjs/src/ai-apps/common/parseLocalStorageData.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/nextjs";
 import type { z } from "zod";
 

--- a/apps/nextjs/src/ai-apps/lesson-planner/state/types.ts
+++ b/apps/nextjs/src/ai-apps/lesson-planner/state/types.ts
@@ -3,6 +3,7 @@ import {
   generationPartPlaceholderSchema,
   generationPartSchema,
 } from "@oakai/core/src/types";
+
 import { z } from "zod";
 
 import {

--- a/apps/nextjs/src/ai-apps/quiz-designer/state/types.ts
+++ b/apps/nextjs/src/ai-apps/quiz-designer/state/types.ts
@@ -3,6 +3,7 @@ import {
   generationPartPlaceholderSchema,
   generationPartSchema,
 } from "@oakai/core/src/types";
+
 import { z } from "zod";
 
 export enum QuizQuestionType {

--- a/apps/nextjs/src/app/actions.ts
+++ b/apps/nextjs/src/app/actions.ts
@@ -4,6 +4,7 @@ import type { AilaPersistedChat } from "@oakai/aila/src/protocol/schema";
 import { chatSchema } from "@oakai/aila/src/protocol/schema";
 import type { Prisma } from "@oakai/db";
 import { prisma } from "@oakai/db";
+
 import * as Sentry from "@sentry/nextjs";
 
 function parseChatAndReportError({

--- a/apps/nextjs/src/app/admin/aila/[chatId]/page.tsx
+++ b/apps/nextjs/src/app/admin/aila/[chatId]/page.tsx
@@ -1,7 +1,8 @@
 "use client";
 
-import { useUser } from "@clerk/nextjs";
 import { aiLogger } from "@oakai/logger";
+
+import { useUser } from "@clerk/nextjs";
 import { redirect } from "next/navigation";
 
 import LoadingWheel from "@/components/LoadingWheel";

--- a/apps/nextjs/src/app/admin/aila/[chatId]/view.stories.tsx
+++ b/apps/nextjs/src/app/admin/aila/[chatId]/view.stories.tsx
@@ -1,4 +1,5 @@
 import type { AilaPersistedChat } from "@oakai/aila/src/protocol/schema";
+
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { chromaticParams } from "@/storybook/chromatic";

--- a/apps/nextjs/src/app/admin/aila/[chatId]/view.tsx
+++ b/apps/nextjs/src/app/admin/aila/[chatId]/view.tsx
@@ -4,12 +4,13 @@ import { toast } from "react-hot-toast";
 import type { AilaPersistedChat } from "@oakai/aila/src/protocol/schema";
 import { getSafetyResult } from "@oakai/core/src/utils/ailaModeration/helpers";
 import type { Moderation, SafetyViolation } from "@oakai/db";
+
 import {
   OakAccordion,
-  OakPrimaryButton,
   OakFlex,
-  OakSmallSecondaryButton,
   OakP,
+  OakPrimaryButton,
+  OakSmallSecondaryButton,
 } from "@oaknational/oak-components";
 import * as Sentry from "@sentry/nextjs";
 

--- a/apps/nextjs/src/app/aila/[id]/download/DownloadView.stories.tsx
+++ b/apps/nextjs/src/app/aila/[id]/download/DownloadView.stories.tsx
@@ -1,4 +1,5 @@
 import type { AilaPersistedChat } from "@oakai/aila/src/protocol/schema";
+
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { chromaticParams } from "@/storybook/chromatic";

--- a/apps/nextjs/src/app/aila/[id]/download/DownloadView.tsx
+++ b/apps/nextjs/src/app/aila/[id]/download/DownloadView.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { AilaPersistedChat } from "@oakai/aila/src/protocol/schema";
+
 import { Box, Flex, Grid } from "@radix-ui/themes";
 
 import Layout from "@/components/AppComponents/Layout";

--- a/apps/nextjs/src/app/aila/[id]/share/index.stories.tsx
+++ b/apps/nextjs/src/app/aila/[id]/share/index.stories.tsx
@@ -1,4 +1,5 @@
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
+
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { chromaticParams } from "@/storybook/chromatic";

--- a/apps/nextjs/src/app/aila/[id]/share/index.tsx
+++ b/apps/nextjs/src/app/aila/[id]/share/index.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
 import type { PersistedModerationBase } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
+
 import { OakSmallPrimaryButton } from "@oaknational/oak-components";
 import * as Sentry from "@sentry/react";
 import Link from "next/link";

--- a/apps/nextjs/src/app/aila/[id]/share/page.tsx
+++ b/apps/nextjs/src/app/aila/[id]/share/page.tsx
@@ -1,9 +1,10 @@
-import type { User } from "@clerk/nextjs/server";
-import { clerkClient } from "@clerk/nextjs/server";
 import { getSessionModerations } from "@oakai/aila/src/features/moderation/getSessionModerations";
 import { demoUsers } from "@oakai/core/src/models/demoUsers";
 import { isToxic } from "@oakai/core/src/utils/ailaModeration/helpers";
 import type { PersistedModerationBase } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
+
+import type { User } from "@clerk/nextjs/server";
+import { clerkClient } from "@clerk/nextjs/server";
 import type { Metadata } from "next";
 import { notFound } from "next/navigation";
 

--- a/apps/nextjs/src/app/aila/help/index.tsx
+++ b/apps/nextjs/src/app/aila/help/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useRef, type MutableRefObject } from "react";
+import { type MutableRefObject, useRef } from "react";
 
 import {
   OakBox,

--- a/apps/nextjs/src/app/api/aila-download-all/route.ts
+++ b/apps/nextjs/src/app/api/aila-download-all/route.ts
@@ -1,6 +1,7 @@
-import { auth } from "@clerk/nextjs/server";
-import { prisma, type LessonExportType } from "@oakai/db";
+import { type LessonExportType, prisma } from "@oakai/db";
 import { downloadDriveFile } from "@oakai/exports";
+
+import { auth } from "@clerk/nextjs/server";
 import * as Sentry from "@sentry/node";
 import { kv } from "@vercel/kv";
 import archiver from "archiver";

--- a/apps/nextjs/src/app/api/aila-download/downloadHelpers.ts
+++ b/apps/nextjs/src/app/api/aila-download/downloadHelpers.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@oakai/db";
+
 import * as Sentry from "@sentry/node";
 
 export async function saveDownloadEvent({

--- a/apps/nextjs/src/app/api/aila-download/route.ts
+++ b/apps/nextjs/src/app/api/aila-download/route.ts
@@ -1,6 +1,7 @@
-import { auth } from "@clerk/nextjs/server";
-import { prisma, type LessonExportType } from "@oakai/db";
+import { type LessonExportType, prisma } from "@oakai/db";
 import { downloadDriveFile } from "@oakai/exports";
+
+import { auth } from "@clerk/nextjs/server";
 import * as Sentry from "@sentry/node";
 
 import { withSentry } from "@/lib/sentry/withSentry";

--- a/apps/nextjs/src/app/api/chat/chatHandler.ts
+++ b/apps/nextjs/src/app/api/chat/chatHandler.ts
@@ -2,9 +2,9 @@ import type { Aila } from "@oakai/aila/src/core/Aila";
 import type { AilaServices } from "@oakai/aila/src/core/AilaServices";
 import type { Message } from "@oakai/aila/src/core/chat";
 import type {
+  AilaInitializationOptions,
   AilaOptions,
   AilaPublicChatOptions,
-  AilaInitializationOptions,
 } from "@oakai/aila/src/core/types";
 import { AilaAmericanisms } from "@oakai/aila/src/features/americanisms/AilaAmericanisms";
 import {
@@ -21,6 +21,7 @@ import { withTelemetry } from "@oakai/core/src/tracing/serverTracing";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 import { prisma as globalPrisma } from "@oakai/db/client";
 import { aiLogger } from "@oakai/logger";
+
 import { captureException } from "@sentry/nextjs";
 import type { NextRequest } from "next/server";
 import invariant from "tiny-invariant";

--- a/apps/nextjs/src/app/api/chat/config.ts
+++ b/apps/nextjs/src/app/api/chat/config.ts
@@ -1,9 +1,10 @@
 import { Aila } from "@oakai/aila/src/core/Aila";
 import type { AilaInitializationOptions } from "@oakai/aila/src/core/types";
 import {
-  prisma as globalPrisma,
   type PrismaClientWithAccelerate,
+  prisma as globalPrisma,
 } from "@oakai/db";
+
 import { nanoid } from "nanoid";
 
 import { createWebActionsPlugin } from "./webActionsPlugin";

--- a/apps/nextjs/src/app/api/chat/errorHandling.test.ts
+++ b/apps/nextjs/src/app/api/chat/errorHandling.test.ts
@@ -5,6 +5,7 @@ import { UserBannedError } from "@oakai/core/src/models/userBannedError";
 import type { TracingSpan } from "@oakai/core/src/tracing/serverTracing";
 import { RateLimitExceededError } from "@oakai/core/src/utils/rateLimiting/userBasedRateLimiter";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
+
 import invariant from "tiny-invariant";
 
 import {

--- a/apps/nextjs/src/app/api/chat/fixtures/FixtureRecordLLMService.ts
+++ b/apps/nextjs/src/app/api/chat/fixtures/FixtureRecordLLMService.ts
@@ -2,6 +2,7 @@ import type { Message } from "@oakai/aila/src/core/chat";
 import type { LLMService } from "@oakai/aila/src/core/llm/LLMService";
 import { OpenAIService } from "@oakai/aila/src/core/llm/OpenAIService";
 import { aiLogger } from "@oakai/logger";
+
 import fs from "fs/promises";
 import type { ZodSchema } from "zod";
 

--- a/apps/nextjs/src/app/api/chat/fixtures/FixtureRecordOpenAiClient.ts
+++ b/apps/nextjs/src/app/api/chat/fixtures/FixtureRecordOpenAiClient.ts
@@ -1,6 +1,7 @@
 import type { OpenAILike } from "@oakai/aila/src/features/moderation/moderators/OpenAiModerator";
 import { createOpenAIClient } from "@oakai/core/src/llm/openai";
 import { aiLogger } from "@oakai/logger";
+
 import fs from "fs/promises";
 import type OpenAI from "openai";
 import type { ChatCompletionCreateParamsNonStreaming } from "openai/resources/index.mjs";

--- a/apps/nextjs/src/app/api/chat/fixtures/FixtureReplayLLMService.ts
+++ b/apps/nextjs/src/app/api/chat/fixtures/FixtureReplayLLMService.ts
@@ -1,5 +1,6 @@
 import { MockLLMService } from "@oakai/aila/src/core/llm/MockLLMService";
 import { aiLogger } from "@oakai/logger";
+
 import fs from "fs";
 
 const log = aiLogger("fixtures");

--- a/apps/nextjs/src/app/api/chat/fixtures/FixtureReplayOpenAiClient.ts
+++ b/apps/nextjs/src/app/api/chat/fixtures/FixtureReplayOpenAiClient.ts
@@ -1,5 +1,6 @@
 import type { OpenAILike } from "@oakai/aila/src/features/moderation/moderators/OpenAiModerator";
 import { aiLogger } from "@oakai/logger";
+
 import fs from "fs/promises";
 import type OpenAI from "openai";
 

--- a/apps/nextjs/src/app/api/chat/route.test.ts
+++ b/apps/nextjs/src/app/api/chat/route.test.ts
@@ -3,6 +3,7 @@ import { MockLLMService } from "@oakai/aila/src/core/llm/MockLLMService";
 import type { AilaInitializationOptions } from "@oakai/aila/src/core/types";
 import { MockCategoriser } from "@oakai/aila/src/features/categorisation/categorisers/MockCategoriser";
 import { mockTracer } from "@oakai/core/src/tracing/mockTracer";
+
 import { NextRequest } from "next/server";
 
 import { expectTracingSpan } from "../../../utils/testHelpers/tracing";

--- a/apps/nextjs/src/app/api/chat/user.ts
+++ b/apps/nextjs/src/app/api/chat/user.ts
@@ -1,4 +1,3 @@
-import { auth, clerkClient } from "@clerk/nextjs/server";
 import { AilaAuthenticationError } from "@oakai/aila/src/core/AilaError";
 import { demoUsers } from "@oakai/core";
 import { posthogAiBetaServerClient } from "@oakai/core/src/analytics/posthogAiBetaServerClient";
@@ -7,6 +6,8 @@ import { UserBannedError } from "@oakai/core/src/models/userBannedError";
 import { withTelemetry } from "@oakai/core/src/tracing/serverTracing";
 import { rateLimits } from "@oakai/core/src/utils/rateLimiting/rateLimit";
 import { RateLimitExceededError } from "@oakai/core/src/utils/rateLimiting/userBasedRateLimiter";
+
+import { auth, clerkClient } from "@clerk/nextjs/server";
 
 async function checkRateLimit(
   userId: string,

--- a/apps/nextjs/src/app/api/chat/webActionsPlugin.test.ts
+++ b/apps/nextjs/src/app/api/chat/webActionsPlugin.test.ts
@@ -3,6 +3,7 @@ import { AilaThreatDetectionError } from "@oakai/aila/src/features/threatDetecti
 import { inngest } from "@oakai/core/src/inngest";
 import { UserBannedError } from "@oakai/core/src/models/userBannedError";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
+
 import type { Moderation } from "@prisma/client";
 
 import { createWebActionsPlugin } from "./webActionsPlugin";

--- a/apps/nextjs/src/app/api/chat/webActionsPlugin.ts
+++ b/apps/nextjs/src/app/api/chat/webActionsPlugin.ts
@@ -6,6 +6,7 @@ import { SafetyViolations as defaultSafetyViolations } from "@oakai/core/src/mod
 import { UserBannedError } from "@oakai/core/src/models/userBannedError";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/nextjs";
 import { waitUntil } from "@vercel/functions";
 

--- a/apps/nextjs/src/app/api/cron-jobs/expired-exports/route.ts
+++ b/apps/nextjs/src/app/api/cron-jobs/expired-exports/route.ts
@@ -1,7 +1,8 @@
-import type { drive_v3 } from "@googleapis/drive";
 import { prisma } from "@oakai/db";
 import { googleDrive } from "@oakai/exports/src/gSuite/drive/client";
 import { aiLogger } from "@oakai/logger";
+
+import type { drive_v3 } from "@googleapis/drive";
 import * as Sentry from "@sentry/node";
 import type { NextRequest } from "next/server";
 import { isTruthy } from "remeda";

--- a/apps/nextjs/src/app/api/cron-jobs/google-drive-size-quota/route.ts
+++ b/apps/nextjs/src/app/api/cron-jobs/google-drive-size-quota/route.ts
@@ -4,6 +4,7 @@ import {
 } from "@oakai/core/src/utils/slack";
 import { googleDrive } from "@oakai/exports/src/gSuite/drive/client";
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/node";
 import type { NextRequest } from "next/server";
 

--- a/apps/nextjs/src/app/api/inngest/route.ts
+++ b/apps/nextjs/src/app/api/inngest/route.ts
@@ -1,4 +1,5 @@
 import { functions, inngest } from "@oakai/core";
+
 import { serve } from "inngest/next";
 
 const inngestServer = serve({ client: inngest, functions });

--- a/apps/nextjs/src/app/api/qd-download/route.ts
+++ b/apps/nextjs/src/app/api/qd-download/route.ts
@@ -1,7 +1,8 @@
-import { auth } from "@clerk/nextjs/server";
 import type { LessonExportType } from "@oakai/db";
 import { prisma } from "@oakai/db/client";
 import { downloadDriveFile } from "@oakai/exports";
+
+import { auth } from "@clerk/nextjs/server";
 import * as Sentry from "@sentry/node";
 
 import { withSentry } from "@/lib/sentry/withSentry";

--- a/apps/nextjs/src/app/api/trpc/chat/[trpc]/route.ts
+++ b/apps/nextjs/src/app/api/trpc/chat/[trpc]/route.ts
@@ -1,6 +1,7 @@
 import { createContext } from "@oakai/api/src/context";
 import { chatAppRouter } from "@oakai/api/src/router/chat";
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/nextjs";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import type { NextRequest, NextResponse } from "next/server";

--- a/apps/nextjs/src/app/api/trpc/main/[trpc]/route.ts
+++ b/apps/nextjs/src/app/api/trpc/main/[trpc]/route.ts
@@ -1,6 +1,7 @@
 import { createContext } from "@oakai/api/src/context";
 import { oakAppRouter } from "@oakai/api/src/router";
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/nextjs";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import type { NextRequest, NextResponse } from "next/server";

--- a/apps/nextjs/src/app/api/trpc/test-support/[trpc]/route.ts
+++ b/apps/nextjs/src/app/api/trpc/test-support/[trpc]/route.ts
@@ -2,6 +2,7 @@ import { createContext } from "@oakai/api/src/context";
 import { testSupportRouter as testSupportRouterInternal } from "@oakai/api/src/router/testSupport";
 import { router } from "@oakai/api/src/trpc";
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/nextjs";
 import { fetchRequestHandler } from "@trpc/server/adapters/fetch";
 import type { NextRequest, NextResponse } from "next/server";

--- a/apps/nextjs/src/app/api/webhooks/clerk/route.ts
+++ b/apps/nextjs/src/app/api/webhooks/clerk/route.ts
@@ -1,7 +1,8 @@
-import type { UserJSON } from "@clerk/backend";
-import type { WebhookEvent } from "@clerk/nextjs/server";
 import { posthogAiBetaServerClient } from "@oakai/core/src/analytics/posthogAiBetaServerClient";
 import { aiLogger } from "@oakai/logger";
+
+import type { UserJSON } from "@clerk/backend";
+import type { WebhookEvent } from "@clerk/nextjs/server";
 import * as Sentry from "@sentry/node";
 import { headers } from "next/headers";
 import { Webhook } from "svix";

--- a/apps/nextjs/src/app/home-page.tsx
+++ b/apps/nextjs/src/app/home-page.tsx
@@ -9,8 +9,8 @@ import {
   OakHeading,
   OakLink,
   OakP,
-  oakColorTokens,
   OakQuote,
+  oakColorTokens,
 } from "@oaknational/oak-components";
 import type { Metadata } from "next";
 import Image from "next/image";

--- a/apps/nextjs/src/app/onboarding/onboarding.tsx
+++ b/apps/nextjs/src/app/onboarding/onboarding.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useRef } from "react";
 
-import { useUser } from "@clerk/nextjs";
 import logger from "@oakai/logger/browser";
+
+import { useUser } from "@clerk/nextjs";
 
 import { AcceptTermsForm } from "@/components/Onboarding/AcceptTermsForm";
 import { LegacyUpgradeNotice } from "@/components/Onboarding/LegacyUpgradeNotice";

--- a/apps/nextjs/src/app/prompts/prompts.tsx
+++ b/apps/nextjs/src/app/prompts/prompts.tsx
@@ -3,6 +3,7 @@
 import React, { useEffect, useMemo } from "react";
 
 import type { SerializedAppWithPrompt } from "@oakai/core/src/models/serializers";
+
 import {
   OakBox,
   OakHeading,

--- a/apps/nextjs/src/app/quiz-designer/preview/[slug]/page.tsx
+++ b/apps/nextjs/src/app/quiz-designer/preview/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import { Apps } from "@oakai/core";
 import { prisma } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
+
 import { redirect } from "next/navigation";
 
 import { serverSideFeatureFlag } from "@/utils/serverSideFeatureFlag";

--- a/apps/nextjs/src/app/quiz-designer/quiz-designer-page.tsx
+++ b/apps/nextjs/src/app/quiz-designer/quiz-designer-page.tsx
@@ -2,8 +2,9 @@
 
 import { memo, useCallback, useEffect, useReducer, useState } from "react";
 
-import { useUser } from "@clerk/nextjs";
 import { aiLogger } from "@oakai/logger";
+
+import { useUser } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 import { equals } from "remeda";
 

--- a/apps/nextjs/src/app/sign-in/[[...sign-in]]/DetectStuckBannedUser.tsx
+++ b/apps/nextjs/src/app/sign-in/[[...sign-in]]/DetectStuckBannedUser.tsx
@@ -2,8 +2,9 @@
 
 import { useEffect, useRef } from "react";
 
-import { useClerk } from "@clerk/nextjs";
 import { aiLogger } from "@oakai/logger";
+
+import { useClerk } from "@clerk/nextjs";
 import { useRouter } from "next/navigation";
 
 const log = aiLogger("auth");

--- a/apps/nextjs/src/components/AppComponents/Chat/AiSdk.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/AiSdk.tsx
@@ -4,6 +4,7 @@ import { toast } from "react-hot-toast";
 import { generateMessageId } from "@oakai/aila/src/helpers/chat/generateMessageId";
 import { parseMessageParts } from "@oakai/aila/src/protocol/jsonPatchProtocol";
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/nextjs";
 import { useChat } from "ai/react";
 import { nanoid } from "nanoid";

--- a/apps/nextjs/src/components/AppComponents/Chat/Chat/ChatModerationDisplay.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/Chat/ChatModerationDisplay.stories.tsx
@@ -1,4 +1,5 @@
 import type { PersistedModerationBase } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
+
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { chromaticParams } from "@/storybook/chromatic";

--- a/apps/nextjs/src/components/AppComponents/Chat/Chat/ChatModerationDisplay.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/Chat/ChatModerationDisplay.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 
 import type { PersistedModerationBase } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
+
 import { Flex } from "@radix-ui/themes";
 
 import ToxicModerationView from "../toxic-moderation-view";

--- a/apps/nextjs/src/components/AppComponents/Chat/Chat/hooks/useProgressForDownloads.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/Chat/hooks/useProgressForDownloads.ts
@@ -5,6 +5,7 @@ import type {
   LooseLessonPlan,
 } from "@oakai/aila/src/protocol/schema";
 import { lessonPlanSectionsSchema } from "@oakai/exports/src/schema/input.schema";
+
 import type { ZodIssue } from "zod";
 
 export type ProgressForDownloads = {

--- a/apps/nextjs/src/components/AppComponents/Chat/Chat/utils/index.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/Chat/utils/index.ts
@@ -1,5 +1,6 @@
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
 import { aiLogger } from "@oakai/logger";
+
 import type { Message } from "ai/react";
 import { z } from "zod";
 

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.stories.tsx
@@ -1,4 +1,5 @@
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
+
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { chromaticParams } from "@/storybook/chromatic";

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-lessonPlanDisplay.tsx
@@ -5,6 +5,7 @@ import type {
   LessonPlanKey,
 } from "@oakai/aila/src/protocol/schema";
 import { aiLogger } from "@oakai/logger";
+
 import { Flex, Text } from "@radix-ui/themes";
 import { cva } from "class-variance-authority";
 import scrollIntoView from "scroll-into-view-if-needed";
@@ -12,9 +13,9 @@ import scrollIntoView from "scroll-into-view-if-needed";
 import { allSectionsInOrder } from "@/lib/lessonPlan/sectionsInOrder";
 import {
   useChatStore,
-  useModerationStore,
-  useLessonPlanStore,
   useLessonPlanActions,
+  useLessonPlanStore,
+  useModerationStore,
 } from "@/stores/AilaStoresProvider";
 import { slugToSentenceCase } from "@/utils/toSentenceCase";
 

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-message/ChatMessagePart.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-message/ChatMessagePart.stories.tsx
@@ -1,4 +1,5 @@
 import type { MessagePart } from "@oakai/aila/src/protocol/jsonPatchProtocol";
+
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { chromaticParams } from "@/storybook/chromatic";

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-share-dialog.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-share-dialog.tsx
@@ -4,6 +4,7 @@ import * as React from "react";
 import { toast } from "react-hot-toast";
 
 import { aiLogger } from "@oakai/logger";
+
 import type { DialogProps } from "@radix-ui/react-dialog";
 import * as Sentry from "@sentry/nextjs";
 

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-start.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-start.tsx
@@ -3,8 +3,9 @@
 import React, { useCallback, useEffect, useState } from "react";
 import { toast } from "react-hot-toast";
 
-import { useUser } from "@clerk/nextjs";
 import { aiLogger } from "@oakai/logger";
+
+import { useUser } from "@clerk/nextjs";
 import { Flex } from "@radix-ui/themes";
 import * as Sentry from "@sentry/nextjs";
 import { useRouter } from "next/navigation";

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/action-button-wrapper.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/action-button-wrapper.tsx
@@ -2,6 +2,7 @@ import { useRef, useState } from "react";
 
 import { getLastAssistantMessage } from "@oakai/aila/src/helpers/chat/getLastAssistantMessage";
 import type { LessonPlanSectionWhileStreaming } from "@oakai/aila/src/protocol/schema";
+
 import { OakBox } from "@oaknational/oak-components";
 import type { AilaUserModificationAction } from "@prisma/client";
 

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/action-drop-down.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/action-drop-down.tsx
@@ -1,12 +1,13 @@
 import {
-  useCallback,
   type Dispatch,
   type RefObject,
   type SetStateAction,
+  useCallback,
 } from "react";
 import { toast } from "react-hot-toast";
 
 import { aiLogger } from "@oakai/logger";
+
 import { OakP, OakRadioGroup } from "@oaknational/oak-components";
 import type { $Enums, AilaUserModificationAction } from "@prisma/client";
 import { TextArea } from "@radix-ui/themes";

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/add-additional-materials-button.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/add-additional-materials-button.tsx
@@ -1,4 +1,5 @@
 import type { LessonPlanSectionWhileStreaming } from "@oakai/aila/src/protocol/schema";
+
 import type { AilaUserModificationAction } from "@prisma/client";
 
 import ActionButtonWrapper from "./action-button-wrapper";

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/drop-down-form-wrapper.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/drop-down-form-wrapper.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef } from "react";
 
 import type { AilaUserFlagType, AilaUserModificationAction } from "@oakai/db";
+
 import {
   OakBox,
   OakFlex,

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/flag-button.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/flag-button.tsx
@@ -4,11 +4,12 @@ import { toast } from "react-hot-toast";
 import { getLastAssistantMessage } from "@oakai/aila/src/helpers/chat/getLastAssistantMessage";
 import type { LessonPlanSectionWhileStreaming } from "@oakai/aila/src/protocol/schema";
 import type { AilaUserFlagType } from "@oakai/db";
+
 import { OakBox, OakP, OakRadioGroup } from "@oaknational/oak-components";
 import * as Sentry from "@sentry/nextjs";
 import styled from "styled-components";
 
-import { useLessonPlanStore, useChatStore } from "@/stores/AilaStoresProvider";
+import { useChatStore, useLessonPlanStore } from "@/stores/AilaStoresProvider";
 import { trpc } from "@/utils/trpc";
 
 import ActionButton from "./action-button";

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/lesson-plan-section-content.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/lesson-plan-section-content.tsx
@@ -3,6 +3,7 @@ import type {
   LessonPlanSectionWhileStreaming,
 } from "@oakai/aila/src/protocol/schema";
 import { sectionToMarkdown } from "@oakai/aila/src/protocol/sectionToMarkdown";
+
 import { OakFlex } from "@oaknational/oak-components";
 
 import { lessonSectionTitlesAndMiniDescriptions } from "@/data/lessonSectionTitlesAndMiniDescriptions";

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/modify-button.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/modify-button.tsx
@@ -1,4 +1,5 @@
 import type { LessonPlanSectionWhileStreaming } from "@oakai/aila/src/protocol/schema";
+
 import type { AilaUserModificationAction } from "@prisma/client";
 
 import ActionButtonWrapper from "./action-button-wrapper";

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/LessonPlanProgressDropdown.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/LessonPlanProgressDropdown.stories.tsx
@@ -4,6 +4,7 @@ import type {
   Misconception,
   Quiz,
 } from "@oakai/aila/src/protocol/schema";
+
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { chromaticParams } from "@/storybook/chromatic";

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/LessonPlanProgressDropdown.test.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/LessonPlanProgressDropdown.test.tsx
@@ -6,9 +6,9 @@ import React from "react";
 
 import { composeStories } from "@storybook/react";
 import {
+  fireEvent,
   render,
   screen,
-  fireEvent,
   waitFor,
   within,
 } from "@testing-library/react";

--- a/apps/nextjs/src/components/AppComponents/Chat/guidance-required.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/guidance-required.stories.tsx
@@ -1,4 +1,5 @@
 import type { PersistedModerationBase } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
+
 import type { Meta, StoryObj } from "@storybook/react";
 
 import { chromaticParams } from "@/storybook/chromatic";

--- a/apps/nextjs/src/components/AppComponents/Chat/lesson-plan-section/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/lesson-plan-section/index.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 
 import type { LessonPlanKey } from "@oakai/aila/src/protocol/schema";
+
 import { OakBox, OakFlex, OakP } from "@oaknational/oak-components";
 import styled from "styled-components";
 

--- a/apps/nextjs/src/components/AppComponents/Chat/sidebar-items.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/sidebar-items.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { format, isToday, isThisWeek, isThisMonth } from "date-fns";
+import { format, isThisMonth, isThisWeek, isToday } from "date-fns";
 import { AnimatePresence } from "framer-motion";
 
 import type { SideBarChatItem } from "@/lib/types";

--- a/apps/nextjs/src/components/AppComponents/Chat/toxic-moderation-view.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/toxic-moderation-view.tsx
@@ -3,6 +3,7 @@ import { toast } from "react-hot-toast";
 import Textarea from "react-textarea-autosize";
 
 import type { PersistedModerationBase } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
+
 import * as Sentry from "@sentry/nextjs";
 import { useRouter } from "next/navigation";
 

--- a/apps/nextjs/src/components/AppComponents/Chat/ui/button.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/ui/button.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
 import { Slot } from "@radix-ui/react-slot";
-import { cva, type VariantProps } from "class-variance-authority";
+import { type VariantProps, cva } from "class-variance-authority";
 
 import { cn } from "@/lib/utils";
 

--- a/apps/nextjs/src/components/AppComponents/Chat/ui/sheet.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/ui/sheet.tsx
@@ -3,7 +3,7 @@
 import * as React from "react";
 
 import * as SheetPrimitive from "@radix-ui/react-dialog";
-import { cva, type VariantProps } from "class-variance-authority";
+import { type VariantProps, cva } from "class-variance-authority";
 
 import { Icon } from "@/components/Icon";
 import { cn } from "@/lib/utils";

--- a/apps/nextjs/src/components/AppComponents/ComparativeJudgement/JudgementFeedbackDialog.tsx
+++ b/apps/nextjs/src/components/AppComponents/ComparativeJudgement/JudgementFeedbackDialog.tsx
@@ -1,7 +1,8 @@
 import { useState } from "react";
 
-import { useUser } from "@clerk/nextjs";
 import { aiLogger } from "@oakai/logger";
+
+import { useUser } from "@clerk/nextjs";
 import * as Dialog from "@radix-ui/react-dialog";
 
 import { trpc } from "@/utils/trpc";

--- a/apps/nextjs/src/components/AppComponents/ComparativeJudgement/KeyStageAndSubjectPicker.tsx
+++ b/apps/nextjs/src/components/AppComponents/ComparativeJudgement/KeyStageAndSubjectPicker.tsx
@@ -5,6 +5,7 @@ import type {
   SubjectName,
 } from "@oakai/core/src/data/subjectsAndKeyStages";
 import { subjectsAndKeyStages } from "@oakai/core/src/data/subjectsAndKeyStages";
+
 import { Flex } from "@radix-ui/themes";
 
 import Input from "@/components/Input";

--- a/apps/nextjs/src/components/AppComponents/ComparativeJudgement/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/ComparativeJudgement/index.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 
 import type { KeyStageName, SubjectName } from "@oakai/core";
+
 import { Flex } from "@radix-ui/themes";
 
 import { Icon } from "@/components/Icon";

--- a/apps/nextjs/src/components/AppComponents/DialogContext/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/DialogContext/index.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { createContext, useState, useContext, useMemo } from "react";
+import React, { createContext, useContext, useMemo, useState } from "react";
 
 import type { DialogTypes } from "../Chat/Chat/types";
 

--- a/apps/nextjs/src/components/AppComponents/FeedbackForms/ModerationFeedbackForm.tsx
+++ b/apps/nextjs/src/components/AppComponents/FeedbackForms/ModerationFeedbackForm.tsx
@@ -2,6 +2,7 @@ import { useEffect } from "react";
 
 import { moderationSlugToDescription } from "@oakai/core/src/utils/ailaModeration/helpers";
 import type { PersistedModerationBase } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
+
 import { Dialog } from "@radix-ui/themes";
 
 import Button from "@/components/Button";

--- a/apps/nextjs/src/components/AppComponents/QuizDesigner/Hero.tsx
+++ b/apps/nextjs/src/components/AppComponents/QuizDesigner/Hero.tsx
@@ -2,6 +2,7 @@ import type { Dispatch } from "react";
 import { useCallback } from "react";
 
 import type { KeyStageName, SubjectName } from "@oakai/core";
+
 import { Box, Flex, Heading, Text } from "@radix-ui/themes";
 import Image from "next/image";
 

--- a/apps/nextjs/src/components/AppComponents/QuizDesigner/QuizQuestionRow/Answer.tsx
+++ b/apps/nextjs/src/components/AppComponents/QuizDesigner/QuizQuestionRow/Answer.tsx
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 import type { GenerationPart } from "@oakai/core/src/types";
 import { GenerationPartType } from "@oakai/core/src/types";
 import browserLogger from "@oakai/logger/browser";
+
 import { Flex } from "@radix-ui/themes";
 
 import type { QuizAppAction } from "@/ai-apps/quiz-designer/state/actions";

--- a/apps/nextjs/src/components/AppComponents/QuizDesigner/QuizQuestionRow/Distractor.tsx
+++ b/apps/nextjs/src/components/AppComponents/QuizDesigner/QuizQuestionRow/Distractor.tsx
@@ -6,6 +6,7 @@ import { useCallback, useState } from "react";
 import type { GenerationPart } from "@oakai/core/src/types";
 import { GenerationPartType } from "@oakai/core/src/types";
 import browserLogger from "@oakai/logger/browser";
+
 import { Flex } from "@radix-ui/themes";
 import { z } from "zod";
 

--- a/apps/nextjs/src/components/AppComponents/QuizDesigner/SubjectKeyStageSection/Choose.tsx
+++ b/apps/nextjs/src/components/AppComponents/QuizDesigner/SubjectKeyStageSection/Choose.tsx
@@ -4,6 +4,7 @@ import type {
   KeyStageName,
   SubjectName,
 } from "@oakai/core/src/data/subjectsAndKeyStages";
+
 import { Box, Flex } from "@radix-ui/themes";
 import { useDebounce } from "usehooks-ts";
 

--- a/apps/nextjs/src/components/AppComponents/QuizDesigner/SubjectKeyStageSection/Confirmed.tsx
+++ b/apps/nextjs/src/components/AppComponents/QuizDesigner/SubjectKeyStageSection/Confirmed.tsx
@@ -1,4 +1,5 @@
 import type { KeyStageName, SubjectName } from "@oakai/core";
+
 import { Flex, Heading, Text } from "@radix-ui/themes";
 
 type ConfirmedProps = {

--- a/apps/nextjs/src/components/AppComponents/common/RateLimitNotification.tsx
+++ b/apps/nextjs/src/components/AppComponents/common/RateLimitNotification.tsx
@@ -1,7 +1,8 @@
 import { useEffect, useState } from "react";
 
-import { useUser } from "@clerk/nextjs";
 import type { RateLimitInfo } from "@oakai/api/src/types";
+
+import { useUser } from "@clerk/nextjs";
 import { Box, Flex, Text } from "@radix-ui/themes";
 import { cva } from "class-variance-authority";
 

--- a/apps/nextjs/src/components/AppComponents/common/SingleGeneration/GenerationFeedbackDialog.tsx
+++ b/apps/nextjs/src/components/AppComponents/common/SingleGeneration/GenerationFeedbackDialog.tsx
@@ -1,8 +1,9 @@
 import { useCallback, useState } from "react";
 
-import { useUser } from "@clerk/nextjs";
 import type { GenerationPart } from "@oakai/core/src/types";
 import { structuredLogger as logger } from "@oakai/logger";
+
+import { useUser } from "@clerk/nextjs";
 import * as Dialog from "@radix-ui/react-dialog";
 import * as Sentry from "@sentry/nextjs";
 

--- a/apps/nextjs/src/components/AppComponents/common/SingleGeneration/GenerationInputAndText.tsx
+++ b/apps/nextjs/src/components/AppComponents/common/SingleGeneration/GenerationInputAndText.tsx
@@ -4,6 +4,7 @@ import type {
   GenerationPart,
   GenerationPartPlaceholder,
 } from "@oakai/core/src/types";
+
 import { Text } from "@radix-ui/themes";
 
 function GenerationInputAndText({

--- a/apps/nextjs/src/components/AppComponents/common/SingleGeneration/GenerationWrapper.tsx
+++ b/apps/nextjs/src/components/AppComponents/common/SingleGeneration/GenerationWrapper.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 
 import type { GenerationPart } from "@oakai/core/src/types";
+
 import { Box } from "@radix-ui/themes";
 
 import GenerationFeedbackDialog, {

--- a/apps/nextjs/src/components/AppComponents/download/DownloadAllButton.tsx
+++ b/apps/nextjs/src/components/AppComponents/download/DownloadAllButton.tsx
@@ -3,6 +3,7 @@ import { toast } from "react-hot-toast";
 
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
 import { aiLogger } from "@oakai/logger";
+
 import { Box } from "@radix-ui/themes";
 import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";

--- a/apps/nextjs/src/components/AppComponents/download/DownloadButton.tsx
+++ b/apps/nextjs/src/components/AppComponents/download/DownloadButton.tsx
@@ -1,4 +1,5 @@
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
+
 import { Box } from "@radix-ui/themes";
 import Link from "next/link";
 

--- a/apps/nextjs/src/components/ContextProviders/ChatModerationContext.tsx
+++ b/apps/nextjs/src/components/ContextProviders/ChatModerationContext.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from "react";
-import { useMemo, createContext, useContext } from "react";
+import { createContext, useContext, useMemo } from "react";
 
 import { useModerationModal } from "../AppComponents/FeedbackForms/ModerationFeedbackModal";
 

--- a/apps/nextjs/src/components/ContextProviders/CookieConsentProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/CookieConsentProvider.tsx
@@ -4,10 +4,10 @@ import type { PropsWithChildren } from "react";
 import { useCallback, useEffect } from "react";
 
 import {
-  OakCookieConsentProvider,
-  OakCookieConsent,
-  useCookieConsent as useCookieConsentUI,
   type Consent,
+  OakCookieConsent,
+  OakCookieConsentProvider,
+  useCookieConsent as useCookieConsentUI,
 } from "@oaknational/oak-components";
 import {
   OakConsentProvider,

--- a/apps/nextjs/src/components/ContextProviders/FeatureFlagProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/FeatureFlagProvider.tsx
@@ -2,12 +2,12 @@
 
 import type { ReactNode } from "react";
 import {
-  useMemo,
   createContext,
   useContext,
   useEffect,
-  useState,
+  useMemo,
   useRef,
+  useState,
 } from "react";
 
 import { aiLogger } from "@oakai/logger";

--- a/apps/nextjs/src/components/DialogControl/ContentOptions/DemoInterstitialDialog.tsx
+++ b/apps/nextjs/src/components/DialogControl/ContentOptions/DemoInterstitialDialog.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useState } from "react";
 
 import { aiLogger } from "@oakai/logger";
+
 import {
   OakFlex,
   OakLink,

--- a/apps/nextjs/src/components/DialogControl/ContentOptions/ReportContentDialog.tsx
+++ b/apps/nextjs/src/components/DialogControl/ContentOptions/ReportContentDialog.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 
 import { aiLogger } from "@oakai/logger";
+
 import {
   OakFlex,
   OakP,

--- a/apps/nextjs/src/components/DialogControl/ContentOptions/ShareChatDialog.tsx
+++ b/apps/nextjs/src/components/DialogControl/ContentOptions/ShareChatDialog.tsx
@@ -1,6 +1,7 @@
 import { useCallback } from "react";
 
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
+
 import {
   OakBox,
   OakFlex,

--- a/apps/nextjs/src/components/DialogControl/DialogContents.stories.tsx
+++ b/apps/nextjs/src/components/DialogControl/DialogContents.stories.tsx
@@ -1,6 +1,6 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { fn } from "@storybook/test";
-import { http, HttpResponse } from "msw";
+import { HttpResponse, http } from "msw";
 import { SurveyQuestionType, SurveyType } from "posthog-js";
 import type { PostHog } from "posthog-js";
 

--- a/apps/nextjs/src/components/DialogControl/DialogContents.tsx
+++ b/apps/nextjs/src/components/DialogControl/DialogContents.tsx
@@ -1,8 +1,9 @@
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
+
 import {
+  type OakIconName,
   OakModalCenter,
   OakModalCenterBody,
-  type OakIconName,
 } from "@oaknational/oak-components";
 import type { Message } from "ai";
 import styled from "styled-components";

--- a/apps/nextjs/src/components/ExportsDialogs/useExportAdditionalMaterials.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportAdditionalMaterials.ts
@@ -1,7 +1,8 @@
-import { useEffect, useMemo, useState, useCallback } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { exportSlidesFullLessonSchema } from "@oakai/exports/browser";
 import type { LessonSlidesInputData } from "@oakai/exports/src/schema/input.schema";
+
 import * as Sentry from "@sentry/nextjs";
 import { useDebounce } from "@uidotdev/usehooks";
 import type { ZodError } from "zod";

--- a/apps/nextjs/src/components/ExportsDialogs/useExportAllLessonAssets.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportAllLessonAssets.ts
@@ -4,6 +4,7 @@ import type { LessonDeepPartial } from "@oakai/exports/browser";
 import { exportSlidesFullLessonSchema } from "@oakai/exports/browser";
 import type { LessonInputData } from "@oakai/exports/src/schema/input.schema";
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/nextjs";
 import { useDebounce } from "@uidotdev/usehooks";
 import type { ZodError } from "zod";

--- a/apps/nextjs/src/components/ExportsDialogs/useExportLessonPlanDoc.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportLessonPlanDoc.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { exportDocLessonPlanSchema } from "@oakai/exports/browser";
 import type { LessonPlanDocInputData } from "@oakai/exports/src/schema/input.schema";
+
 import * as Sentry from "@sentry/nextjs";
 import { useDebounce } from "@uidotdev/usehooks";
 import type { ZodError } from "zod";

--- a/apps/nextjs/src/components/ExportsDialogs/useExportLessonSlides.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportLessonSlides.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { exportSlidesFullLessonSchema } from "@oakai/exports/browser";
 import type { LessonSlidesInputData } from "@oakai/exports/src/schema/input.schema";
+
 import * as Sentry from "@sentry/nextjs";
 import { useDebounce } from "@uidotdev/usehooks";
 import type { ZodError } from "zod";

--- a/apps/nextjs/src/components/ExportsDialogs/useExportQuizDesignerSlides.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportQuizDesignerSlides.ts
@@ -3,6 +3,7 @@ import { useEffect, useState } from "react";
 import type { ExportableQuizAppState } from "@oakai/exports/src/schema/input.schema";
 import { exportableQuizAppStateSchema } from "@oakai/exports/src/schema/input.schema";
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/nextjs";
 import { useDebounce } from "@uidotdev/usehooks";
 import type { ZodError } from "zod";

--- a/apps/nextjs/src/components/ExportsDialogs/useExportQuizDoc.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportQuizDoc.ts
@@ -5,6 +5,7 @@ import type {
   LessonDeepPartial,
   QuizDocInputData,
 } from "@oakai/exports/src/schema/input.schema";
+
 import * as Sentry from "@sentry/nextjs";
 import { useDebounce } from "@uidotdev/usehooks";
 import type { ZodError } from "zod";

--- a/apps/nextjs/src/components/ExportsDialogs/useExportWorksheetSlides.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportWorksheetSlides.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { exportSlidesWorksheetSchema } from "@oakai/exports/browser";
 import type { WorksheetSlidesInputData } from "@oakai/exports/src/schema/input.schema";
+
 import * as Sentry from "@sentry/nextjs";
 import { useDebounce } from "@uidotdev/usehooks";
 import type { ZodError } from "zod";

--- a/apps/nextjs/src/components/ExportsDialogs/useExportsExistenceCheck.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportsExistenceCheck.ts
@@ -1,6 +1,7 @@
 import { useCallback, useState } from "react";
 
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/react";
 
 const log = aiLogger("exports");

--- a/apps/nextjs/src/components/Footer.tsx
+++ b/apps/nextjs/src/components/Footer.tsx
@@ -4,13 +4,13 @@ import { useAuth } from "@clerk/nextjs";
 import {
   OakBox,
   OakFlex,
+  OakIcon,
+  OakLI,
   OakLink,
   OakMaxWidth,
-  useCookieConsent,
   OakP,
   OakUL,
-  OakLI,
-  OakIcon,
+  useCookieConsent,
 } from "@oaknational/oak-components";
 import Image from "next/image";
 import Link from "next/link";

--- a/apps/nextjs/src/components/Onboarding/AcceptTermsForm.tsx
+++ b/apps/nextjs/src/components/Onboarding/AcceptTermsForm.tsx
@@ -2,8 +2,9 @@
 
 import { useState } from "react";
 
-import { useUser } from "@clerk/nextjs";
 import logger from "@oakai/logger/browser";
+
+import { useUser } from "@clerk/nextjs";
 import {
   OakBox,
   OakFlex,

--- a/apps/nextjs/src/components/SubjectAndKeyStageSelect/index.tsx
+++ b/apps/nextjs/src/components/SubjectAndKeyStageSelect/index.tsx
@@ -5,6 +5,7 @@ import type {
   SubjectName,
 } from "@oakai/core/src/data/subjectsAndKeyStages";
 import { subjectsAndKeyStages } from "@oakai/core/src/data/subjectsAndKeyStages";
+
 import { Flex } from "@radix-ui/themes";
 
 import Input from "../Input";

--- a/apps/nextjs/src/hooks/surveys/usePosthogFeedbackSurvey.ts
+++ b/apps/nextjs/src/hooks/surveys/usePosthogFeedbackSurvey.ts
@@ -1,6 +1,7 @@
-import { useEffect, useState, useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/react";
 import type { Survey } from "posthog-js";
 import { SurveyType } from "posthog-js";

--- a/apps/nextjs/src/hooks/useDemoLocking.ts
+++ b/apps/nextjs/src/hooks/useDemoLocking.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 
 import type { LessonPlanKey } from "@oakai/aila/src/protocol/schema";
+
 import type { Message } from "ai";
 
 import { useDemoUser } from "@/components/ContextProviders/Demo";

--- a/apps/nextjs/src/hooks/useGeneration.ts
+++ b/apps/nextjs/src/hooks/useGeneration.ts
@@ -8,6 +8,7 @@ import {
   default as browserLogger,
   default as logger,
 } from "@oakai/logger/browser";
+
 import { TRPCClientError } from "@trpc/client";
 import type { z } from "zod";
 

--- a/apps/nextjs/src/hooks/useQuestionsForJudgement.ts
+++ b/apps/nextjs/src/hooks/useQuestionsForJudgement.ts
@@ -1,6 +1,7 @@
 import { useState } from "react";
 
 import { aiLogger } from "@oakai/logger";
+
 import { z } from "zod";
 
 import { optionSchema } from "@/ai-apps/comparative-judgement/state/types";

--- a/apps/nextjs/src/hooks/useQuizSession.ts
+++ b/apps/nextjs/src/hooks/useQuizSession.ts
@@ -1,8 +1,9 @@
 import type { Dispatch } from "react";
 import { useEffect, useRef } from "react";
 
-import { useUser } from "@clerk/nextjs";
 import browserLogger from "@oakai/logger/browser";
+
+import { useUser } from "@clerk/nextjs";
 import * as Sentry from "@sentry/nextjs";
 import { z } from "zod";
 

--- a/apps/nextjs/src/lib/analytics/helpers.ts
+++ b/apps/nextjs/src/lib/analytics/helpers.ts
@@ -2,6 +2,7 @@ import type { ModerationDocument } from "@oakai/aila/src/protocol/jsonPatchProto
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
 import { parseKeyStage } from "@oakai/core/src/data/parseKeyStage";
 import { lessonPlanSectionsSchema } from "@oakai/exports/src/schema/input.schema";
+
 import { isTruthy } from "remeda";
 
 import type {

--- a/apps/nextjs/src/lib/analytics/lessonPlanTrackingContext.tsx
+++ b/apps/nextjs/src/lib/analytics/lessonPlanTrackingContext.tsx
@@ -10,6 +10,7 @@ import {
 
 import { getLastAssistantMessage } from "@oakai/aila/src/helpers/chat/getLastAssistantMessage";
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
+
 import type { Message } from "ai";
 
 import type { UserAction } from "./helpers";

--- a/apps/nextjs/src/lib/analytics/trackLessonPlanRefined.ts
+++ b/apps/nextjs/src/lib/analytics/trackLessonPlanRefined.ts
@@ -1,12 +1,13 @@
 import { parseMessageParts } from "@oakai/aila/src/protocol/jsonPatchProtocol";
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
 import { isToxic } from "@oakai/core/src/utils/ailaModeration/helpers";
+
 import * as Sentry from "@sentry/nextjs";
 
 import {
-  isPatch,
-  isModeration,
   isAccountLocked,
+  isModeration,
+  isPatch,
 } from "@/components/AppComponents/Chat/chat-message/protocol";
 import type { TrackFns } from "@/components/ContextProviders/AnalyticsProvider";
 

--- a/apps/nextjs/src/lib/avo/getAvoBridge.ts
+++ b/apps/nextjs/src/lib/avo/getAvoBridge.ts
@@ -2,6 +2,7 @@
  * @see https://www.avo.app/docs/implementation/start-using-avo-functions
  */
 import browserLogger from "@oakai/logger/browser";
+
 import * as Sentry from "@sentry/nextjs";
 
 import type { AnalyticsService } from "@/components/ContextProviders/AnalyticsProvider";

--- a/apps/nextjs/src/lib/clerk/useClerkIdentify.ts
+++ b/apps/nextjs/src/lib/clerk/useClerkIdentify.ts
@@ -1,6 +1,6 @@
-import { useRef, useEffect } from "react";
+import { useEffect, useRef } from "react";
 
-import { useUser, useAuth } from "@clerk/nextjs";
+import { useAuth, useUser } from "@clerk/nextjs";
 
 import { useClerkDemoMetadata } from "@/hooks/useClerkDemoMetadata";
 

--- a/apps/nextjs/src/lib/cookie-consent/consentClient.ts
+++ b/apps/nextjs/src/lib/cookie-consent/consentClient.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import { OakConsentClient } from "@oaknational/oak-consent-client";
 import * as Sentry from "@sentry/nextjs";
 

--- a/apps/nextjs/src/lib/feature-flags/bootstrap.ts
+++ b/apps/nextjs/src/lib/feature-flags/bootstrap.ts
@@ -1,8 +1,9 @@
 "use server";
 
-import { auth } from "@clerk/nextjs/server";
 import { posthogAiBetaServerClient } from "@oakai/core/src/analytics/posthogAiBetaServerClient";
 import { aiLogger } from "@oakai/logger";
+
+import { auth } from "@clerk/nextjs/server";
 import cookie from "cookie";
 import type { ReadonlyHeaders } from "next/dist/server/web/spec-extension/adapters/headers";
 

--- a/apps/nextjs/src/lib/hooks/use-enter-submit.tsx
+++ b/apps/nextjs/src/lib/hooks/use-enter-submit.tsx
@@ -1,4 +1,4 @@
-import { useRef, type RefObject } from "react";
+import { type RefObject, useRef } from "react";
 
 import { aiLogger } from "@oakai/logger";
 

--- a/apps/nextjs/src/lib/hooks/use-sidebar.tsx
+++ b/apps/nextjs/src/lib/hooks/use-sidebar.tsx
@@ -2,11 +2,11 @@
 
 import {
   createContext,
+  useCallback,
   useContext,
+  useEffect,
   useMemo,
   useState,
-  useEffect,
-  useCallback,
 } from "react";
 
 const LOCAL_STORAGE_KEY = "sidebar";

--- a/apps/nextjs/src/lib/lessonPlan/sectionsInOrder.ts
+++ b/apps/nextjs/src/lib/lessonPlan/sectionsInOrder.ts
@@ -1,6 +1,6 @@
 import {
-  allSectionsInOrder,
   type LessonPlanKey,
+  allSectionsInOrder,
 } from "@oakai/aila/src/protocol/schema";
 
 export { allSectionsInOrder };

--- a/apps/nextjs/src/lib/utils.ts
+++ b/apps/nextjs/src/lib/utils.ts
@@ -1,4 +1,4 @@
-import { clsx, type ClassValue } from "clsx";
+import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {

--- a/apps/nextjs/src/middlewares/auth.middleware.ts
+++ b/apps/nextjs/src/middlewares/auth.middleware.ts
@@ -1,6 +1,7 @@
+import { aiLogger } from "@oakai/logger";
+
 import type { ClerkMiddlewareAuth } from "@clerk/nextjs/server";
 import { clerkMiddleware, createRouteMatcher } from "@clerk/nextjs/server";
-import { aiLogger } from "@oakai/logger";
 import type { NextFetchEvent, NextRequest } from "next/server";
 import { NextResponse } from "next/server";
 

--- a/apps/nextjs/src/middlewares/middlewareErrorLogging.ts
+++ b/apps/nextjs/src/middlewares/middlewareErrorLogging.ts
@@ -1,4 +1,5 @@
 import { structuredLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/nextjs";
 import type { NextFetchEvent, NextRequest } from "next/server";
 

--- a/apps/nextjs/src/mocks/analytics/provider.tsx
+++ b/apps/nextjs/src/mocks/analytics/provider.tsx
@@ -5,6 +5,7 @@ See the readme for why this is needed.
 import React from "react";
 
 import { aiLogger } from "@oakai/logger";
+
 import type { PostHog } from "posthog-js";
 
 import Avo from "@/lib/avo/Avo";

--- a/apps/nextjs/src/stores/AilaStoresProvider.tsx
+++ b/apps/nextjs/src/stores/AilaStoresProvider.tsx
@@ -1,18 +1,18 @@
-import { useState, useRef, createContext, useContext, useEffect } from "react";
+import { createContext, useContext, useEffect, useRef, useState } from "react";
 
 import invariant from "tiny-invariant";
-import { useStore, type StoreApi, type ExtractState } from "zustand";
+import { type ExtractState, type StoreApi, useStore } from "zustand";
 
 import { useLessonPlanTracking } from "@/lib/analytics/lessonPlanTrackingContext";
 import { createChatStore } from "@/stores/chatStore";
 import type { ChatState } from "@/stores/chatStore/types";
 import {
-  createModerationStore,
   type ModerationState,
+  createModerationStore,
 } from "@/stores/moderationStore";
 import { trpc } from "@/utils/trpc";
 
-import { createLessonPlanStore, type LessonPlanState } from "./lessonPlanStore";
+import { type LessonPlanState, createLessonPlanStore } from "./lessonPlanStore";
 
 export type AilaStores = {
   chat: StoreApi<ChatState>;

--- a/apps/nextjs/src/stores/chatStore/__tests__/executeQueuedActions.test.tsx
+++ b/apps/nextjs/src/stores/chatStore/__tests__/executeQueuedActions.test.tsx
@@ -1,7 +1,7 @@
 import type { GetStore } from "@/stores/AilaStoresProvider";
 import type { TrpcUtils } from "@/utils/trpc";
 
-import { createChatStore, type AiSdkActions } from "..";
+import { type AiSdkActions, createChatStore } from "..";
 
 describe("Chat Store executeQueuedAction", () => {
   const mockAiSdkActions = {

--- a/apps/nextjs/src/stores/chatStore/__tests__/handleAppend.test.ts
+++ b/apps/nextjs/src/stores/chatStore/__tests__/handleAppend.test.ts
@@ -1,7 +1,7 @@
 import type { GetStore } from "@/stores/AilaStoresProvider";
 import type { TrpcUtils } from "@/utils/trpc";
 
-import { createChatStore, type AiSdkActions } from "../index";
+import { type AiSdkActions, createChatStore } from "../index";
 
 describe("handleAppend", () => {
   const mockAiSdkActions = {

--- a/apps/nextjs/src/stores/chatStore/__tests__/handleStop.test.ts
+++ b/apps/nextjs/src/stores/chatStore/__tests__/handleStop.test.ts
@@ -1,7 +1,7 @@
 import type { GetStore } from "@/stores/AilaStoresProvider";
 import type { TrpcUtils } from "@/utils/trpc";
 
-import { createChatStore, type AiSdkActions } from "..";
+import { type AiSdkActions, createChatStore } from "..";
 
 describe("handleStop", () => {
   const mockAiSdkActions = {

--- a/apps/nextjs/src/stores/chatStore/__tests__/setMessages.test.ts
+++ b/apps/nextjs/src/stores/chatStore/__tests__/setMessages.test.ts
@@ -1,7 +1,7 @@
 import type { GetStore } from "@/stores/AilaStoresProvider";
 import type { TrpcUtils } from "@/utils/trpc";
 
-import { createChatStore, type ChatState } from "..";
+import { type ChatState, createChatStore } from "..";
 import type { AiMessage } from "../types";
 
 const fixedDate = new Date("2023-01-01T12:00:00.000Z");

--- a/apps/nextjs/src/stores/chatStore/index.ts
+++ b/apps/nextjs/src/stores/chatStore/index.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import { createStore } from "zustand";
 
 import type { TrpcUtils } from "@/utils/trpc";

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleAilaStreamingStatusUpdated.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleAilaStreamingStatusUpdated.ts
@@ -1,6 +1,6 @@
 import { aiLogger } from "@oakai/logger";
 
-import type { ChatSetter, ChatGetter, AilaStreamingStatus } from "../types";
+import type { AilaStreamingStatus, ChatGetter, ChatSetter } from "../types";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const log = aiLogger("chat:store");

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleAppend.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleAppend.ts
@@ -1,8 +1,9 @@
 import { aiLogger } from "@oakai/logger";
+
 import invariant from "tiny-invariant";
 
 import { canAppendSelector } from "../selectors";
-import type { ChatSetter, ChatGetter } from "../types";
+import type { ChatGetter, ChatSetter } from "../types";
 
 const log = aiLogger("chat:store");
 

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleExecuteQueuedAction.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleExecuteQueuedAction.ts
@@ -1,6 +1,6 @@
 import { aiLogger } from "@oakai/logger";
 
-import type { ChatSetter, ChatGetter } from "../types";
+import type { ChatGetter, ChatSetter } from "../types";
 
 const log = aiLogger("chat:store");
 

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleFetchInitialMessages.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleFetchInitialMessages.ts
@@ -1,10 +1,11 @@
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/nextjs";
 import invariant from "tiny-invariant";
 
 import type { TrpcUtils } from "@/utils/trpc";
 
-import type { ChatSetter, ChatGetter, AiMessage } from "../types";
+import type { AiMessage, ChatGetter, ChatSetter } from "../types";
 
 const log = aiLogger("chat:store");
 

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleScrollToBottom.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleScrollToBottom.ts
@@ -1,6 +1,6 @@
 import { aiLogger } from "@oakai/logger";
 
-import type { ChatSetter, ChatGetter } from "../types";
+import type { ChatGetter, ChatSetter } from "../types";
 
 const log = aiLogger("chat:store");
 

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleSetMessages.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleSetMessages.ts
@@ -4,7 +4,7 @@ import type { GetStore } from "@/stores/AilaStoresProvider";
 
 import { calculateStreamingStatus } from "../actions/calculateStreamingStatus";
 import { getNextStableMessages, parseStreamingMessage } from "../parsing";
-import type { ChatSetter, ChatGetter, AiMessage } from "../types";
+import type { AiMessage, ChatGetter, ChatSetter } from "../types";
 
 export function handleSetMessages(
   getStore: GetStore,

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleStop.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleStop.ts
@@ -1,4 +1,4 @@
-import type { ChatSetter, ChatGetter } from "../types";
+import type { ChatGetter, ChatSetter } from "../types";
 
 export const handleStop = (set: ChatSetter, get: ChatGetter) => () => {
   if (get().queuedUserAction) {

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleStreamingFinished.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleStreamingFinished.ts
@@ -1,4 +1,4 @@
-import type { ChatSetter, ChatGetter } from "../types";
+import type { ChatGetter, ChatSetter } from "../types";
 
 export const handleStreamingFinished =
   (set: ChatSetter, get: ChatGetter) => () => {

--- a/apps/nextjs/src/stores/chatStore/types.ts
+++ b/apps/nextjs/src/stores/chatStore/types.ts
@@ -1,5 +1,6 @@
 import type { MessagePart } from "@oakai/aila/src/protocol/jsonPatchProtocol";
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
+
 import type { Message as AiMessage } from "ai";
 import type { ChatRequestOptions, CreateMessage } from "ai";
 import type { StoreApi } from "zustand";

--- a/apps/nextjs/src/stores/lessonPlanStore/index.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/index.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import { createStore } from "zustand";
 
 import type { LessonPlanTrackingContextProps } from "@/lib/analytics/lessonPlanTrackingContext";

--- a/apps/nextjs/src/stores/lessonPlanStore/stateActionFunctions/handleMessagesUpdated.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/stateActionFunctions/handleMessagesUpdated.ts
@@ -1,10 +1,11 @@
 import {
+  type PatchDocument,
   applyLessonPlanPatchImmutable,
   extractPatches,
-  type PatchDocument,
 } from "@oakai/aila/src/protocol/jsonPatchProtocol";
 import { LessonPlanKeySchema } from "@oakai/aila/src/protocol/schema";
 import { aiLogger } from "@oakai/logger";
+
 import { createHash } from "crypto";
 
 import type { AiMessage } from "@/stores/chatStore/types";

--- a/apps/nextjs/src/stores/lessonPlanStore/stateActionFunctions/handleRefetch.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/stateActionFunctions/handleRefetch.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/nextjs";
 import invariant from "tiny-invariant";
 

--- a/apps/nextjs/src/stores/lessonPlanStore/types.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/types.ts
@@ -2,6 +2,7 @@ import type {
   LessonPlanKey,
   LooseLessonPlan,
 } from "@oakai/aila/src/protocol/schema";
+
 import type { StoreApi } from "zustand";
 
 import type { AiMessage } from "../chatStore/types";

--- a/apps/nextjs/src/stores/moderationStore/actionFunctions/handleAilaStreamingStatus.ts
+++ b/apps/nextjs/src/stores/moderationStore/actionFunctions/handleAilaStreamingStatus.ts
@@ -2,7 +2,7 @@ import { aiLogger } from "@oakai/logger";
 
 import type { AilaStreamingStatus } from "@/stores/chatStore/types";
 
-import type { ModerationSetter, ModerationGetter } from "../types";
+import type { ModerationGetter, ModerationSetter } from "../types";
 
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 const log = aiLogger("chat:store");

--- a/apps/nextjs/src/stores/moderationStore/actionFunctions/handleFetchModeration.tsx
+++ b/apps/nextjs/src/stores/moderationStore/actionFunctions/handleFetchModeration.tsx
@@ -1,9 +1,10 @@
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/nextjs";
 
 import type { TrpcUtils } from "@/utils/trpc";
 
-import type { ModerationSetter, ModerationGetter } from "../types";
+import type { ModerationGetter, ModerationSetter } from "../types";
 
 const log = aiLogger("moderation:store");
 

--- a/apps/nextjs/src/stores/moderationStore/actionFunctions/handleToxicModeration.tsx
+++ b/apps/nextjs/src/stores/moderationStore/actionFunctions/handleToxicModeration.tsx
@@ -2,7 +2,7 @@ import type { PersistedModerationBase } from "@oakai/core/src/utils/ailaModerati
 
 import type { GetStore } from "@/stores/AilaStoresProvider";
 
-import type { ModerationSetter, ModerationGetter } from "../types";
+import type { ModerationGetter, ModerationSetter } from "../types";
 
 export const handleToxicModeration =
   (

--- a/apps/nextjs/src/stores/moderationStore/actionFunctions/handleUpdateModerationState.tsx
+++ b/apps/nextjs/src/stores/moderationStore/actionFunctions/handleUpdateModerationState.tsx
@@ -1,7 +1,8 @@
 import { isToxic } from "@oakai/core/src/utils/ailaModeration/helpers";
+
 import type { Moderation } from "@prisma/client";
 
-import type { ModerationSetter, ModerationGetter } from "../types";
+import type { ModerationGetter, ModerationSetter } from "../types";
 
 export const handleUpdateModerationState = (
   set: ModerationSetter,

--- a/apps/nextjs/src/stores/moderationStore/types.ts
+++ b/apps/nextjs/src/stores/moderationStore/types.ts
@@ -1,4 +1,5 @@
 import type { PersistedModerationBase } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
+
 import type { Moderation } from "@prisma/client";
 import type { StoreApi } from "zustand";
 

--- a/apps/nextjs/src/stores/zustandHelpers.ts
+++ b/apps/nextjs/src/stores/zustandHelpers.ts
@@ -1,4 +1,5 @@
-import { aiLogger, type LoggerKey } from "@oakai/logger";
+import { type LoggerKey, aiLogger } from "@oakai/logger";
+
 import type { StoreApi } from "zustand";
 
 export const logStoreUpdates = <T extends object>(

--- a/apps/nextjs/src/utils/serverSideFeatureFlag.ts
+++ b/apps/nextjs/src/utils/serverSideFeatureFlag.ts
@@ -1,6 +1,7 @@
-import { auth, clerkClient } from "@clerk/nextjs/server";
 import { posthogAiBetaServerClient } from "@oakai/core/src/analytics/posthogAiBetaServerClient";
 import { aiLogger } from "@oakai/logger";
+
+import { auth, clerkClient } from "@clerk/nextjs/server";
 import { kv } from "@vercel/kv";
 
 const log = aiLogger("feature-flags");

--- a/apps/nextjs/src/utils/trpc.tsx
+++ b/apps/nextjs/src/utils/trpc.tsx
@@ -5,6 +5,7 @@ import { useState } from "react";
 import type { AppRouter } from "@oakai/api/src/router";
 import type { ChatAppRouter } from "@oakai/api/src/router/chat";
 import { transformer } from "@oakai/api/transformer";
+
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import type { TRPCLink } from "@trpc/client";
 import { httpBatchLink, loggerLink } from "@trpc/client";

--- a/apps/nextjs/tests-e2e/helpers/auth/index.ts
+++ b/apps/nextjs/tests-e2e/helpers/auth/index.ts
@@ -1,7 +1,8 @@
-import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import type { TestSupportRouter } from "@oakai/api/src/router/testSupport";
 import { transformer } from "@oakai/api/transformer";
 import { aiLogger } from "@oakai/logger";
+
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import type { Page } from "@playwright/test";
 import { test } from "@playwright/test";
 import { createTRPCProxyClient, httpBatchLink, loggerLink } from "@trpc/client";

--- a/apps/nextjs/tests-e2e/tests/aila-chat/auth.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/auth.test.ts
@@ -1,5 +1,5 @@
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import { TEST_BASE_URL } from "../../config/config";
 import { bypassVercelProtection } from "../../helpers/vercel";

--- a/apps/nextjs/tests-e2e/tests/aila-chat/downloads.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/downloads.test.ts
@@ -1,6 +1,6 @@
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import type { Page } from "@playwright/test";
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import { TEST_BASE_URL } from "../../config/config";
 import { bypassVercelProtection } from "../../helpers/vercel";

--- a/apps/nextjs/tests-e2e/tests/aila-chat/flexible-prompt-live.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/flexible-prompt-live.test.ts
@@ -1,5 +1,5 @@
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import { TEST_BASE_URL } from "../../config/config";
 import { bypassVercelProtection } from "../../helpers/vercel";

--- a/apps/nextjs/tests-e2e/tests/aila-chat/full-romans.mobile.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/full-romans.mobile.test.ts
@@ -1,6 +1,6 @@
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import type { Page } from "@playwright/test";
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import { TEST_BASE_URL } from "../../config/config";
 import { bypassVercelProtection } from "../../helpers/vercel";

--- a/apps/nextjs/tests-e2e/tests/aila-chat/full-romans.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/full-romans.test.ts
@@ -1,5 +1,5 @@
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import { TEST_BASE_URL } from "../../config/config";
 import { bypassVercelProtection } from "../../helpers/vercel";

--- a/apps/nextjs/tests-e2e/tests/aila-chat/rate-limiting.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/rate-limiting.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import { TEST_BASE_URL } from "../../config/config";
 import { prepareUser } from "../../helpers/auth";

--- a/apps/nextjs/tests-e2e/tests/auth.test.ts
+++ b/apps/nextjs/tests-e2e/tests/auth.test.ts
@@ -1,12 +1,13 @@
-import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import { aiLogger } from "@oakai/logger";
+
+import { setupClerkTestingToken } from "@clerk/testing/playwright";
 import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
 import {
+  TEST_BASE_URL,
   TEST_USER_EMAIL,
   TEST_USER_PASSWORD,
-  TEST_BASE_URL,
 } from "../config/config";
 import { bypassVercelProtection } from "../helpers/vercel";
 

--- a/apps/nextjs/tests-e2e/tests/banned-users.test.ts
+++ b/apps/nextjs/tests-e2e/tests/banned-users.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import { TEST_BASE_URL } from "../config/config";
 import { prepareUser } from "../helpers/auth";

--- a/apps/nextjs/tests-e2e/tests/chat-performance.test.ts
+++ b/apps/nextjs/tests-e2e/tests/chat-performance.test.ts
@@ -1,4 +1,4 @@
-import { expect, test, type Page } from "@playwright/test";
+import { type Page, expect, test } from "@playwright/test";
 
 import { TEST_BASE_URL } from "../config/config";
 import { prepareUser } from "../helpers/auth";

--- a/apps/nextjs/tests-e2e/tests/demo-accounts.test.ts
+++ b/apps/nextjs/tests-e2e/tests/demo-accounts.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import { TEST_BASE_URL } from "../config/config";
 import { prepareUser } from "../helpers/auth";

--- a/apps/nextjs/tests-e2e/tests/modifiy-lesson.test.ts
+++ b/apps/nextjs/tests-e2e/tests/modifiy-lesson.test.ts
@@ -1,4 +1,4 @@
-import { test, expect, type Page } from "@playwright/test";
+import { type Page, expect, test } from "@playwright/test";
 
 import { TEST_BASE_URL } from "../config/config";
 import { prepareUser } from "../helpers/auth";

--- a/apps/nextjs/tests-e2e/tests/onboarding.test.ts
+++ b/apps/nextjs/tests-e2e/tests/onboarding.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import { TEST_BASE_URL } from "../config/config";
 import { prepareUser } from "../helpers/auth";

--- a/apps/nextjs/tests-e2e/tests/public.test.ts
+++ b/apps/nextjs/tests-e2e/tests/public.test.ts
@@ -1,4 +1,4 @@
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import { TEST_BASE_URL } from "../config/config";
 import { bypassVercelProtection } from "../helpers/vercel";

--- a/apps/nextjs/tests-e2e/tests/sharing.test.ts
+++ b/apps/nextjs/tests-e2e/tests/sharing.test.ts
@@ -1,5 +1,5 @@
 import type { Page } from "@playwright/test";
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import { TEST_BASE_URL } from "../config/config";
 import { prepareUser } from "../helpers/auth";

--- a/apps/nextjs/tests-e2e/tests/sidebar.test.ts
+++ b/apps/nextjs/tests-e2e/tests/sidebar.test.ts
@@ -1,5 +1,5 @@
 import { setupClerkTestingToken } from "@clerk/testing/playwright";
-import { test, expect } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 
 import { TEST_BASE_URL } from "../config/config";
 import { bypassVercelProtection } from "../helpers/vercel";

--- a/packages/aila/src/core/Aila.ts
+++ b/packages/aila/src/core/Aila.ts
@@ -4,8 +4,8 @@ import { aiLogger } from "@oakai/logger";
 
 import {
   DEFAULT_MODEL,
-  DEFAULT_TEMPERATURE,
   DEFAULT_NUMBER_OF_RECORDS_IN_RAG,
+  DEFAULT_TEMPERATURE,
 } from "../constants";
 import type { AilaAmericanismsFeature } from "../features/americanisms";
 import { NullAilaAmericanisms } from "../features/americanisms/NullAilaAmericanisms";
@@ -34,9 +34,9 @@ import { OpenAIService } from "./llm/OpenAIService";
 import type { AilaPlugin } from "./plugins/types";
 import type {
   AilaGenerateDocumentOptions,
+  AilaInitializationOptions,
   AilaOptions,
   AilaOptionsWithDefaultFallbackValues,
-  AilaInitializationOptions,
 } from "./types";
 
 const log = aiLogger("aila");

--- a/packages/aila/src/core/chat/AilaChat.ts
+++ b/packages/aila/src/core/chat/AilaChat.ts
@@ -1,10 +1,11 @@
 import {
+  subjectWarnings,
   subjects,
   unsupportedSubjects,
-  subjectWarnings,
 } from "@oakai/core/src/utils/subjects";
 // TODO: GCLOMAX This is a bodge. Fix as soon as possible due to the new prisma client set up.
 import { aiLogger } from "@oakai/logger";
+
 import invariant from "tiny-invariant";
 
 import { DEFAULT_MODEL, DEFAULT_TEMPERATURE } from "../../constants";
@@ -17,8 +18,8 @@ import type {
   JsonPatchDocumentOptional,
 } from "../../protocol/jsonPatchProtocol";
 import {
-  extractPatches,
   LLMMessageSchema,
+  extractPatches,
   parseMessageParts,
 } from "../../protocol/jsonPatchProtocol";
 import type {

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import type { ReadableStreamDefaultController } from "stream/web";
 
 import { AilaThreatDetectionError } from "../../features/threatDetection/types";

--- a/packages/aila/src/core/document/AilaDocument.ts
+++ b/packages/aila/src/core/document/AilaDocument.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import { deepClone } from "fast-json-patch";
 
 import { AilaCategorisation } from "../../features/categorisation/categorisers/AilaCategorisation";

--- a/packages/aila/src/core/llm/OpenAIService.ts
+++ b/packages/aila/src/core/llm/OpenAIService.ts
@@ -1,7 +1,8 @@
-import type { OpenAIProvider } from "@ai-sdk/openai";
 import type { HeliconeChatMeta } from "@oakai/core/src/llm/helicone";
 import { createVercelOpenAIClient } from "@oakai/core/src/llm/openai";
 import { aiLogger } from "@oakai/logger";
+
+import type { OpenAIProvider } from "@ai-sdk/openai";
 import { streamObject, streamText } from "ai";
 import type { ZodSchema } from "zod";
 

--- a/packages/aila/src/core/quiz/LessonSlugQuizMapping.ts
+++ b/packages/aila/src/core/quiz/LessonSlugQuizMapping.ts
@@ -1,5 +1,6 @@
-import { Client } from "@elastic/elasticsearch";
 import { aiLogger } from "@oakai/logger";
+
+import { Client } from "@elastic/elasticsearch";
 import { z } from "zod";
 
 import type { QuizPath } from "../../protocol/schema";

--- a/packages/aila/src/core/quiz/fullservices/BaseFullQuizService.ts
+++ b/packages/aila/src/core/quiz/fullservices/BaseFullQuizService.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import type { z } from "zod";
 
 import type {
@@ -11,8 +12,8 @@ import type {
   AilaQuizGeneratorService,
   AilaQuizReranker,
   FullQuizService,
-  quizPatchType,
   QuizSelector,
+  quizPatchType,
 } from "../interfaces";
 
 const log = aiLogger("aila:quiz");

--- a/packages/aila/src/core/quiz/fullservices/BasedOnQuizService.ts
+++ b/packages/aila/src/core/quiz/fullservices/BasedOnQuizService.ts
@@ -3,9 +3,9 @@ import type { z } from "zod";
 import type { BaseType } from "../ChoiceModels";
 import { AilaQuizFactory } from "../generators/AilaQuizGeneratorFactory";
 import type {
+  AilaQuizGeneratorService,
   AilaQuizReranker,
   QuizSelector,
-  AilaQuizGeneratorService,
 } from "../interfaces";
 import { AilaQuizRerankerFactoryImpl } from "../rerankers/AilaQuizRerankerFactory";
 import { QuizSelectorFactoryImpl } from "../selectors/QuizSelectorFactory";

--- a/packages/aila/src/core/quiz/generators/BaseQuizGenerator.ts
+++ b/packages/aila/src/core/quiz/generators/BaseQuizGenerator.ts
@@ -1,7 +1,8 @@
-import { Client } from "@elastic/elasticsearch";
-import type { SearchHitsMetadata } from "@elastic/elasticsearch/lib/api/types";
 import { prisma } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
+
+import { Client } from "@elastic/elasticsearch";
+import type { SearchHitsMetadata } from "@elastic/elasticsearch/lib/api/types";
 import { CohereClient } from "cohere-ai";
 import type { RerankResponseResultsItem } from "cohere-ai/api/types";
 import { z } from "zod";

--- a/packages/aila/src/core/quiz/rerankers.ts
+++ b/packages/aila/src/core/quiz/rerankers.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import { CohereClient } from "cohere-ai";
 
 import type { DocumentReranker, SimplifiedResult } from "./interfaces";

--- a/packages/aila/src/core/quiz/rerankers/AilaQuizReranker.ts
+++ b/packages/aila/src/core/quiz/rerankers/AilaQuizReranker.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import { kv } from "@vercel/kv";
 import { pick } from "remeda";
 import { Md5 } from "ts-md5";

--- a/packages/aila/src/core/quiz/selectors/SimpleQuizSelector.ts
+++ b/packages/aila/src/core/quiz/selectors/SimpleQuizSelector.ts
@@ -1,5 +1,5 @@
 import type { BaseType, MaxRatingFunctionApplier } from "../ChoiceModels";
-import { selectHighestRated, type RatingFunction } from "../ChoiceModels";
+import { type RatingFunction, selectHighestRated } from "../ChoiceModels";
 import { BaseQuizSelector } from "./BaseQuizSelector";
 
 export class SimpleQuizSelector<

--- a/packages/aila/src/features/americanisms/AilaAmericanisms.ts
+++ b/packages/aila/src/features/americanisms/AilaAmericanisms.ts
@@ -1,6 +1,7 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="./american-british-english-translator.d.ts" />
 import { textify } from "@oakai/core/src/utils/textify";
+
 import translator from "american-british-english-translator";
 
 import type { AilaAmericanismsFeature } from ".";

--- a/packages/aila/src/features/analytics/adapters/DatadogAnalyticsAdapter.ts
+++ b/packages/aila/src/features/analytics/adapters/DatadogAnalyticsAdapter.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import { getEncoding } from "js-tiktoken";
 import { z } from "zod";
 

--- a/packages/aila/src/features/analytics/adapters/PosthogAnalyticsAdapter.ts
+++ b/packages/aila/src/features/analytics/adapters/PosthogAnalyticsAdapter.ts
@@ -1,4 +1,5 @@
 import type { ModerationResult } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
+
 import { getEncoding } from "js-tiktoken";
 import { PostHog } from "posthog-node";
 import invariant from "tiny-invariant";

--- a/packages/aila/src/features/categorisation/categorisers/AilaCategorisation.ts
+++ b/packages/aila/src/features/categorisation/categorisers/AilaCategorisation.ts
@@ -1,6 +1,7 @@
 import { CategoriseKeyStageAndSubjectResponse } from "@oakai/core/src/rag/categorisation";
 import { keyStages, subjects } from "@oakai/core/src/utils/subjects";
 import { aiLogger } from "@oakai/logger";
+
 import type { ChatCompletionMessageParam } from "openai/resources/index.mjs";
 import { Md5 } from "ts-md5";
 

--- a/packages/aila/src/features/errorReporting/reporters/SentryErrorReporter.ts
+++ b/packages/aila/src/features/errorReporting/reporters/SentryErrorReporter.ts
@@ -1,7 +1,8 @@
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/nextjs";
 
-import type { AilaErrorSeverity, AilaErrorBreadcrumb } from "../types";
+import type { AilaErrorBreadcrumb, AilaErrorSeverity } from "../types";
 import { AilaErrorReporter } from "./AilaErrorReporter";
 
 const log = aiLogger("aila:errors");

--- a/packages/aila/src/features/generation/AilaGeneration.ts
+++ b/packages/aila/src/features/generation/AilaGeneration.ts
@@ -6,6 +6,7 @@ import {
 import type { Prompt } from "@oakai/db";
 import { prisma } from "@oakai/db/client";
 import { aiLogger } from "@oakai/logger";
+
 import { kv } from "@vercel/kv";
 import { getEncoding } from "js-tiktoken";
 

--- a/packages/aila/src/features/moderation/AilaModeration.ts
+++ b/packages/aila/src/features/moderation/AilaModeration.ts
@@ -9,6 +9,7 @@ import type { ModerationResult } from "@oakai/core/src/utils/ailaModeration/mode
 import type { Moderation, PrismaClientWithAccelerate } from "@oakai/db";
 import { prisma as globalPrisma } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
+
 import invariant from "tiny-invariant";
 
 import type { AilaServices } from "../../core/AilaServices";

--- a/packages/aila/src/features/moderation/getSessionModerations.ts
+++ b/packages/aila/src/features/moderation/getSessionModerations.ts
@@ -1,5 +1,6 @@
 import { Moderations } from "@oakai/core/src/models/moderations";
 import { prisma } from "@oakai/db/client";
+
 import type { Moderation } from "@prisma/client";
 
 export async function getSessionModerations(

--- a/packages/aila/src/features/moderation/moderators/MockModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/MockModerator.ts
@@ -1,7 +1,7 @@
 import type { ModerationResult } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
 import { aiLogger } from "@oakai/logger";
 
-import { AilaModerator, AilaModerationError } from ".";
+import { AilaModerationError, AilaModerator } from ".";
 
 const log = aiLogger("aila:testing");
 

--- a/packages/aila/src/features/moderation/moderators/OpenAiModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/OpenAiModerator.ts
@@ -3,6 +3,7 @@ import { moderationPrompt } from "@oakai/core/src/utils/ailaModeration/moderatio
 import type { ModerationResult } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
 import { moderationResponseSchema } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
 import { aiLogger } from "@oakai/logger";
+
 import type OpenAI from "openai";
 import type {
   ChatCompletion,
@@ -10,7 +11,7 @@ import type {
 } from "openai/resources/index.mjs";
 import zodToJsonSchema from "zod-to-json-schema";
 
-import { AilaModerator, AilaModerationError } from ".";
+import { AilaModerationError, AilaModerator } from ".";
 import {
   DEFAULT_MODERATION_MODEL,
   DEFAULT_MODERATION_TEMPERATURE,

--- a/packages/aila/src/features/snapshotStore/AilaSnapshotStore.ts
+++ b/packages/aila/src/features/snapshotStore/AilaSnapshotStore.ts
@@ -1,6 +1,7 @@
 import { LessonSnapshots } from "@oakai/core/src/models/lessonSnapshots";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 import { prisma as globalPrisma } from "@oakai/db/client";
+
 import type { LessonSnapshotTrigger } from "@prisma/client";
 import invariant from "tiny-invariant";
 

--- a/packages/aila/src/features/threatDetection/detectors/lakera/LakeraThreatDetector.ts
+++ b/packages/aila/src/features/threatDetection/detectors/lakera/LakeraThreatDetector.ts
@@ -1,13 +1,14 @@
 import { aiLogger } from "@oakai/logger";
+
 import { z } from "zod";
 
 import {
+  AilaThreatDetector,
   type ThreatCategory,
   type ThreatDetectionResult,
   type ThreatSeverity,
-  AilaThreatDetector,
 } from "../AilaThreatDetector";
-import type { Message, LakeraGuardResponse, BreakdownItem } from "./schema";
+import type { BreakdownItem, LakeraGuardResponse, Message } from "./schema";
 import { lakeraGuardRequestSchema, lakeraGuardResponseSchema } from "./schema";
 
 const log = aiLogger("aila:threat");

--- a/packages/aila/src/features/threatDetection/detectors/lakera/test-lakera.ts
+++ b/packages/aila/src/features/threatDetection/detectors/lakera/test-lakera.ts
@@ -1,5 +1,5 @@
 import { config } from "dotenv";
-import { resolve, dirname } from "path";
+import { dirname, resolve } from "path";
 import { fileURLToPath } from "url";
 
 /* eslint-disable no-console */

--- a/packages/aila/src/helpers/errorReporting/index.ts
+++ b/packages/aila/src/helpers/errorReporting/index.ts
@@ -3,6 +3,7 @@
 // Then, we can use the errorReporting feature instance
 // to report errors using the correct error reporting back-end
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/nextjs";
 
 const log = aiLogger("aila:errors");

--- a/packages/aila/src/lib/openai/OpenAICompletionWithLogging.ts
+++ b/packages/aila/src/lib/openai/OpenAICompletionWithLogging.ts
@@ -3,6 +3,7 @@
 import { posthogAiBetaServerClient } from "@oakai/core/src/analytics/posthogAiBetaServerClient";
 import { createOpenAIClient } from "@oakai/core/src/llm/openai";
 import { aiLogger } from "@oakai/logger";
+
 import type OpenAI from "openai";
 import type { PostHog } from "posthog-node";
 

--- a/packages/aila/src/protocol/jsonPatchProtocol.immutability.test.ts
+++ b/packages/aila/src/protocol/jsonPatchProtocol.immutability.test.ts
@@ -1,8 +1,8 @@
 import invariant from "tiny-invariant";
 
 import {
-  applyLessonPlanPatchImmutable,
   type JsonPatchDocument,
+  applyLessonPlanPatchImmutable,
 } from "./jsonPatchProtocol";
 
 describe("applyLessonPlanPatchImmutable", () => {

--- a/packages/aila/src/protocol/jsonPatchProtocol.ts
+++ b/packages/aila/src/protocol/jsonPatchProtocol.ts
@@ -1,8 +1,9 @@
 import { moderationCategoriesSchema } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/nextjs";
 import type { Operation } from "fast-json-patch";
-import { applyPatch, deepClone, JsonPatchError } from "fast-json-patch";
+import { JsonPatchError, applyPatch, deepClone } from "fast-json-patch";
 import * as immer from "immer";
 import untruncateJson from "untruncate-json";
 import { z } from "zod";

--- a/packages/aila/src/protocol/sectionToMarkdown.ts
+++ b/packages/aila/src/protocol/sectionToMarkdown.ts
@@ -1,4 +1,5 @@
 import { camelCaseToSentenceCase } from "@oakai/core/src/utils/camelCaseConversion";
+
 import { isArray, isNumber, isObject, isString } from "remeda";
 import { z } from "zod";
 

--- a/packages/aila/src/utils/lessonPlan/fetchLessonPlan.ts
+++ b/packages/aila/src/utils/lessonPlan/fetchLessonPlan.ts
@@ -1,4 +1,5 @@
 import type { PrismaClientWithAccelerate } from "@oakai/db";
+
 import { kv } from "@vercel/kv";
 
 import type { LooseLessonPlan } from "../../protocol/schema";

--- a/packages/aila/src/utils/reportAnalyticsEvent.ts
+++ b/packages/aila/src/utils/reportAnalyticsEvent.ts
@@ -1,4 +1,5 @@
 import { posthogAiBetaServerClient } from "@oakai/core/src/analytics/posthogAiBetaServerClient";
+
 import * as Sentry from "@sentry/node";
 
 import { BOT_USER_ID } from "../constants";

--- a/packages/api/src/context.ts
+++ b/packages/api/src/context.ts
@@ -1,9 +1,10 @@
+import { prisma } from "@oakai/db";
+
 import type {
   SignedInAuthObject,
   SignedOutAuthObject,
 } from "@clerk/backend/internal";
 import { getAuth } from "@clerk/nextjs/server";
-import { prisma } from "@oakai/db";
 import type { inferAsyncReturnType } from "@trpc/server";
 import type { NodeHTTPCreateContextFnOptions } from "@trpc/server/adapters/node-http";
 import type { NextRequest, NextResponse } from "next/server";

--- a/packages/api/src/export/exportAdditionalMaterialsDoc.ts
+++ b/packages/api/src/export/exportAdditionalMaterialsDoc.ts
@@ -1,8 +1,9 @@
-import type { SignedInAuthObject } from "@clerk/backend/internal";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 import { exportAdditionalMaterials } from "@oakai/exports";
 import type { LessonInputData } from "@oakai/exports/src/schema/input.schema";
 import { aiLogger } from "@oakai/logger";
+
+import type { SignedInAuthObject } from "@clerk/backend/internal";
 import * as Sentry from "@sentry/nextjs";
 
 import type { OutputSchema } from "../router/exports";

--- a/packages/api/src/export/exportHelpers.ts
+++ b/packages/api/src/export/exportHelpers.ts
@@ -1,5 +1,3 @@
-import type { SignedInAuthObject } from "@clerk/backend/internal";
-import { clerkClient } from "@clerk/nextjs/server";
 import { LessonSnapshots } from "@oakai/core";
 import type { Snapshot } from "@oakai/core/src/models/lessonSnapshots";
 import type {
@@ -7,11 +5,14 @@ import type {
   LessonSnapshot,
   PrismaClientWithAccelerate,
 } from "@oakai/db";
+
+import type { SignedInAuthObject } from "@clerk/backend/internal";
+import { clerkClient } from "@clerk/nextjs/server";
 import * as Sentry from "@sentry/nextjs";
 
 import {
-  ailaGetExportBySnapshotId,
   type OutputSchema,
+  ailaGetExportBySnapshotId,
 } from "../router/exports";
 
 export const getUserEmail = async (ctx: {

--- a/packages/api/src/export/exportLessonPlan.ts
+++ b/packages/api/src/export/exportLessonPlan.ts
@@ -1,8 +1,9 @@
-import type { SignedInAuthObject } from "@clerk/backend/internal";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 import { exportDocLessonPlan } from "@oakai/exports";
 import type { LessonInputData } from "@oakai/exports/src/schema/input.schema";
 import { aiLogger } from "@oakai/logger";
+
+import type { SignedInAuthObject } from "@clerk/backend/internal";
 import * as Sentry from "@sentry/nextjs";
 
 import type { OutputSchema } from "../router/exports";

--- a/packages/api/src/export/exportLessonSlides.ts
+++ b/packages/api/src/export/exportLessonSlides.ts
@@ -1,8 +1,9 @@
-import type { SignedInAuthObject } from "@clerk/backend/internal";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 import { exportSlidesFullLesson } from "@oakai/exports";
 import type { LessonSlidesInputData } from "@oakai/exports/src/schema/input.schema";
 import { aiLogger } from "@oakai/logger";
+
+import type { SignedInAuthObject } from "@clerk/backend/internal";
 import * as Sentry from "@sentry/nextjs";
 
 import type { OutputSchema } from "../router/exports";

--- a/packages/api/src/export/exportQuizDesignerSlides.ts
+++ b/packages/api/src/export/exportQuizDesignerSlides.ts
@@ -1,8 +1,9 @@
-import type { SignedInAuthObject } from "@clerk/backend/internal";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 import { exportQuizDesignerSlides } from "@oakai/exports";
 import type { ExportableQuizAppState } from "@oakai/exports/src/schema/input.schema";
 import { aiLogger } from "@oakai/logger";
+
+import type { SignedInAuthObject } from "@clerk/backend/internal";
 import * as Sentry from "@sentry/nextjs";
 
 import type { OutputSchema } from "../router/exports";

--- a/packages/api/src/export/exportQuizDoc.ts
+++ b/packages/api/src/export/exportQuizDoc.ts
@@ -1,8 +1,9 @@
-import type { SignedInAuthObject } from "@clerk/backend/internal";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 import { exportDocQuiz } from "@oakai/exports";
 import type { QuizDocInputData } from "@oakai/exports/src/schema/input.schema";
 import { aiLogger } from "@oakai/logger";
+
+import type { SignedInAuthObject } from "@clerk/backend/internal";
 import * as Sentry from "@sentry/nextjs";
 import { z } from "zod";
 

--- a/packages/api/src/export/exportWorksheets.ts
+++ b/packages/api/src/export/exportWorksheets.ts
@@ -1,8 +1,9 @@
-import type { SignedInAuthObject } from "@clerk/backend/internal";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 import { exportDocsWorksheet } from "@oakai/exports";
 import type { WorksheetSlidesInputData } from "@oakai/exports/src/schema/input.schema";
 import { aiLogger } from "@oakai/logger";
+
+import type { SignedInAuthObject } from "@clerk/backend/internal";
 import * as Sentry from "@sentry/nextjs";
 
 import type { OutputSchema } from "../router/exports";

--- a/packages/api/src/middleware/adminAuth.ts
+++ b/packages/api/src/middleware/adminAuth.ts
@@ -1,6 +1,7 @@
+import { aiLogger } from "@oakai/logger";
+
 import type { SignedInAuthObject } from "@clerk/backend/internal";
 import { clerkClient } from "@clerk/nextjs/server";
-import { aiLogger } from "@oakai/logger";
 import { TRPCError } from "@trpc/server";
 
 import { t } from "../trpc";

--- a/packages/api/src/middleware/auth.ts
+++ b/packages/api/src/middleware/auth.ts
@@ -1,5 +1,6 @@
-import type { SignedInAuthObject } from "@clerk/backend/internal";
 import { aiLogger } from "@oakai/logger";
+
+import type { SignedInAuthObject } from "@clerk/backend/internal";
 import { TRPCError } from "@trpc/server";
 
 import { t } from "../trpc";

--- a/packages/api/src/middleware/rateLimiter.ts
+++ b/packages/api/src/middleware/rateLimiter.ts
@@ -2,6 +2,7 @@ import { inngest } from "@oakai/core/src/inngest";
 import { rateLimits } from "@oakai/core/src/utils/rateLimiting/rateLimit";
 import type { RateLimiter } from "@oakai/core/src/utils/rateLimiting/userBasedRateLimiter";
 import { RateLimitExceededError } from "@oakai/core/src/utils/rateLimiting/userBasedRateLimiter";
+
 import { TRPCError } from "@trpc/server";
 
 import { t } from "../trpc";

--- a/packages/api/src/middleware/testSupport.ts
+++ b/packages/api/src/middleware/testSupport.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import { TRPCError } from "@trpc/server";
 
 import { publicProcedure, t } from "../trpc";

--- a/packages/api/src/router/admin.ts
+++ b/packages/api/src/router/admin.ts
@@ -1,6 +1,7 @@
 import { Moderations, SafetyViolations } from "@oakai/core";
 import type { Moderation, SafetyViolation } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
+
 import { z } from "zod";
 
 import type { AilaPersistedChat } from "../../../aila/src/protocol/schema";

--- a/packages/api/src/router/app.ts
+++ b/packages/api/src/router/app.ts
@@ -2,7 +2,8 @@ import { Apps } from "@oakai/core";
 import { serializeApp } from "@oakai/core/src/models/serializers";
 import { sendEmailRequestingMoreGenerations } from "@oakai/core/src/utils/sendEmailRequestingMoreGenerations";
 import { prisma } from "@oakai/db";
-import { structuredLogger as logger, aiLogger } from "@oakai/logger";
+import { aiLogger, structuredLogger as logger } from "@oakai/logger";
+
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 

--- a/packages/api/src/router/appSessions.ts
+++ b/packages/api/src/router/appSessions.ts
@@ -1,9 +1,10 @@
-import type { SignedInAuthObject } from "@clerk/backend/internal";
-import { clerkClient } from "@clerk/nextjs/server";
 import { demoUsers } from "@oakai/core";
 import { rateLimits } from "@oakai/core/src/utils/rateLimiting/rateLimit";
 import { RateLimitExceededError } from "@oakai/core/src/utils/rateLimiting/userBasedRateLimiter";
 import type { Prisma, PrismaClientWithAccelerate } from "@oakai/db";
+
+import type { SignedInAuthObject } from "@clerk/backend/internal";
+import { clerkClient } from "@clerk/nextjs/server";
 import * as Sentry from "@sentry/nextjs";
 import { TRPCError } from "@trpc/server";
 import { isTruthy } from "remeda";

--- a/packages/api/src/router/auth.ts
+++ b/packages/api/src/router/auth.ts
@@ -1,7 +1,8 @@
-import { clerkClient } from "@clerk/nextjs/server";
 import { demoUsers } from "@oakai/core";
 import { createHubspotCustomer } from "@oakai/core/src/analytics/hubspotClient";
 import { posthogAiBetaServerClient } from "@oakai/core/src/analytics/posthogAiBetaServerClient";
+
+import { clerkClient } from "@clerk/nextjs/server";
 import { z } from "zod";
 
 import { protectedProcedure } from "../middleware/auth";

--- a/packages/api/src/router/chats.ts
+++ b/packages/api/src/router/chats.ts
@@ -1,4 +1,5 @@
 import { prisma } from "@oakai/db/client";
+
 import * as Sentry from "@sentry/nextjs";
 import { TRPCError } from "@trpc/server";
 import { isTruthy } from "remeda";

--- a/packages/api/src/router/cloudinary.ts
+++ b/packages/api/src/router/cloudinary.ts
@@ -1,5 +1,6 @@
 import { requestImageDescription } from "@oakai/core/src/functions/generation/imageAltTextRequestGeneration.ts/requestImageDescription";
 import { aiLogger } from "@oakai/logger";
+
 import { v2 as cloudinary } from "cloudinary";
 import { z } from "zod";
 

--- a/packages/api/src/router/exports.ts
+++ b/packages/api/src/router/exports.ts
@@ -1,15 +1,16 @@
-import type { SignedInAuthObject } from "@clerk/backend/internal";
-import { clerkClient } from "@clerk/nextjs/server";
 import { sendEmail } from "@oakai/core/src/utils/sendEmail";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 import {
   exportDocLessonPlanSchema,
   exportDocQuizSchema,
-  exportSlidesFullLessonSchema,
   exportDocsWorksheetSchema,
+  exportSlidesFullLessonSchema,
 } from "@oakai/exports";
 import { exportableQuizAppStateSchema } from "@oakai/exports/src/schema/input.schema";
 import { aiLogger } from "@oakai/logger";
+
+import type { SignedInAuthObject } from "@clerk/backend/internal";
+import { clerkClient } from "@clerk/nextjs/server";
 import type { LessonExportType } from "@prisma/client";
 import * as Sentry from "@sentry/nextjs";
 import { kv } from "@vercel/kv";

--- a/packages/api/src/router/generations.ts
+++ b/packages/api/src/router/generations.ts
@@ -14,6 +14,7 @@ import {
 import { sendQuizFeedbackEmail } from "@oakai/core/src/utils/sendQuizFeedbackEmail";
 import { requestGenerationWorker } from "@oakai/core/src/workers/generations/requestGeneration";
 import { aiLogger, structuredLogger as logger } from "@oakai/logger";
+
 import { TRPCError } from "@trpc/server";
 import { Redis } from "@upstash/redis";
 import { waitUntil } from "@vercel/functions";

--- a/packages/api/src/router/health.ts
+++ b/packages/api/src/router/health.ts
@@ -1,7 +1,8 @@
 import { aiLogger } from "@oakai/logger";
+
 import { TRPCError } from "@trpc/server";
 
-import { router, publicProcedure } from "../trpc";
+import { publicProcedure, router } from "../trpc";
 
 const log = aiLogger("db");
 

--- a/packages/api/src/router/judgements.ts
+++ b/packages/api/src/router/judgements.ts
@@ -4,7 +4,8 @@ import type {
   subjectsAndKeyStages,
 } from "@oakai/core";
 import { sendJudgementFeedbackEmail } from "@oakai/core/src/utils/sendJudgementFeedbackEmail";
-import { structuredLogger as logger, aiLogger } from "@oakai/logger";
+import { aiLogger, structuredLogger as logger } from "@oakai/logger";
+
 import { z } from "zod";
 
 import { protectedProcedure } from "../middleware/auth";

--- a/packages/api/src/router/lesson-summary.ts
+++ b/packages/api/src/router/lesson-summary.ts
@@ -1,4 +1,5 @@
 import { LessonSummaries } from "@oakai/core";
+
 import { z } from "zod";
 
 import { protectedProcedure } from "../middleware/auth";

--- a/packages/api/src/router/lesson.ts
+++ b/packages/api/src/router/lesson.ts
@@ -1,6 +1,7 @@
 import { Lessons, inngest } from "@oakai/core";
 import type { LessonSummary, Transcript } from "@oakai/db";
 import { LessonWithSnippets } from "@oakai/db";
+
 import { TRPCError } from "@trpc/server";
 import { z } from "zod";
 

--- a/packages/api/src/router/moderations.ts
+++ b/packages/api/src/router/moderations.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/node";
 import { z } from "zod";
 

--- a/packages/api/src/router/snippet.ts
+++ b/packages/api/src/router/snippet.ts
@@ -1,4 +1,5 @@
 import { Snippets } from "@oakai/core";
+
 import { z } from "zod";
 
 import { protectedProcedure } from "../middleware/auth";

--- a/packages/api/src/router/subjectsAndKeyStage.ts
+++ b/packages/api/src/router/subjectsAndKeyStage.ts
@@ -1,9 +1,10 @@
 import {
-  subjectsAndKeyStages,
   type KeyStageName,
   type SubjectName,
+  subjectsAndKeyStages,
 } from "@oakai/core";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
+
 import { z } from "zod";
 
 import { protectedProcedure } from "../middleware/auth";

--- a/packages/api/src/router/testSupport/prepareUser.ts
+++ b/packages/api/src/router/testSupport/prepareUser.ts
@@ -1,5 +1,6 @@
-import { clerkClient } from "@clerk/nextjs/server";
 import { aiLogger } from "@oakai/logger";
+
+import { clerkClient } from "@clerk/nextjs/server";
 import { waitUntil } from "@vercel/functions";
 import os from "os";
 import { z } from "zod";

--- a/packages/api/src/router/testSupport/userPreparation/clerkUsers.ts
+++ b/packages/api/src/router/testSupport/userPreparation/clerkUsers.ts
@@ -1,6 +1,7 @@
+import { aiLogger } from "@oakai/logger";
+
 import { clerkClient } from "@clerk/nextjs/server";
 import { isClerkAPIResponseError } from "@clerk/shared";
-import { aiLogger } from "@oakai/logger";
 
 const log = aiLogger("testing");
 

--- a/packages/api/src/router/testSupport/userPreparation/metadata.ts
+++ b/packages/api/src/router/testSupport/userPreparation/metadata.ts
@@ -1,6 +1,7 @@
+import { aiLogger } from "@oakai/logger";
+
 import { clerkClient } from "@clerk/nextjs/server";
 import type { User } from "@clerk/nextjs/server";
-import { aiLogger } from "@oakai/logger";
 import { difference, equals } from "remeda";
 
 type MetadataArgs = {

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import { initTRPC } from "@trpc/server";
 import { ZodError } from "zod";
 

--- a/packages/core/src/analytics/posthogAiBetaServerClient/featureFlagEvaluation.ts
+++ b/packages/core/src/analytics/posthogAiBetaServerClient/featureFlagEvaluation.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import { kv } from "@vercel/kv";
 import type { PostHog } from "posthog-node";
 

--- a/packages/core/src/functions/demo/populateDemoStatuses.ts
+++ b/packages/core/src/functions/demo/populateDemoStatuses.ts
@@ -1,5 +1,6 @@
-import { clerkClient } from "@clerk/nextjs/server";
 import { aiLogger } from "@oakai/logger";
+
+import { clerkClient } from "@clerk/nextjs/server";
 
 import { inngest } from "../../inngest";
 import { populateDemoStatusesSchema } from "./populateDemoStatuses.schema";

--- a/packages/core/src/functions/quizAnswer/generateQuizAnswerEmbeddings.ts
+++ b/packages/core/src/functions/quizAnswer/generateQuizAnswerEmbeddings.ts
@@ -1,4 +1,4 @@
-import { prisma, QuizAnswerStatus } from "@oakai/db";
+import { QuizAnswerStatus, prisma } from "@oakai/db";
 
 import { inngest } from "../../inngest";
 import { QuizAnswers } from "../../models";

--- a/packages/core/src/functions/slack/notifyModeration.ts
+++ b/packages/core/src/functions/slack/notifyModeration.ts
@@ -1,8 +1,8 @@
 import { inngest } from "../../inngest";
 import {
+  actionsBlock,
   slackNotificationChannelId,
   slackWebClient,
-  actionsBlock,
   userIdBlock,
 } from "../../utils/slack";
 import { getExternalFacingUrl } from "./getExternalFacingUrl";

--- a/packages/core/src/functions/slack/notifyRateLimit.ts
+++ b/packages/core/src/functions/slack/notifyRateLimit.ts
@@ -1,8 +1,8 @@
 import { inngest } from "../../inngest";
 import {
+  actionsBlock,
   slackNotificationChannelId,
   slackWebClient,
-  actionsBlock,
   userIdBlock,
 } from "../../utils/slack";
 import { notifyRateLimitSchema } from "./notifyRateLimit.schema";

--- a/packages/core/src/functions/slack/notifyUserBan.ts
+++ b/packages/core/src/functions/slack/notifyUserBan.ts
@@ -1,8 +1,8 @@
 import { inngest } from "../../inngest";
 import {
+  actionsBlock,
   slackNotificationChannelId,
   slackWebClient,
-  actionsBlock,
   userIdBlock,
 } from "../../utils/slack";
 

--- a/packages/core/src/inngest/index.ts
+++ b/packages/core/src/inngest/index.ts
@@ -1,5 +1,6 @@
 /* eslint-disable @typescript-eslint/no-unsafe-member-access */
-import { structuredLogger, aiLogger } from "@oakai/logger";
+import { aiLogger, structuredLogger } from "@oakai/logger";
+
 import { EventSchemas, Inngest } from "inngest";
 import getConfig from "next/config";
 

--- a/packages/core/src/middleware/eventLogger.ts
+++ b/packages/core/src/middleware/eventLogger.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import { InngestMiddleware } from "inngest";
 
 const log = aiLogger("inngest");

--- a/packages/core/src/models/apps.ts
+++ b/packages/core/src/models/apps.ts
@@ -1,4 +1,5 @@
-import type { Prompt, PrismaClientWithAccelerate } from "@oakai/db";
+import type { PrismaClientWithAccelerate, Prompt } from "@oakai/db";
+
 import { Prisma } from "@prisma/client";
 import type { App } from "@prisma/client";
 

--- a/packages/core/src/models/generations.ts
+++ b/packages/core/src/models/generations.ts
@@ -7,6 +7,7 @@ import type {
 import { GenerationStatus } from "@oakai/db";
 import type { StructuredLogger } from "@oakai/logger";
 import { structuredLogger } from "@oakai/logger";
+
 import type { Logger as InngestLogger } from "inngest/middleware/logger";
 import { omit } from "remeda";
 import { Md5 } from "ts-md5";

--- a/packages/core/src/models/lessonPlans.ts
+++ b/packages/core/src/models/lessonPlans.ts
@@ -9,6 +9,7 @@ import type {
 } from "@oakai/db";
 import { LessonPlanPartStatus, LessonPlanStatus } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
+
 import { z } from "zod";
 
 import { LLMResponseJsonSchema } from "../../../aila/src/protocol/jsonPatchProtocol";

--- a/packages/core/src/models/lessonSnapshots.ts
+++ b/packages/core/src/models/lessonSnapshots.ts
@@ -3,6 +3,7 @@ import type {
   LessonSnapshotTrigger,
   PrismaClientWithAccelerate,
 } from "@oakai/db";
+
 import crypto from "crypto";
 
 import type { AilaDocumentContent } from "../../../aila/src/core/document/types";

--- a/packages/core/src/models/lessonSummaries.ts
+++ b/packages/core/src/models/lessonSummaries.ts
@@ -3,6 +3,7 @@ import type {
   LessonSummary,
   PrismaClientWithAccelerate,
 } from "@oakai/db";
+
 import { Prisma } from "@prisma/client";
 import { OpenAIEmbeddings } from "langchain/embeddings/openai";
 import { PrismaVectorStore } from "langchain/vectorstores/prisma";

--- a/packages/core/src/models/lessons.ts
+++ b/packages/core/src/models/lessons.ts
@@ -10,6 +10,7 @@ import type {
 import { ZLesson } from "@oakai/db";
 import { ZNewLesson } from "@oakai/db/schemas/lesson";
 import { aiLogger } from "@oakai/logger";
+
 import { StructuredOutputParser } from "langchain/output_parsers";
 import { PromptTemplate } from "langchain/prompts";
 import { RunnableSequence } from "langchain/schema/runnable";

--- a/packages/core/src/models/promptVariants.ts
+++ b/packages/core/src/models/promptVariants.ts
@@ -1,5 +1,6 @@
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
+
 import dedent from "ts-dedent";
 import { Md5 } from "ts-md5";
 

--- a/packages/core/src/models/prompts.ts
+++ b/packages/core/src/models/prompts.ts
@@ -1,6 +1,7 @@
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 import type { StructuredLogger } from "@oakai/logger";
 import { structuredLogger } from "@oakai/logger";
+
 import type { Logger as InngestLogger } from "inngest/middleware/logger";
 import { PromptTemplate } from "langchain/prompts";
 import type { BaseMessage } from "langchain/schema";

--- a/packages/core/src/models/safetyViolations.ts
+++ b/packages/core/src/models/safetyViolations.ts
@@ -1,12 +1,13 @@
-import { clerkClient } from "@clerk/nextjs/server";
 import type {
+  PrismaClientWithAccelerate,
   SafetyViolationAction,
   SafetyViolationRecordType,
   SafetyViolationSource,
-  PrismaClientWithAccelerate,
 } from "@oakai/db";
 import type { StructuredLogger } from "@oakai/logger";
 import { structuredLogger } from "@oakai/logger";
+
+import { clerkClient } from "@clerk/nextjs/server";
 import type { Logger as InngestLogger } from "inngest/middleware/logger";
 
 import { posthogAiBetaServerClient } from "../analytics/posthogAiBetaServerClient";

--- a/packages/core/src/models/serializers.ts
+++ b/packages/core/src/models/serializers.ts
@@ -15,6 +15,7 @@
  */
 import type { App, Generation, Prompt } from "@oakai/db";
 import { GenerationStatus } from "@oakai/db";
+
 import { z } from "zod";
 
 import type { AppWithPrompt } from "./apps";

--- a/packages/core/src/models/snippets.ts
+++ b/packages/core/src/models/snippets.ts
@@ -1,6 +1,7 @@
 import type { PrismaClientWithAccelerate, Snippet } from "@oakai/db";
 import { Prisma, SnippetStatus, SnippetVariant } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
+
 import { LLMChain, RetrievalQAChain } from "langchain/chains";
 import { OpenAIEmbeddings } from "langchain/embeddings/openai";
 import {

--- a/packages/core/src/models/transcript.ts
+++ b/packages/core/src/models/transcript.ts
@@ -1,5 +1,6 @@
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
+
 import { Document } from "langchain/document";
 import { StructuredOutputParser } from "langchain/output_parsers";
 import { PromptTemplate } from "langchain/prompts";

--- a/packages/core/src/prompts/lesson-assistant/index.ts
+++ b/packages/core/src/prompts/lesson-assistant/index.ts
@@ -8,12 +8,12 @@ import {
   context,
   endingTheInteraction,
   generateResponse,
+  interactingWithTheUser,
   protocol,
   rag,
   schema,
   signOff,
   task,
-  interactingWithTheUser,
 } from "./parts";
 import { currentLessonPlan } from "./parts/currentLessonPlan";
 import { languageAndVoice } from "./parts/languageAndVoice";

--- a/packages/core/src/rag/index.ts
+++ b/packages/core/src/rag/index.ts
@@ -1,5 +1,3 @@
-import { PrismaVectorStore } from "@langchain/community/vectorstores/prisma";
-import { OpenAIEmbeddings } from "@langchain/openai";
 import type {
   KeyStage,
   LessonPlanPart,
@@ -7,6 +5,9 @@ import type {
   Subject,
 } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
+
+import { PrismaVectorStore } from "@langchain/community/vectorstores/prisma";
+import { OpenAIEmbeddings } from "@langchain/openai";
 import type { LessonPlan, LessonSummary, Snippet } from "@prisma/client";
 import { Prisma, PrismaClient } from "@prisma/client";
 import { withAccelerate } from "@prisma/extension-accelerate";

--- a/packages/core/src/scripts/import-new-lessons/createSnippetsForNewLessons.ts
+++ b/packages/core/src/scripts/import-new-lessons/createSnippetsForNewLessons.ts
@@ -1,6 +1,7 @@
 import type { Snippet, SnippetVariant } from "@oakai/db";
 import { prisma } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
+
 import { z } from "zod";
 
 const log = aiLogger("core");

--- a/packages/core/src/scripts/import-new-lessons/getTranscriptsForNewLessons.ts
+++ b/packages/core/src/scripts/import-new-lessons/getTranscriptsForNewLessons.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
+
 import { z } from "zod";
 
 import { getCaptionsFromFile } from "../../utils/getCaptionsFromFile";

--- a/packages/core/src/scripts/import-new-lessons/importNewLessons.ts
+++ b/packages/core/src/scripts/import-new-lessons/importNewLessons.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
+
 import { GraphQLClient, gql } from "graphql-request";
 
 const log = aiLogger("core");

--- a/packages/core/src/scripts/processLessons.ts
+++ b/packages/core/src/scripts/processLessons.ts
@@ -1,5 +1,6 @@
 // Called with pnpm run process:lessons -- --keyStage=3 --subject=religious-education
 import { aiLogger } from "@oakai/logger";
+
 import invariant from "tiny-invariant";
 
 import { inngest } from "../inngest";

--- a/packages/core/src/tracing/baseTracing.ts
+++ b/packages/core/src/tracing/baseTracing.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import tracer from "dd-trace";
 
 const log = aiLogger("tracing");

--- a/packages/core/src/utils/getCaptionsFromFile.ts
+++ b/packages/core/src/utils/getCaptionsFromFile.ts
@@ -1,5 +1,6 @@
-import { Storage } from "@google-cloud/storage";
 import { aiLogger } from "@oakai/logger";
+
+import { Storage } from "@google-cloud/storage";
 import type { Cue } from "webvtt-parser";
 import { WebVTTParser } from "webvtt-parser";
 import { z } from "zod";

--- a/packages/core/src/utils/rateLimiting/userBasedRateLimiter.ts
+++ b/packages/core/src/utils/rateLimiting/userBasedRateLimiter.ts
@@ -1,6 +1,7 @@
+import { aiLogger } from "@oakai/logger";
+
 import type { User } from "@clerk/nextjs/server";
 import { clerkClient } from "@clerk/nextjs/server";
-import { aiLogger } from "@oakai/logger";
 import type { Ratelimit } from "@upstash/ratelimit";
 import { waitUntil } from "@vercel/functions";
 

--- a/packages/core/src/utils/slack.ts
+++ b/packages/core/src/utils/slack.ts
@@ -1,10 +1,10 @@
 import type { ActionsBlock, SectionBlock } from "@slack/web-api";
 import { WebClient } from "@slack/web-api";
 import {
-  uniqueNamesGenerator,
   adjectives,
-  colors,
   animals,
+  colors,
+  uniqueNamesGenerator,
 } from "unique-names-generator";
 
 import { getExternalFacingUrl } from "../functions/slack/getExternalFacingUrl";

--- a/packages/core/src/workers/generations/requestGeneration.ts
+++ b/packages/core/src/workers/generations/requestGeneration.ts
@@ -1,7 +1,8 @@
 import type { Prisma } from "@oakai/db";
 import { GenerationStatus, ModerationType, prisma } from "@oakai/db";
 import type { StructuredLogger } from "@oakai/logger";
-import { structuredLogger as baseLogger, aiLogger } from "@oakai/logger";
+import { aiLogger, structuredLogger as baseLogger } from "@oakai/logger";
+
 import { Redis } from "@upstash/redis";
 import { NonRetriableError } from "inngest";
 import type { z } from "zod";

--- a/packages/db/client/index.ts
+++ b/packages/db/client/index.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import { PrismaClient } from "@prisma/client";
 import { withAccelerate } from "@prisma/extension-accelerate";
 

--- a/packages/db/prisma/seed.ts
+++ b/packages/db/prisma/seed.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import { PrismaClient } from "@prisma/client";
 
 const log = aiLogger("db");

--- a/packages/db/scripts/import-export/validate_data.ts
+++ b/packages/db/scripts/import-export/validate_data.ts
@@ -4,6 +4,7 @@
  *
  **/
 import { aiLogger } from "@oakai/logger";
+
 import { Prisma } from "@prisma/client";
 import csvParser from "csv-parser";
 import dotenv from "dotenv";

--- a/packages/db/scripts/processing/update_clerk_users.ts
+++ b/packages/db/scripts/processing/update_clerk_users.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import { z } from "zod";
 
 import { prisma } from "../../";

--- a/packages/eslint-config/src/index.mjs
+++ b/packages/eslint-config/src/index.mjs
@@ -16,7 +16,7 @@ import path from "path";
 import { fileURLToPath } from "url";
 
 import { ignores } from "./ignores.mjs";
-import { rules, javascriptRules } from "./rules.mjs";
+import { javascriptRules, rules } from "./rules.mjs";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = path.dirname(__filename);

--- a/packages/exports/src/exportSlidesFullLesson.ts
+++ b/packages/exports/src/exportSlidesFullLesson.ts
@@ -3,8 +3,8 @@ import { exportGeneric } from "./exportGeneric";
 import { googleSlides } from "./gSuite/slides/client";
 import {
   CYCLE_TAGS,
-  deleteSlides,
   type CycleNumber,
+  deleteSlides,
 } from "./gSuite/slides/deleteSlides";
 import { populateSlides } from "./gSuite/slides/populateSlides";
 import type { LessonSlidesInputData } from "./schema/input.schema";

--- a/packages/exports/src/gSuite/docs/client.ts
+++ b/packages/exports/src/gSuite/docs/client.ts
@@ -1,4 +1,4 @@
-import { docs_v1, auth } from "@googleapis/docs";
+import { auth, docs_v1 } from "@googleapis/docs";
 
 import { credentials } from "../credentials";
 

--- a/packages/exports/src/gSuite/docs/imageReplacements.ts
+++ b/packages/exports/src/gSuite/docs/imageReplacements.ts
@@ -1,5 +1,6 @@
-import type { docs_v1 } from "@googleapis/docs";
 import { aiLogger } from "@oakai/logger";
+
+import type { docs_v1 } from "@googleapis/docs";
 
 const log = aiLogger("exports");
 

--- a/packages/exports/src/gSuite/docs/populateDoc.ts
+++ b/packages/exports/src/gSuite/docs/populateDoc.ts
@@ -1,5 +1,6 @@
-import type { docs_v1 } from "@googleapis/docs";
 import { aiLogger } from "@oakai/logger";
+
+import type { docs_v1 } from "@googleapis/docs";
 
 import type { Result } from "../../types";
 import type { ValueToString } from "../../utils";

--- a/packages/exports/src/gSuite/drive/client.ts
+++ b/packages/exports/src/gSuite/drive/client.ts
@@ -1,4 +1,4 @@
-import { drive, auth } from "@googleapis/drive";
+import { auth, drive } from "@googleapis/drive";
 
 import { credentials } from "../credentials";
 

--- a/packages/exports/src/gSuite/slides/client.ts
+++ b/packages/exports/src/gSuite/slides/client.ts
@@ -1,4 +1,4 @@
-import { slides, auth } from "@googleapis/slides";
+import { auth, slides } from "@googleapis/slides";
 
 import { credentials } from "../credentials";
 

--- a/packages/ingest/src/captions/getCaptionsByFileName.ts
+++ b/packages/ingest/src/captions/getCaptionsByFileName.ts
@@ -1,5 +1,6 @@
-import { Storage } from "@google-cloud/storage";
 import { aiLogger } from "@oakai/logger";
+
+import { Storage } from "@google-cloud/storage";
 import type { Cue } from "webvtt-parser";
 import * as WebVTTModule from "webvtt-parser";
 

--- a/packages/ingest/src/chunking/getLessonPlanParts.ts
+++ b/packages/ingest/src/chunking/getLessonPlanParts.ts
@@ -1,4 +1,5 @@
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
+
 import yaml from "yaml";
 import { z } from "zod";
 

--- a/packages/ingest/src/generate-lesson-plans/getLessonPlanBatchFileLine.ts
+++ b/packages/ingest/src/generate-lesson-plans/getLessonPlanBatchFileLine.ts
@@ -1,5 +1,6 @@
 import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
 import { CompletedLessonPlanSchema } from "@oakai/aila/src/protocol/schema";
+
 import { zodResponseFormat } from "openai/helpers/zod";
 
 import type { PersistedIngest } from "../db-helpers/getIngestById";

--- a/packages/ingest/src/generate-lesson-plans/getUserPrompt.ts
+++ b/packages/ingest/src/generate-lesson-plans/getUserPrompt.ts
@@ -1,7 +1,7 @@
 import { isTruthy } from "remeda";
 
 import { IngestError } from "../IngestError";
-import type { RawLesson, Captions } from "../zod-schema/zodSchema";
+import type { Captions, RawLesson } from "../zod-schema/zodSchema";
 import { exitQuizPromptPart } from "./user-prompt-parts/exitQuiz.promptPart";
 import { keyLearningPointsPromptPart } from "./user-prompt-parts/keyLearningPoints.promptPart";
 import { lessonKeywordsPromptPart } from "./user-prompt-parts/keywords.promptPart";

--- a/packages/ingest/src/generate-lesson-plans/parseBatchLessonPlan.ts
+++ b/packages/ingest/src/generate-lesson-plans/parseBatchLessonPlan.ts
@@ -1,6 +1,6 @@
 import {
-  CompletedLessonPlanSchema,
   type CompletedLessonPlan,
+  CompletedLessonPlanSchema,
 } from "@oakai/aila/src/protocol/schema";
 import { parseKeyStage } from "@oakai/core/src/data/parseKeyStage";
 

--- a/packages/ingest/src/generate-lesson-plans/transformQuiz.ts
+++ b/packages/ingest/src/generate-lesson-plans/transformQuiz.ts
@@ -1,4 +1,5 @@
 import type { Quiz } from "@oakai/aila/src/protocol/schema";
+
 import { isTruthy, partition } from "remeda";
 
 import { IngestError } from "../IngestError";

--- a/packages/ingest/src/import-lessons/importLessons.ts
+++ b/packages/ingest/src/import-lessons/importLessons.ts
@@ -6,7 +6,7 @@ import { getDataHash } from "../utils/getDataHash";
 import type { RawLesson } from "../zod-schema/zodSchema";
 import { RawLessonSchema } from "../zod-schema/zodSchema";
 import { graphqlClient } from "./graphql/client";
-import { query, type QueryVariables } from "./graphql/query";
+import { type QueryVariables, query } from "./graphql/query";
 
 const log = aiLogger("ingest");
 

--- a/packages/ingest/src/import-lessons/importLessonsFromCSV.ts
+++ b/packages/ingest/src/import-lessons/importLessonsFromCSV.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
+
 import csv from "csv-parser";
 import fs from "node:fs";
 

--- a/packages/ingest/src/import-lessons/importLessonsFromOakDB.ts
+++ b/packages/ingest/src/import-lessons/importLessonsFromOakDB.ts
@@ -6,7 +6,7 @@ import { getDataHash } from "../utils/getDataHash";
 import type { RawLesson } from "../zod-schema/zodSchema";
 import { RawLessonSchema } from "../zod-schema/zodSchema";
 import { graphqlClient } from "./graphql/client";
-import { query, type QueryVariables } from "./graphql/query";
+import { type QueryVariables, query } from "./graphql/query";
 
 type ImportLessonsFromOakDBProps = {
   ingestId: string;

--- a/packages/ingest/src/openai-batches/writeBatchFile.ts
+++ b/packages/ingest/src/openai-batches/writeBatchFile.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import fs from "node:fs";
 
 import { IngestError } from "../IngestError";

--- a/packages/ingest/src/singleLessonDryRun.ts
+++ b/packages/ingest/src/singleLessonDryRun.ts
@@ -1,5 +1,6 @@
 import { CompletedLessonPlanSchemaWithoutLength } from "@oakai/aila/src/protocol/schema";
 import { aiLogger } from "@oakai/logger";
+
 import fs from "node:fs";
 import path from "node:path";
 import { zodResponseFormat } from "openai/helpers/zod.mjs";
@@ -14,9 +15,9 @@ import { getSystemPrompt } from "./generate-lesson-plans/getSystemPrompt";
 import { getUserPrompt } from "./generate-lesson-plans/getUserPrompt";
 import { graphqlClient } from "./import-lessons/graphql/client";
 import {
-  query,
   type QueryVariables,
   type QueryWhere,
+  query,
 } from "./import-lessons/graphql/query";
 import { openai } from "./openai-batches/openai";
 import { type RawLesson, RawLessonSchema } from "./zod-schema/zodSchema";

--- a/packages/ingest/src/steps/7-publish.ts
+++ b/packages/ingest/src/steps/7-publish.ts
@@ -3,6 +3,7 @@ import {
   type LooseLessonPlan,
 } from "@oakai/aila/src/protocol/schema";
 import type { Prisma, PrismaClientWithAccelerate } from "@oakai/db";
+
 import { createId } from "@paralleldrive/cuid2";
 import { isTruthy } from "remeda";
 import { z } from "zod";

--- a/packages/ingest/src/utils/splitJsonlByRowsOrSize.ts
+++ b/packages/ingest/src/utils/splitJsonlByRowsOrSize.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+
 import * as fs from "node:fs";
 import * as path from "node:path";
 import * as readline from "node:readline";

--- a/packages/prettier-config/index.mjs
+++ b/packages/prettier-config/index.mjs
@@ -17,8 +17,15 @@ const plugins = [
 
 export default {
   arrowParens: "always",
-  importOrder: ["^react(.*)", "<THIRD_PARTY_MODULES>", "@/(.*)", "^[./]"],
+  importOrder: [
+    "^react",
+    "^@oakai/(.*)$",
+    "<THIRD_PARTY_MODULES>",
+    "^@/(.*)$",
+    "^[./]",
+  ],
   importOrderSeparation: true,
+  importOrderSortSpecifiers: true,
   jsxSingleQuote: false,
   plugins,
   printWidth: 80,

--- a/packages/rag/getRelevantLessonPlans/getRelevantLessonPlans.ts
+++ b/packages/rag/getRelevantLessonPlans/getRelevantLessonPlans.ts
@@ -1,5 +1,6 @@
 import { prisma } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
+
 import { CohereClient } from "cohere-ai";
 import OpenAI from "openai";
 

--- a/packages/rag/lib/search/search.test.ts
+++ b/packages/rag/lib/search/search.test.ts
@@ -1,5 +1,6 @@
-import { generateMock } from "@anatine/zod-mock";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
+
+import { generateMock } from "@anatine/zod-mock";
 
 import { CompletedLessonPlanSchema } from "../../../aila/src/protocol/schema";
 import type { RagLogger } from "../../types";

--- a/packages/rag/lib/search/search.ts
+++ b/packages/rag/lib/search/search.ts
@@ -1,4 +1,5 @@
 import type { PrismaClientWithAccelerate } from "@oakai/db";
+
 import { uniqBy } from "remeda";
 
 import type { RagLessonPlanResult, RagLogger } from "../../types";


### PR DESCRIPTION
## Description

- Enforces import order for all imports
- Uses our updated Prettier config
- No user-facing changes

We were reliant on eslint for this, which seemed to not be very effective. This shifts us over to Prettier so we get auto-format on save for import ordering.
