### PR TITLE
revert: revert prompt schema alignment

### DIFF
--- a/packages/aila/src/protocol/jsonPatchProtocol.ts
+++ b/packages/aila/src/protocol/jsonPatchProtocol.ts
@@ -473,6 +473,19 @@ export const JsonPatchDocumentJsonSchema = zodToJsonSchema(
   "patchDocumentSchema",
 );
 
+export const LLMResponseSchema = z.discriminatedUnion("type", [
+  PatchDocumentSchema,
+  PromptDocumentSchema,
+  StateDocumentSchema,
+  CommentDocumentSchema,
+  ErrorDocumentSchema,
+]);
+
+export const LLMResponseJsonSchema = zodToJsonSchema(
+  LLMResponseSchema,
+  "llmResponseSchema",
+);
+
 export const MessagePartDocumentSchema = z.discriminatedUnion("type", [
   ModerationDocumentSchema,
   ErrorDocumentSchema,
@@ -562,15 +575,6 @@ const LLMMessageSchemaWhileStreaming = z.object({
   prompt: TextDocumentSchema.optional(),
   status: z.literal("complete").optional(),
 });
-
-export const LLMResponseSchema = z.discriminatedUnion("type", [
-  LLMMessageSchema,
-]);
-
-export const LLMResponseJsonSchema = zodToJsonSchema(
-  LLMResponseSchema,
-  "llmResponseSchema",
-);
 
 function tryParseJson(str: string): {
   parsed: { type: string } | null;

--- a/packages/core/src/prompts/lesson-assistant/parts/protocol.ts
+++ b/packages/core/src/prompts/lesson-assistant/parts/protocol.ts
@@ -1,6 +1,7 @@
 import type { TemplateProps } from "..";
 
-const responseFormatWithStructuredOutputs = "{\"response\":\"llmMessage\", patches:[{},{}...], prompt:{}}";
+const responseFormatWithStructuredOutputs =
+  '{"response":"llmMessage", patches:[{},{}...], prompt:{}}';
 const responseFormatWithoutStructuredOutputs = `A series of JSON documents separated using the JSON Text Sequences specification, where each row is separated by the ␞ character and ends with a new line character.
 Your response should be a series of patches followed by one and only one prompt to the user.`;
 

--- a/packages/core/src/prompts/lesson-assistant/parts/protocol.ts
+++ b/packages/core/src/prompts/lesson-assistant/parts/protocol.ts
@@ -1,7 +1,6 @@
 import type { TemplateProps } from "..";
 
-const responseFormatWithStructuredOutputs =
-  '{"type":"llmMessage", patches:[{},{}...], prompt:{}}';
+const responseFormatWithStructuredOutputs = "{\"response\":\"llmMessage\", patches:[{},{}...], prompt:{}}";
 const responseFormatWithoutStructuredOutputs = `A series of JSON documents separated using the JSON Text Sequences specification, where each row is separated by the ␞ character and ends with a new line character.
 Your response should be a series of patches followed by one and only one prompt to the user.`;
 


### PR DESCRIPTION
We've seen an increase in issues in the LLM response. One example is that it's referring to sections by their camelcase key names. This could relate to us adding those key names in a JSON schema change