### PR TITLE
chore: move cspell file to standard cspell.json

### DIFF
--- a/cspell.json
+++ b/cspell.json
@@ -35,7 +35,7 @@
     ".git/{index,*refs,*HEAD}",
     ".vscode",
     ".vscode-insiders",
-    ".cspell.json",
+    "cspell.json",
     ".env.*",
     "**/*/package.json",
     "pnpm-lock.yaml",

--- a/packages/eslint-config/src/index.mjs
+++ b/packages/eslint-config/src/index.mjs
@@ -24,7 +24,7 @@ const __dirname = path.dirname(__filename);
 const projectRoot = path.resolve(__dirname, "../../..");
 
 // Define the path to the .cspell.json file in the root of the monorepo
-const cspellConfigPath = path.resolve(projectRoot, ".cspell.json");
+const cspellConfigPath = path.resolve(projectRoot, "cspell.json");
 
 const packages = [
   { dir: "apps/nextjs", isReact: true, isBrowser: true },


### PR DESCRIPTION
My editor's [cspell extension](https://github.com/mantou132/zed-cspell) looks for the cspell file in the standard cspell.json. This change lets that extension work for me. Maybe it's the same for vscode and derivatives too