### PR TITLE
wip: experimentation of leaning into AI sdk

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -69,7 +69,7 @@
     "@types/object-hash": "^3.0.6",
     "@types/ramda": "^0.30.2",
     "@uidotdev/usehooks": "^2.4.1",
-    "ai": "^4.0.20",
+    "ai": "^4.1.0",
     "american-british-english-translator": "^0.2.1",
     "archiver": "^7.0.1",
     "axios": "^1.6.8",

--- a/apps/nextjs/src/app/api/chat/fixtures/FixtureRecordLLMService.ts
+++ b/apps/nextjs/src/app/api/chat/fixtures/FixtureRecordLLMService.ts
@@ -18,14 +18,6 @@ export class FixtureRecordLLMService implements LLMService {
     this._openAIService = new OpenAIService({ userId: undefined, chatId });
   }
 
-  async createChatCompletionStream(params: {
-    model: string;
-    messages: Message[];
-    temperature: number;
-  }): Promise<ReadableStreamDefaultReader<string>> {
-    return this._openAIService.createChatCompletionStream(params);
-  }
-
   async createChatCompletionObjectStream(params: {
     model: string;
     schema: ZodSchema;

--- a/apps/nextjs/src/components/AppComponents/Chat/AiSdk.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/AiSdk.tsx
@@ -59,6 +59,7 @@ export function AiSdk({ id }: Readonly<AiSdkProps>) {
     reload,
     stop: stopStreaming,
     isLoading,
+    data,
   } = useChat({
     sendExtraMessageFields: true,
     // NOTE: these initial messages are used by the chat endpoint
@@ -80,6 +81,7 @@ export function AiSdk({ id }: Readonly<AiSdkProps>) {
       Sentry.captureException(new Error("Use chat error"), {
         extra: { originalError: error },
       });
+      console.error(error);
       log.error("UseChat error", { error, messages });
       setHasFinished(true);
     },
@@ -113,6 +115,8 @@ export function AiSdk({ id }: Readonly<AiSdkProps>) {
       messageFinished();
     },
   });
+  log.info("ai sdk data", data);
+  log.info(messages[messages.length - 1]);
 
   useEffect(() => {
     /**
@@ -147,3 +151,11 @@ export function AiSdk({ id }: Readonly<AiSdkProps>) {
 
   return null;
 }
+
+// {"response":"llmMessage",
+//   "patches":[
+//     {"type":"patch","reasoning":"There are no existing Oak lessons for this topic, so I've started a new lesson from scratch. I've added a learning outcome for the lesson.","value":{"op":"add","path":"/learningOutcome","value":"I can explain the reasons for the end of Roman rule in Britain."}},
+//     {"type":"patch","reasoning":"Added learning cycles to break down the lesson into manageable parts for pupils.","value":{"op":"add","path":"/learningCycles","value":["Identify the key events leading to the end of Roman rule in Britain","Explain the impact of the Roman withdrawal on British society","Discuss the role of archaeology in understanding this historical period"]}
+//   }],
+//   "prompt":{"type":"text","message":"Are the learning outcome and learning cycles appropriate for your pupils? If not, suggest an edit. Otherwise, tap **Continue** to move on to the next step."}
+// }

--- a/apps/nextjs/src/stores/chatStore/parsing.ts
+++ b/apps/nextjs/src/stores/chatStore/parsing.ts
@@ -38,8 +38,12 @@ export const parseStreamingMessage = (
   previousIteration: ParsedMessage | null,
 ): ParsedMessage => {
   try {
-    return parseMessage(message);
+    log.info("will parse message", message);
+    const parsed = parseMessage(message);
+    log.info("parsed message", parsed);
+    return parsed;
   } catch (e) {
+    log.error("parsing failed", e);
     if (message.id === previousIteration?.id) {
       log.warn(
         "Failed to parse streaming message. Falling back to previous iteration",

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleSetMessages.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleSetMessages.ts
@@ -1,3 +1,4 @@
+import { aiLogger } from "@oakai/logger";
 import invariant from "tiny-invariant";
 
 import type { GetStore } from "@/stores/AilaStoresProvider";
@@ -5,6 +6,8 @@ import type { GetStore } from "@/stores/AilaStoresProvider";
 import { calculateStreamingStatus } from "../actions/calculateStreamingStatus";
 import { getNextStableMessages, parseStreamingMessage } from "../parsing";
 import type { ChatSetter, ChatGetter, AiMessage } from "../types";
+
+const log = aiLogger("chat:store");
 
 export function handleSetMessages(
   getStore: GetStore,
@@ -32,6 +35,7 @@ export function handleSetMessages(
         ailaStreamingStatus: "Idle",
       });
     } else if (lastMessageIsUser(messages)) {
+      log.info("last message is user");
       // AI SDK is loading without a message from the API: we're waiting for a response
 
       const nextStableMessages = getNextStableMessages(
@@ -54,6 +58,7 @@ export function handleSetMessages(
         currentMessageData,
         get().streamingMessage,
       );
+      log.info("streaming message", streamingMessage);
 
       const stableMessageData = messages.slice(0, messages.length - 1);
       const nextStableMessages = getNextStableMessages(

--- a/apps/nextjs/src/stores/zustandHelpers.ts
+++ b/apps/nextjs/src/stores/zustandHelpers.ts
@@ -12,7 +12,7 @@ export const logStoreUpdates = <T extends object>(
       .map((key) => {
         const value = state[key];
         if (value && typeof value === "object") {
-          const prevValue = prevState[key] || {};
+          const prevValue = prevState[key] ?? {};
           // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           const changedKeys = Object.keys(value).filter(
             // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
@@ -23,7 +23,6 @@ export const logStoreUpdates = <T extends object>(
 
         return `/${key}`;
       });
-    // .map((key) => `/${key}`);
     log.info(`State updated: ${changedKeys.join(", ")}`);
   });
 };

--- a/packages/aila/package.json
+++ b/packages/aila/package.json
@@ -36,7 +36,7 @@
     "@oakai/rag": "*",
     "@sentry/nextjs": "^8.49.0",
     "@vercel/kv": "^0.2.2",
-    "ai": "^4.0.20",
+    "ai": "^4.1.0",
     "american-british-english-translator": "^0.2.1",
     "cloudinary": "^1.41.1",
     "dedent": "^1.5.3",

--- a/packages/aila/src/core/Aila.ts
+++ b/packages/aila/src/core/Aila.ts
@@ -290,6 +290,8 @@ export class Aila implements AilaServices {
     }
 
     await this.initialise();
+    // TODO: not in service
+    // await this._chat.setupGeneration();
     return this._chat.startStreaming(abortController);
   }
 

--- a/packages/aila/src/core/AilaServices.ts
+++ b/packages/aila/src/core/AilaServices.ts
@@ -1,3 +1,5 @@
+import type { LanguageModelUsage } from "ai";
+
 import type { AilaAmericanismsFeature } from "../features/americanisms";
 import type { AilaAnalytics } from "../features/analytics/AilaAnalytics";
 import type { AilaErrorReporter } from "../features/errorReporting";
@@ -26,7 +28,7 @@ import type { AilaOptionsWithDefaultFallbackValues } from "./types";
 // We can then mock these out in tests without needing to instantiate the entire Aila object.
 export interface AilaAnalyticsService {
   readonly analytics?: AilaAnalytics;
-  reportUsageMetrics(text: string): Promise<void>;
+  reportUsageMetrics(usage: LanguageModelUsage): Promise<void>;
 }
 
 export interface AilaDocumentService {

--- a/packages/aila/src/core/chat/PatchEnqueuer.ts
+++ b/packages/aila/src/core/chat/PatchEnqueuer.ts
@@ -67,6 +67,7 @@ export class PatchEnqueuer {
     };
   }
 
+  // TODO: replace all RS with custom data messages?
   private formatPatch(patch: JsonPatchDocumentOptional): string {
     return `\n␞\n${JSON.stringify(patch)}\n␞\n`; // #TODO remove duplicate separators
   }

--- a/packages/aila/src/core/llm/LLMService.ts
+++ b/packages/aila/src/core/llm/LLMService.ts
@@ -4,11 +4,6 @@ import type { Message } from "../chat";
 
 export interface LLMService {
   name: string;
-  createChatCompletionStream(params: {
-    model: string;
-    messages: Message[];
-    temperature: number;
-  }): Promise<ReadableStreamDefaultReader<string>>;
   createChatCompletionObjectStream(params: {
     model: string;
     schema: ZodSchema;

--- a/packages/aila/src/core/llm/MockLLMService.ts
+++ b/packages/aila/src/core/llm/MockLLMService.ts
@@ -21,21 +21,6 @@ export class MockLLMService implements LLMService {
     this.responseObject = responseObject;
   }
 
-  async createChatCompletionStream(): Promise<
-    ReadableStreamDefaultReader<string>
-  > {
-    const responseChunks = this.responseChunks;
-    const stream = new ReadableStream<string>({
-      async start(controller) {
-        for (const chunk of responseChunks) {
-          controller.enqueue(chunk);
-          await sleep(0);
-        }
-        controller.close();
-      },
-    });
-    return Promise.resolve(stream.getReader());
-  }
   async createChatCompletionObjectStream(): Promise<
     ReadableStreamDefaultReader<string>
   > {

--- a/packages/aila/src/core/llm/OpenAIService.ts
+++ b/packages/aila/src/core/llm/OpenAIService.ts
@@ -2,7 +2,7 @@ import type { OpenAIProvider } from "@ai-sdk/openai";
 import type { HeliconeChatMeta } from "@oakai/core/src/llm/helicone";
 import { createVercelOpenAIClient } from "@oakai/core/src/llm/openai";
 import { aiLogger } from "@oakai/logger";
-import { streamObject, streamText } from "ai";
+import { streamObject } from "ai";
 import type { ZodSchema } from "zod";
 
 import type { Message } from "../chat";
@@ -10,8 +10,6 @@ import type { LLMService } from "./LLMService";
 
 const log = aiLogger("aila:llm");
 
-const STRUCTURED_OUTPUTS_ENABLED =
-  process.env.NEXT_PUBLIC_STRUCTURED_OUTPUTS_ENABLED === "true";
 export class OpenAIService implements LLMService {
   private readonly _openAIProvider: OpenAIProvider;
 
@@ -24,23 +22,6 @@ export class OpenAIService implements LLMService {
     });
   }
 
-  async createChatCompletionStream(params: {
-    model: string;
-    messages: Message[];
-    temperature: number;
-  }): Promise<ReadableStreamDefaultReader<string>> {
-    const { textStream: stream } = streamText({
-      model: this._openAIProvider(params.model),
-      messages: params.messages.map((m) => ({
-        role: m.role,
-        content: m.content,
-      })),
-      temperature: params.temperature,
-    });
-
-    return Promise.resolve(stream.getReader());
-  }
-
   async createChatCompletionObjectStream(params: {
     model: string;
     schema: ZodSchema;
@@ -49,9 +30,6 @@ export class OpenAIService implements LLMService {
     temperature: number;
   }): Promise<ReadableStreamDefaultReader<string>> {
     const { model, messages, temperature, schema, schemaName } = params;
-    if (!STRUCTURED_OUTPUTS_ENABLED) {
-      return this.createChatCompletionStream({ model, messages, temperature });
-    }
     const startTime = Date.now();
     const { textStream: stream } = streamObject({
       model: this._openAIProvider(model, { structuredOutputs: true }),

--- a/packages/aila/src/core/llm/OpenAIServiceCustomData.ts
+++ b/packages/aila/src/core/llm/OpenAIServiceCustomData.ts
@@ -1,0 +1,96 @@
+import type { HeliconeChatMeta } from "@oakai/core/src/llm/helicone";
+import { createVercelOpenAIClient } from "@oakai/core/src/llm/openai";
+import { aiLogger } from "@oakai/logger";
+
+import type { OpenAIProvider } from "@ai-sdk/openai";
+import { createDataStreamResponse, streamObject } from "ai";
+import type { ZodSchema } from "zod";
+
+import type { Message } from "../chat";
+import type { LLMService } from "./LLMService";
+
+const log = aiLogger("aila:llm");
+
+export class OpenAIServiceCustomData implements LLMService {
+  private readonly _openAIProvider: OpenAIProvider;
+
+  public name = "OpenAIService";
+
+  constructor({ userId, chatId }: HeliconeChatMeta) {
+    this._openAIProvider = createVercelOpenAIClient({
+      chatMeta: { userId, chatId },
+      app: "lesson-assistant",
+    });
+  }
+
+  async createChatCompletionObjectStream(params: {
+    model: string;
+    schema: ZodSchema;
+    schemaName: string;
+    messages: Message[];
+    temperature: number;
+  }): Promise<ReadableStreamDefaultReader<string>> {
+    const { model, messages, temperature, schema, schemaName } = params;
+    const startTime = Date.now();
+
+    const response = createDataStreamResponse({
+      execute: (dataStream) => {
+        const { textStream: stream } = streamObject({
+          model: this._openAIProvider(model, { structuredOutputs: true }),
+          output: "object",
+          schema,
+          schemaName,
+          messages: messages.map((m) => ({
+            role: m.role,
+            content: m.content,
+          })),
+          temperature,
+          // onChunk() {
+          //   dataStream.writeMessageAnnotation({ chunk: "123" });
+          // },
+          // onFinish() {
+          //   // message annotation:
+          //   dataStream.writeMessageAnnotation({
+          //     id: generateId(), // e.g. id from saved DB record
+          //     other: "information",
+          //   });
+          //   // call annotation:
+          //   dataStream.writeData("call completed");
+          // },
+        });
+        result.mergeIntoDataStream(dataStream);
+      },
+      onError: (error) => {
+        // Error messages are masked by default for security reasons.
+        // If you want to expose the error message to the client, you can do so here:
+        return error instanceof Error ? error.message : String(error);
+      },
+    });
+
+    // createDataStream: creates a data stream
+    // createDataStreamResponse: creates a response object that streams data
+    // pipeDataStreamToResponse: pipes a data stream to a server response object
+
+    const reader = stream.getReader();
+    const { value } = await reader.read();
+    const timeToFirstToken = Date.now() - startTime;
+
+    log.info(`Time to first token: ${timeToFirstToken}ms`);
+
+    //   const newStream = new ReadableStream({
+    //     start(controller) {
+    //       controller.enqueue(value);
+    //     },
+    //     async pull(controller) {
+    //       const { done, value } = await reader.read();
+    //       if (done) {
+    //         controller.close();
+    //       } else {
+    //         controller.enqueue(value);
+    //       }
+    //     },
+    //   });
+
+    //   return newStream.getReader();
+  }
+}

--- a/packages/aila/src/core/llm/OpenAIServiceObject.ts
+++ b/packages/aila/src/core/llm/OpenAIServiceObject.ts
@@ -1,0 +1,95 @@
+import type { HeliconeChatMeta } from "@oakai/core/src/llm/helicone";
+import { createVercelOpenAIClient } from "@oakai/core/src/llm/openai";
+import { aiLogger } from "@oakai/logger";
+
+import type { OpenAIProvider } from "@ai-sdk/openai";
+import { streamObject } from "ai";
+import type { ZodSchema } from "zod";
+
+import type { Message } from "../chat";
+import type { LLMService } from "./LLMService";
+
+const log = aiLogger("aila:llm");
+
+export class OpenAIServiceObject implements LLMService {
+  private readonly _openAIProvider: OpenAIProvider;
+
+  public name = "OpenAIService";
+
+  constructor({ userId, chatId }: HeliconeChatMeta) {
+    this._openAIProvider = createVercelOpenAIClient({
+      chatMeta: { userId, chatId },
+      app: "lesson-assistant",
+    });
+  }
+
+  async createChatCompletionObjectStream(params: {
+    model: string;
+    schema: ZodSchema;
+    schemaName: string;
+    messages: Message[];
+    temperature: number;
+  }): Promise<ReadableStreamDefaultReader<string>> {
+    const { model, messages, temperature, schema, schemaName } = params;
+    const startTime = Date.now();
+    // const { textStream: stream } = streamObject({
+    const { partialObjectStream } = streamObject({
+      model: this._openAIProvider(model, { structuredOutputs: true }),
+      output: "object",
+      // output: 'array',
+      schema,
+      schemaName,
+      messages: messages.map((m) => ({
+        role: m.role,
+        content: m.content,
+      })),
+      temperature,
+    });
+
+    /**
+    Stream of partial objects. It gets more complete as the stream progresses.
+
+    Note that the partial object is not validated.
+    If you want to be certain that the actual content matches your schema, you need to implement your own validation for partial results.
+       */
+    // readonly partialObjectStream: AsyncIterableStream<PARTIAL>;
+    /**
+     * Stream over complete array elements. Only available if the output strategy is set to `array`.
+     */
+    // readonly elementStream: ELEMENT_STREAM;
+    /**
+    Text stream of the JSON representation of the generated object. It contains text chunks.
+    When the stream is finished, the object is valid JSON that can be parsed.
+       */
+    // readonly textStream: AsyncIterableStream<string>;
+    /**
+    Stream of different types of events, including partial objects, errors, and finish events.
+    Only errors that stop the stream, such as network errors, are thrown.
+       */
+    // readonly fullStream: AsyncIterableStream<ObjectStreamPart<PARTIAL>>;
+
+    // TODO
+
+    // const reader = stream.getReader();
+    // const { value } = await reader.read();
+    // const timeToFirstToken = Date.now() - startTime;
+
+    // log.info(`Time to first token: ${timeToFirstToken}ms`);
+
+    // const newStream = new ReadableStream({
+    //   start(controller) {
+    //     controller.enqueue(value);
+    //   },
+    //   async pull(controller) {
+    //     const { done, value } = await reader.read();
+    //     if (done) {
+    //       controller.close();
+    //     } else {
+    //       controller.enqueue(value);
+    //     }
+    //   },
+    // });
+
+    // return newStream.getReader();
+  }
+}

--- a/packages/aila/src/core/quiz/fullservices/CompositeFullQuizServiceBuilder.ts
+++ b/packages/aila/src/core/quiz/fullservices/CompositeFullQuizServiceBuilder.ts
@@ -1,4 +1,5 @@
 import { aiLogger } from "@oakai/logger";
+import { omit } from "remeda/dist/commonjs/omit";
 
 import { AilaQuizFactory } from "../generators/AilaQuizGeneratorFactory";
 import type {
@@ -34,7 +35,10 @@ export class CompositeFullQuizServiceBuilder {
       generatorArray.push(AilaQuizFactory.createQuizGenerator(generator));
     }
 
-    log.info("Building Composite full quiz service with settings:", settings);
+    // log.info(
+    //   "Building Composite full quiz service with settings:",
+    //   omit(settings, "quizRatingSchema" as unknown),
+    // );
     return new CompositeFullQuizService(generatorArray, selector, reranker);
   }
 }

--- a/packages/aila/src/features/analytics/AilaAnalytics.ts
+++ b/packages/aila/src/features/analytics/AilaAnalytics.ts
@@ -1,3 +1,5 @@
+import type { LanguageModelUsage } from "ai";
+
 import type { AilaServices } from "../../core/AilaServices";
 import type { AnalyticsAdapter } from "./adapters/AnalyticsAdapter";
 
@@ -23,12 +25,12 @@ export class AilaAnalytics {
   }
 
   public async reportUsageMetrics(
-    responseBody: string,
+    usage: LanguageModelUsage,
     startedAt?: number,
   ): Promise<void> {
     const promise = Promise.all(
       this._adapters.map((adapter) =>
-        adapter.reportUsageMetrics(responseBody, startedAt),
+        adapter.reportUsageMetrics(usage, startedAt),
       ),
     );
     this._operations.push(promise);

--- a/packages/aila/src/features/analytics/adapters/AnalyticsAdapter.ts
+++ b/packages/aila/src/features/analytics/adapters/AnalyticsAdapter.ts
@@ -1,3 +1,5 @@
+import type { LanguageModelUsage } from "ai";
+
 import type { AilaServices } from "../../../core/AilaServices";
 
 export abstract class AnalyticsAdapter {
@@ -9,7 +11,7 @@ export abstract class AnalyticsAdapter {
 
   abstract initialiseAnalyticsContext(): void;
   abstract reportUsageMetrics(
-    responseBody: string,
+    usage: LanguageModelUsage,
     startedAt?: number,
   ): Promise<void>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/packages/aila/src/features/analytics/adapters/PosthogAnalyticsAdapter.ts
+++ b/packages/aila/src/features/analytics/adapters/PosthogAnalyticsAdapter.ts
@@ -1,5 +1,5 @@
 import type { ModerationResult } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
-import { getEncoding } from "js-tiktoken";
+import type { LanguageModelUsage } from "ai";
 import { PostHog } from "posthog-node";
 import invariant from "tiny-invariant";
 
@@ -58,23 +58,17 @@ export class PosthogAnalyticsAdapter extends AnalyticsAdapter {
     }
   }
 
-  private calculateMetrics(responseBody: string, startedAt?: number) {
+  private calculateMetrics(usage: LanguageModelUsage, startedAt?: number) {
     const now = Date.now();
     const queryDuration = now - (startedAt ?? this._startedAt);
-    const modelEncoding = getEncoding("cl100k_base");
-    const promptTokens = this._aila.messages.reduce((acc, message) => {
-      return acc + modelEncoding.encode(message.content).length;
-    }, 0);
-    const completionTokens = modelEncoding.encode(responseBody).length;
-    const totalTokens = promptTokens + completionTokens;
     return {
       userId: this._aila.userId,
       chatId: this._aila.chatId,
       queryDuration,
       model: this._aila.options.model,
-      totalTokens,
-      promptTokens,
-      completionTokens,
+      totalTokens: usage.totalTokens,
+      promptTokens: usage.promptTokens,
+      completionTokens: usage.completionTokens,
     };
   }
 }

--- a/packages/aila/src/features/generation/AilaGeneration.ts
+++ b/packages/aila/src/features/generation/AilaGeneration.ts
@@ -138,6 +138,7 @@ export class AilaGeneration {
     );
   }
 
+  // TODO: use LanguqgeModelUsage?
   private calculateTokenUsage() {
     if (!this._responseText) {
       return;

--- a/packages/aila/src/features/types.ts
+++ b/packages/aila/src/features/types.ts
@@ -1,3 +1,5 @@
+import { LanguageModelUsage } from "ai";
+
 import type { Message } from "../core/chat";
 import type { AilaDocumentContent } from "../core/document/types";
 import type { AilaPluginContext } from "../core/plugins";
@@ -20,7 +22,10 @@ export interface AilaModerationFeature {
 
 export interface AilaAnalyticsFeature {
   initialiseAnalyticsContext(): void;
-  reportUsageMetrics(responseBody: string, startedAt?: number): Promise<void>;
+  reportUsageMetrics(
+    usage: LanguageModelUsage,
+    startedAt?: number,
+  ): Promise<void>;
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   reportModerationResult(moderationResultEvent: any): void;
   shutdown(): Promise<void>;

--- a/packages/aila/src/utils/experimentalPatches/fetchExperimentalPatches.ts
+++ b/packages/aila/src/utils/experimentalPatches/fetchExperimentalPatches.ts
@@ -46,7 +46,7 @@ export async function fetchExperimentalPatches({
 }: {
   lessonPlan: LooseLessonPlan;
   llmPatches: PatchDocument[];
-  handlePatch: (patch: ExperimentalPatchDocument) => Promise<void>;
+  handlePatch: (patch: ExperimentalPatchDocument) => void;
   fullQuizService: FullQuizService;
   userId?: string;
 }) {
@@ -81,7 +81,7 @@ export async function fetchExperimentalPatches({
   if (starterQuizPatch) {
     const op = starterQuizPatch.value.op;
     if (op === "remove") {
-      await handlePatch(
+      handlePatch(
         preparePatch({
           op,
           path: "/_experimental_starterQuizMathsV0",
@@ -106,7 +106,7 @@ export async function fetchExperimentalPatches({
       }
 
       if (mathsStarterQuiz) {
-        await handlePatch(
+        handlePatch(
           preparePatch({
             path: "/_experimental_starterQuizMathsV0",
             op,
@@ -122,7 +122,7 @@ export async function fetchExperimentalPatches({
   if (exitQuizPatch) {
     const op = exitQuizPatch.value.op;
     if (op === "remove") {
-      await handlePatch(
+      handlePatch(
         preparePatch({
           op,
           path: "/_experimental_exitQuizMathsV0",
@@ -148,7 +148,7 @@ export async function fetchExperimentalPatches({
       }
 
       if (mathsExitQuiz) {
-        await handlePatch(
+        handlePatch(
           preparePatch({
             path: "/_experimental_exitQuizMathsV0",
             op,

--- a/packages/core/src/llm/openai.ts
+++ b/packages/core/src/llm/openai.ts
@@ -1,9 +1,9 @@
-import type { OpenAIProvider } from "@ai-sdk/openai";
 import { createOpenAI } from "@ai-sdk/openai";
+import type { OpenAIProvider } from "ai-sdk/openai";
 import type { ClientOptions } from "openai";
 import OpenAI from "openai";
 
-import type { HeliconeChatMeta} from "./helicone";
+import type { HeliconeChatMeta } from "./helicone";
 import { heliconeHeaders } from "./helicone";
 
 export type CreateOpenAIClientProps =

--- a/packages/core/src/prompts/lesson-assistant/parts/protocol.ts
+++ b/packages/core/src/prompts/lesson-assistant/parts/protocol.ts
@@ -1,6 +1,8 @@
 import type { TemplateProps } from "..";
 
-const responseFormatWithStructuredOutputs = "{\"response\":\"llmMessage\", patches:[{},{}...], prompt:{}}";
+// TODO structured outputs seems broken as this was wrong and not picked up
+const responseFormatWithStructuredOutputs =
+  '{"type":"llmMessage", patches:[{},{}...], prompt:{}}';
 const responseFormatWithoutStructuredOutputs = `A series of JSON documents separated using the JSON Text Sequences specification, where each row is separated by the ␞ character and ends with a new line character.
 Your response should be a series of patches followed by one and only one prompt to the user.`;
 
@@ -15,6 +17,7 @@ const responseFormat = ({
 
 export const protocol = ({
   isUsingStructuredOutput,
+  // TODO: do you need this is using structured outputs?
   llmResponseJsonSchema,
 }: TemplateProps) => `RULES FOR RESPONDING TO THE USER INTERACTIVELY WHILE CREATING THE LESSON PLAN
 

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -76,7 +76,7 @@ export type LoggerKey =
 
 const errorLogger =
   typeof window === "undefined"
-    ? structuredLogger.error.bind(structuredLogger)
+    ? console.error.bind(console)
     : browserLogger.error.bind(browserLogger);
 
 /**

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -192,8 +192,8 @@ importers:
         specifier: ^2.4.1
         version: 2.4.1(react-dom@18.2.0)(react@18.2.0)
       ai:
-        specifier: ^4.0.20
-        version: 4.0.20(react@18.2.0)(zod@3.23.8)
+        specifier: ^4.1.0
+        version: 4.1.50(react@18.2.0)(zod@3.23.8)
       american-british-english-translator:
         specifier: ^0.2.1
         version: 0.2.1
@@ -514,8 +514,8 @@ importers:
         specifier: ^0.2.2
         version: 0.2.2
       ai:
-        specifier: ^4.0.20
-        version: 4.0.20(react@18.2.0)(zod@3.23.8)
+        specifier: ^4.1.0
+        version: 4.1.50(react@18.2.0)(zod@3.23.8)
       american-british-english-translator:
         specifier: ^0.2.1
         version: 0.2.1
@@ -1062,8 +1062,8 @@ packages:
       zod: 3.23.8
     dev: false
 
-  /@ai-sdk/provider-utils@2.0.4(zod@3.23.8):
-    resolution: {integrity: sha512-GMhcQCZbwM6RoZCri0MWeEWXRt/T+uCxsmHEsTwNvEH3GDjNzchfX25C8ftry2MeEOOn6KfqCLSKomcgK6RoOg==}
+  /@ai-sdk/provider-utils@2.1.10(zod@3.23.8):
+    resolution: {integrity: sha512-4GZ8GHjOFxePFzkl3q42AU0DQOtTQ5w09vmaWUf/pKFXJPizlnzKSUkF0f+VkapIUfDugyMqPMT1ge8XQzVI7Q==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
@@ -1071,7 +1071,7 @@ packages:
       zod:
         optional: true
     dependencies:
-      '@ai-sdk/provider': 1.0.2
+      '@ai-sdk/provider': 1.0.9
       eventsource-parser: 3.0.0
       nanoid: 3.3.8
       secure-json-parse: 2.7.0
@@ -1085,15 +1085,15 @@ packages:
       json-schema: 0.4.0
     dev: false
 
-  /@ai-sdk/provider@1.0.2:
-    resolution: {integrity: sha512-YYtP6xWQyaAf5LiWLJ+ycGTOeBLWrED7LUrvc+SQIWhGaneylqbaGsyQL7VouQUeQ4JZ1qKYZuhmi3W56HADPA==}
+  /@ai-sdk/provider@1.0.9:
+    resolution: {integrity: sha512-jie6ZJT2ZR0uVOVCDc9R2xCX5I/Dum/wEK28lx21PJx6ZnFAN9EzD2WsPhcDWfCgGx3OAZZ0GyM3CEobXpa9LA==}
     engines: {node: '>=18'}
     dependencies:
       json-schema: 0.4.0
     dev: false
 
-  /@ai-sdk/react@1.0.6(react@18.2.0)(zod@3.23.8):
-    resolution: {integrity: sha512-8Hkserq0Ge6AEi7N4hlv2FkfglAGbkoAXEZ8YSp255c3PbnZz6+/5fppw+aROmZMOfNwallSRuy1i/iPa2rBpQ==}
+  /@ai-sdk/react@1.1.20(react@18.2.0)(zod@3.23.8):
+    resolution: {integrity: sha512-4QOM9fR9SryaRraybckDjrhl1O6XejqELdKmrM5g9y9eLnWAfjwF+W1aN0knkSHzbbjMqN77sy9B9yL8EuJbDw==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -1104,16 +1104,16 @@ packages:
       zod:
         optional: true
     dependencies:
-      '@ai-sdk/provider-utils': 2.0.4(zod@3.23.8)
-      '@ai-sdk/ui-utils': 1.0.5(zod@3.23.8)
+      '@ai-sdk/provider-utils': 2.1.10(zod@3.23.8)
+      '@ai-sdk/ui-utils': 1.1.16(zod@3.23.8)
       react: 18.2.0
       swr: 2.2.5(react@18.2.0)
       throttleit: 2.1.0
       zod: 3.23.8
     dev: false
 
-  /@ai-sdk/ui-utils@1.0.5(zod@3.23.8):
-    resolution: {integrity: sha512-DGJSbDf+vJyWmFNexSPUsS1AAy7gtsmFmoSyNbNbJjwl9hRIf2dknfA1V0ahx6pg3NNklNYFm53L8Nphjovfvg==}
+  /@ai-sdk/ui-utils@1.1.16(zod@3.23.8):
+    resolution: {integrity: sha512-jfblR2yZVISmNK2zyNzJZFtkgX57WDAUQXcmn3XUBJyo8LFsADu+/vYMn5AOyBi9qJT0RBk11PEtIxIqvByw3Q==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.0.0
@@ -1121,8 +1121,8 @@ packages:
       zod:
         optional: true
     dependencies:
-      '@ai-sdk/provider': 1.0.2
-      '@ai-sdk/provider-utils': 2.0.4(zod@3.23.8)
+      '@ai-sdk/provider': 1.0.9
+      '@ai-sdk/provider-utils': 2.1.10(zod@3.23.8)
       zod: 3.23.8
       zod-to-json-schema: 3.24.1(zod@3.23.8)
     dev: false
@@ -10731,8 +10731,8 @@ packages:
       indent-string: 5.0.0
     dev: false
 
-  /ai@4.0.20(react@18.2.0)(zod@3.23.8):
-    resolution: {integrity: sha512-dYevYKtREcjSVopBDFWVNca7WJEI1p9Vr9eo7V7fZHzi2vXGDyEa2WYatjFbpR6z6gpVAxKHsof8EoN+B1IAsA==}
+  /ai@4.1.50(react@18.2.0)(zod@3.23.8):
+    resolution: {integrity: sha512-YBNeemrJKDrxoBQd3V9aaxhKm5q5YyRcF7PZE7W0NmLuvsdva/1aQNYTAsxs47gQFdvqfYmlFy4B0E+356OlPA==}
     engines: {node: '>=18'}
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
@@ -10743,15 +10743,14 @@ packages:
       zod:
         optional: true
     dependencies:
-      '@ai-sdk/provider': 1.0.2
-      '@ai-sdk/provider-utils': 2.0.4(zod@3.23.8)
-      '@ai-sdk/react': 1.0.6(react@18.2.0)(zod@3.23.8)
-      '@ai-sdk/ui-utils': 1.0.5(zod@3.23.8)
+      '@ai-sdk/provider': 1.0.9
+      '@ai-sdk/provider-utils': 2.1.10(zod@3.23.8)
+      '@ai-sdk/react': 1.1.20(react@18.2.0)(zod@3.23.8)
+      '@ai-sdk/ui-utils': 1.1.16(zod@3.23.8)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
       react: 18.2.0
       zod: 3.23.8
-      zod-to-json-schema: 3.24.1(zod@3.23.8)
     dev: false
 
   /ajv-formats@2.1.1(ajv@8.17.1):


### PR DESCRIPTION
This is a collection of in-situ changes I was making to align the aila package closer to the AI SDK

I wanted to make sweeping changes locally to see how it would fit together, and then pull out parts I liked into PRs

Key changes I was looking at:
- Removing our own calculation of LLM metrics. This is provided by the AI SDK
- Emit a DataStreamResponse from the server. This is part of the AI SDK letting you stream various data types (message, data, annotations, error, etc) down the same stream. We can then remove our own adapters for this format (`0:abcde...`)
- Pass the DataStream to functions that need it, rather than instantiating an enqueuer class
- Don't collect chunks and accumulated text
- Remove instance variables on the Aila class when they're only used by the streaming service
- Remove instance variables which are only used in one function
- Investigate "streaming text with data additions" vs "streaming objects with a union type". streamText vs streamObject(output: "array")
- Make it really clear what code is in the setup and completion around streaming. Maybe even extract those to a new file
- See if we can remove the reference to the aila class from the streaming service, as it encourages a back and forward function calling pattern which is hard to follow
- Split any output using the `␞` delimiter into individual data lines in the DataStream
- Use the changed key logger from the zustand stores when logging the lesson plan changes
- Remove all code behind the structured outputs feature flag. eg: "createChatCompletionStream". I don't think we're going back
- Fix log.error calls