### PR TITLE
chore: limit test GH action to node v20.18 to fix jest v29

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,9 @@ jobs:
       - name: Setup Node 20
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          # NOTE: We're fixing at 20.18 as 20.19 changes require(esm) logic https://nodejs.org/en/blog/release/v20.19.0
+          #       That change is incompatible with jest v29. jest v30 is still in alpha https://github.com/jestjs/jest/pull/15447
+          node-version: 20.18
           cache: "pnpm"
 
       - name: Install deps (with cache)


### PR DESCRIPTION
## Description

Our jest github action has been [failing today](https://github.com/oaknational/oak-ai-lesson-assistant/actions/runs/14035634597/job/39292884714?pr=623#step:8:163) after an automatic update to [node v20.19](https://nodejs.org/en/blog/release/v20.19.0). This version enables `require(esm)` by default, which breaks jest v29. See https://github.com/jestjs/jest/pull/15447. The jest fix is still in alpha, so for now let's pin the node version at v20.18 which we know to work


