### PR TITLE
chore: remove useless logs

### DIFF
--- a/apps/nextjs/src/app/api/trpc/chat/[trpc]/route.ts
+++ b/apps/nextjs/src/app/api/trpc/chat/[trpc]/route.ts
@@ -19,9 +19,6 @@ const handler = (req: NextRequest, res: NextResponse) =>
       return createContext({ req, res });
     },
     onError: (e) => {
-      if (process.env.NODE_ENV === "development") {
-        log.error(e);
-      }
       Sentry.captureException(e.error);
     },
   });

--- a/apps/nextjs/src/app/api/trpc/main/[trpc]/route.ts
+++ b/apps/nextjs/src/app/api/trpc/main/[trpc]/route.ts
@@ -19,9 +19,6 @@ const handler = (req: NextRequest, res: NextResponse) =>
       return createContext({ req, res });
     },
     onError: (e) => {
-      if (process.env.NODE_ENV === "development") {
-        log.error(e);
-      }
       Sentry.captureException(e.error);
     },
   });


### PR DESCRIPTION
## Description

These logs are only meant to show up in development but when there is an error dump a giant and useless error into the terminal that stops you from actually being able to debug as the message includes every trpc definition taking up the entire console window. 

