### PR TITLE
feat: add rag and basedOn to agentic model [AI-1152]

### DIFF
--- a/packages/aila/src/core/AilaServices.ts
+++ b/packages/aila/src/core/AilaServices.ts
@@ -45,8 +45,8 @@ export interface AilaChatService {
   readonly iteration: number | undefined;
   readonly createdAt: Date | undefined;
   readonly persistedChat: AilaPersistedChat | undefined;
-  get relevantLessons(): AilaRagRelevantLesson[];
-  set relevantLessons(lessons: AilaRagRelevantLesson[]);
+  get relevantLessons(): AilaRagRelevantLesson[] | null;
+  set relevantLessons(lessons: AilaRagRelevantLesson[] | null);
   readonly parsedMessages: MessagePart[][];
   readonly isShared: boolean | undefined;
   readonly fullQuizService: FullQuizService;

--- a/packages/aila/src/core/chat/AilaChat.ts
+++ b/packages/aila/src/core/chat/AilaChat.ts
@@ -46,7 +46,7 @@ const log = aiLogger("aila:chat");
 export class AilaChat implements AilaChatService {
   private readonly _id: string;
   private readonly _messages: Message[];
-  private _relevantLessons: AilaRagRelevantLesson[];
+  private _relevantLessons: AilaRagRelevantLesson[] | null;
   private _isShared: boolean | undefined;
   private readonly _userId: string | undefined;
   private readonly _aila: AilaServices;
@@ -91,7 +91,7 @@ export class AilaChat implements AilaChatService {
       });
     this._patchEnqueuer = new PatchEnqueuer();
     this._promptBuilder = promptBuilder ?? new AilaLessonPromptBuilder(aila);
-    this._relevantLessons = [];
+    this._relevantLessons = null;
     this._experimentalPatches = [];
 
     this.fullQuizService = new CompositeFullQuizServiceBuilder().build({
@@ -146,7 +146,7 @@ export class AilaChat implements AilaChatService {
     return this._generation;
   }
 
-  public set relevantLessons(lessons: AilaRagRelevantLesson[]) {
+  public set relevantLessons(lessons: AilaRagRelevantLesson[] | null) {
     this._relevantLessons = lessons;
   }
 
@@ -156,6 +156,10 @@ export class AilaChat implements AilaChatService {
 
   public addMessage(message: Message) {
     this._messages.push(message);
+  }
+
+  public initialiseChunks() {
+    this._chunks = [];
   }
 
   public appendChunk(value?: string) {
@@ -188,8 +192,10 @@ export class AilaChat implements AilaChatService {
     } else if (error instanceof Error) {
       await this.enqueueError({ message: error.message });
     }
-    await this.persistGeneration("FAILED");
-    log.info("Generation marked as failed");
+    if (!this._aila.options.useAgenticAila) {
+      await this.persistGeneration("FAILED");
+      log.info("Generation marked as failed");
+    }
   }
 
   private async enqueueError({ message }: { message: string }) {
@@ -299,6 +305,7 @@ export class AilaChat implements AilaChatService {
       status: "PENDING",
     });
     await this._generation.setupPromptId();
+
     this._chunks = [];
   }
 
@@ -347,7 +354,7 @@ export class AilaChat implements AilaChatService {
     const persistedChat = await persistenceFeature.loadChat();
 
     if (persistedChat) {
-      this._relevantLessons = persistedChat.relevantLessons ?? [];
+      this._relevantLessons = persistedChat.relevantLessons ?? null;
       this._isShared = persistedChat.isShared;
       this._iteration = persistedChat.iteration ?? 1;
       this._createdAt = new Date(persistedChat.createdAt);
@@ -419,7 +426,9 @@ export class AilaChat implements AilaChatService {
     await this.saveSnapshot({ messageId: assistantMessage.id });
     await this.moderate();
     await this.persistChat();
-    await this.persistGeneration("SUCCESS");
+    if (!this.aila.options.useAgenticAila) {
+      await this.persistGeneration("SUCCESS");
+    }
     await this.enqueue({
       type: "comment",
       value: "CHAT_COMPLETE",

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -1,8 +1,6 @@
-import { prisma } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
 import { getRagLessonPlansByIds } from "@oakai/rag";
 
-import type { AilaRagRelevantLesson } from "protocol/schema";
 import type { ReadableStreamDefaultController } from "stream/web";
 
 import { AilaThreatDetectionError } from "../../features/threatDetection/types";

--- a/packages/aila/src/core/quiz/generators/BaseQuizGenerator.ts
+++ b/packages/aila/src/core/quiz/generators/BaseQuizGenerator.ts
@@ -95,18 +95,15 @@ export abstract class BaseQuizGenerator implements AilaQuizGeneratorService {
 
   public async getLessonSlugFromPlanId(planId: string): Promise<string | null> {
     try {
-      const result = await prisma.lessonPlan.findUnique({
+      const result = await prisma.ragLessonPlan.findUnique({
         where: { id: planId },
-        select: {
-          lesson: true,
-        },
       });
 
       if (!result) {
         log.warn("Lesson plan could not be retrieved for planId: ", planId);
         return null;
       }
-      return result?.lesson.slug;
+      return result.oakLessonSlug;
     } catch (error) {
       log.error("Error fetching lesson slug:", error);
       return null;

--- a/packages/aila/src/lib/agents/agents.ts
+++ b/packages/aila/src/lib/agents/agents.ts
@@ -45,6 +45,7 @@ export const agentNames = z.enum([
   "mathsExitQuiz",
   "deleteSection",
   "endTurn",
+  "basedOn",
 ]);
 
 export type AgentName = z.infer<typeof agentNames>;
@@ -182,20 +183,20 @@ export const agents: Record<AgentName, AgentDefinition> = {
     type: "custom",
     name: "endTurn",
   },
+  basedOn: {
+    type: "asyncFunction",
+    name: "basedOn",
+  },
 };
 
 export const sectionAgentMap: Record<
   Exclude<
     LessonPlanKey,
-    | "title"
-    | "subject"
-    | "keyStage"
-    | "topic"
-    | "basedOn"
-    | "additionalMaterials"
+    "title" | "subject" | "keyStage" | "topic" | "additionalMaterials"
   >,
   (ctx: { lessonPlan: LooseLessonPlan }) => AgentName
 > = {
+  basedOn: () => "basedOn",
   learningOutcome: () => "learningOutcome",
   learningCycles: () => "learningCycles",
   priorKnowledge: () => "priorKnowledge",

--- a/packages/aila/src/lib/agents/agents.ts
+++ b/packages/aila/src/lib/agents/agents.ts
@@ -173,7 +173,7 @@ export const agents: Record<AgentName, AgentDefinition> = {
     prompt: learningCyclesInstructions,
     schema: z.object({ value: CycleSchemaWithoutLength }),
     extractRagData: (lp) => {
-      // Extract all cycle data
+      // @todo we probably only need one cycle (the relevant one)
       return JSON.stringify({
         cycle1: lp.cycle1,
         cycle2: lp.cycle2,

--- a/packages/aila/src/lib/agents/agents.ts
+++ b/packages/aila/src/lib/agents/agents.ts
@@ -1,6 +1,7 @@
 import { z } from "zod";
 
 import {
+  type CompletedLessonPlan,
   CycleSchemaWithoutLength,
   KeyLearningPointsSchema,
   KeyStageSchema,
@@ -71,7 +72,7 @@ export type PromptAgentDefinition<
   name: AgentName;
   prompt: string;
   schema: Schema;
-  whenToUse?: string[];
+  extractRagData: (exampleLessonPlan: CompletedLessonPlan) => string;
 };
 export type AgentDefinition<Schema extends AgentResponse = AgentResponseAny> =
   | PromptAgentDefinition<SchemaWithValue>
@@ -79,12 +80,12 @@ export type AgentDefinition<Schema extends AgentResponse = AgentResponseAny> =
       type: "custom";
       name: AgentName;
       schema?: z.ZodTypeAny;
-      whenToUse?: string[];
+      extractRagData?: (exampleLessonPlan: CompletedLessonPlan) => string;
     }
   | {
       type: "asyncFunction";
       name: AgentName;
-      whenToUse?: string[];
+      extractRagData?: (exampleLessonPlan: CompletedLessonPlan) => string;
       // fn: <T>(args: T) => Promise<JsonPatchDocumentOptional>;
     };
 
@@ -94,78 +95,98 @@ export const agents: Record<AgentName, AgentDefinition> = {
     name: "title",
     prompt: "Generate a title for the lesson plan.",
     schema: z.object({ value: LessonTitleSchema }),
+    extractRagData: (lp) => lp.title,
   },
   keyStage: {
     type: "prompt",
     name: "keyStage",
     prompt: "Specify the Key Stage for this lesson.",
     schema: z.object({ value: KeyStageSchema }),
+    extractRagData: (lp) => lp.keyStage,
   },
   subject: {
     type: "prompt",
     name: "subject",
     prompt: "Specify the subject for this lesson.",
     schema: z.object({ value: SubjectSchema }),
+    extractRagData: (lp) => lp.subject,
   },
   topic: {
     type: "prompt",
     name: "topic",
     prompt: "Specify the topic for this lesson.",
     schema: z.object({ value: TopicSchema }),
+    extractRagData: (lp) => lp.topic,
   },
   learningOutcome: {
     type: "prompt",
     name: "learningOutcome",
     prompt: learningOutcomeInstructions,
     schema: z.object({ value: LearningOutcomeSchema }),
+    extractRagData: (lp) => lp.learningOutcome,
   },
   learningCycles: {
     type: "prompt",
     name: "learningCycles",
     prompt: learningCycleTitlesInstructions,
     schema: z.object({ value: LearningCyclesSchema }),
+    extractRagData: (lp) => JSON.stringify(lp.learningCycles),
   },
   priorKnowledge: {
     type: "prompt",
     name: "priorKnowledge",
     prompt: priorKnowledgeInstructions,
     schema: z.object({ value: PriorKnowledgeSchema }),
+    extractRagData: (lp) => JSON.stringify(lp.priorKnowledge),
   },
   keyLearningPoints: {
     type: "prompt",
     name: "keyLearningPoints",
     prompt: keyLearningPointsInstructions,
     schema: z.object({ value: KeyLearningPointsSchema }),
+    extractRagData: (lp) => JSON.stringify(lp.keyLearningPoints),
   },
   misconceptions: {
     type: "prompt",
     name: "misconceptions",
     prompt: misconceptionsInstructions,
     schema: z.object({ value: MisconceptionsSchemaWithoutLength }),
+    extractRagData: (lp) => JSON.stringify(lp.misconceptions),
   },
   keywords: {
     type: "prompt",
     name: "keywords",
     prompt: keywordsInstructions,
     schema: z.object({ value: KeywordsSchemaWithoutLength }),
+    extractRagData: (lp) => JSON.stringify(lp.keywords),
   },
   starterQuiz: {
     type: "prompt",
     name: "starterQuiz",
     prompt: [starterQuizInstructions, quizInstructions].join(`\n\n`),
     schema: z.object({ value: QuizSchemaWithoutLength }),
+    extractRagData: (lp) => JSON.stringify(lp.starterQuiz),
   },
   cycle: {
     type: "prompt",
     name: "cycle",
     prompt: learningCyclesInstructions,
     schema: z.object({ value: CycleSchemaWithoutLength }),
+    extractRagData: (lp) => {
+      // Extract all cycle data
+      return JSON.stringify({
+        cycle1: lp.cycle1,
+        cycle2: lp.cycle2,
+        cycle3: lp.cycle3,
+      });
+    },
   },
   exitQuiz: {
     type: "prompt",
     name: "exitQuiz",
     prompt: [exitQuizInstructions, quizInstructions].join(`\n\n`),
     schema: z.object({ value: QuizSchemaWithoutLength }),
+    extractRagData: (lp) => JSON.stringify(lp.exitQuiz),
   },
   mathsStarterQuiz: {
     type: "asyncFunction",

--- a/packages/aila/src/lib/agents/compatibility/streamHandling.ts
+++ b/packages/aila/src/lib/agents/compatibility/streamHandling.ts
@@ -116,6 +116,13 @@ export function createInteractStreamHandler(
               chat,
               sectionsToEdit,
             });
+          } else {
+            onTurnPlan({
+              turnPlan: null,
+              controller,
+              chat,
+              sectionsToEdit,
+            });
           }
         }
         break;
@@ -146,15 +153,15 @@ function onTurnPlan({
   chat,
   sectionsToEdit,
 }: {
-  turnPlan: TurnPlan;
+  turnPlan: TurnPlan | null;
   controller: ReadableStreamDefaultController;
   chat: AilaChat;
   sectionsToEdit: string[];
 }) {
   // Extract section keys from the plan
-  const newSections = turnPlan.plan.map(
-    (p: TurnPlan["plan"][number]) => p.sectionKey,
-  );
+  const newSections = turnPlan
+    ? turnPlan.plan.map((p: TurnPlan["plan"][number]) => p.sectionKey)
+    : [];
   sectionsToEdit.push(...newSections);
 
   // Stream the opening part of the message with sectionsToEdit

--- a/packages/aila/src/lib/agents/interact.ts
+++ b/packages/aila/src/lib/agents/interact.ts
@@ -9,15 +9,9 @@ import {
   type LooseLessonPlan,
   type Quiz,
 } from "../../protocol/schema";
-import {
-  type AgentDefinition,
-  type AgentName,
-  agents,
-  sectionAgentMap,
-} from "./agents";
+import { agents, sectionAgentMap } from "./agents";
 import { type InteractResult } from "./compatibility/streamHandling";
 import { messageToUserAgent } from "./messageToUser";
-import { preRoutingLogic } from "./preRoutingLogic";
 import { promptAgentHandler } from "./promptAgentHandler";
 import { type TurnPlan, agentRouter } from "./router";
 

--- a/packages/aila/src/lib/agents/lessonPlanSectionGroups.ts
+++ b/packages/aila/src/lib/agents/lessonPlanSectionGroups.ts
@@ -3,6 +3,7 @@ import { z } from "zod";
 import type { LessonPlanKey } from "../../protocol/schema";
 
 export const sectionKeysSchema = z.union([
+  z.literal("basedOn"),
   z.literal("learningOutcome"),
   z.literal("learningCycles"),
   z.literal("priorKnowledge"),
@@ -20,17 +21,7 @@ export const sectionKeysSchema = z.union([
 type SectionGroups = LessonPlanKey[][];
 
 export const sectionGroups: SectionGroups = [
-  // When there are no relevant lessons
-  ["learningOutcome", "learningCycles"],
-
-  // When there are relevant lessons and a base lesson may be selected
-  [
-    // "basedOn",
-    "learningOutcome",
-    "learningCycles",
-  ],
-
-  // General progression
+  ["basedOn", "learningOutcome", "learningCycles"],
   ["priorKnowledge", "keyLearningPoints", "misconceptions", "keywords"],
   ["starterQuiz", "cycle1", "cycle2", "cycle3", "exitQuiz"],
   ["additionalMaterials"],

--- a/packages/aila/src/lib/agents/messageToUser.ts
+++ b/packages/aila/src/lib/agents/messageToUser.ts
@@ -36,7 +36,7 @@ export async function messageToUserAgent({
 
   const responseFormat = zodTextFormat(
     responseSchema,
-    "router_response_schema",
+    "message_to_user_response_schema",
   );
 
   const missingSections = sectionGroups

--- a/packages/aila/src/lib/agents/preRoutingLogic.ts
+++ b/packages/aila/src/lib/agents/preRoutingLogic.ts
@@ -1,0 +1,15 @@
+import type { AilaRagRelevantLesson } from "../../protocol/schema";
+
+export async function preRoutingLogic({
+  relevantLessons,
+}: {
+  relevantLessons: AilaRagRelevantLesson[] | null;
+}) {
+  if (relevantLessons === null) {
+    return {
+      result: {
+        type: "fetch_relevant_lessons",
+      },
+    };
+  }
+}

--- a/packages/aila/src/lib/agents/prompts/messageToUserInstructions.ts
+++ b/packages/aila/src/lib/agents/prompts/messageToUserInstructions.ts
@@ -49,10 +49,9 @@ The message history includes prior dialogue and shows that Aila (powered by a mu
 > Tap **Continue** to move on to the next step.  
 
 # Section Groups (usually completed in sequence):  
-1. \`learningOutcome\`, \`learningCycles\`  
-2. \`basedOn\`, \`learningOutcome\`, \`learningCycles\`  
-3. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
-4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\`, \`exitQuiz\`  
-5. \`additionalMaterials\`
+1. \`basedOn\`, \`learningOutcome\`, \`learningCycles\`  
+2. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
+3. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\`, \`exitQuiz\`  
+4. \`additionalMaterials\`
 
 `;

--- a/packages/aila/src/lib/agents/prompts/routerInstructions.ts
+++ b/packages/aila/src/lib/agents/prompts/routerInstructions.ts
@@ -3,11 +3,10 @@ export const routerInstructions = `You are a planning agent that supports users 
 Given the provided input, create a structured plan detailing exactly which sections require actions before returning the document to the user.
 
 ### Section Groups (process sequentially):
-1. learningOutcome, learningCycles
-2. basedOn, learningOutcome, learningCycles
-3. priorKnowledge, keyLearningPoints, misconceptions, keywords
-4. starterQuiz, cycle1, cycle2, cycle3, exitQuiz
-5. additionalMaterials
+1. basedOn, learningOutcome, learningCycles
+2. priorKnowledge, keyLearningPoints, misconceptions, keywords
+3. starterQuiz, cycle1, cycle2, cycle3, exitQuiz
+4. additionalMaterials
 
 ### Action Types:
 For each planned section, specify exactly one action:

--- a/packages/aila/src/lib/agents/rag/fetchReleventLessons.agent.ts
+++ b/packages/aila/src/lib/agents/rag/fetchReleventLessons.agent.ts
@@ -1,0 +1,36 @@
+import { parseKeyStage } from "@oakai/core/src/data/parseKeyStage";
+import { getRelevantLessonPlans, parseSubjectsForRagSearch } from "@oakai/rag";
+
+import type { LooseLessonPlan } from "protocol/schema";
+
+import type { RagLessonPlan } from "../../../utils/rag/fetchRagContent";
+
+export async function fetchRelevantLessonPlans({
+  document,
+}: {
+  document: LooseLessonPlan;
+}): Promise<{
+  ragLessonPlans: RagLessonPlan[];
+}> {
+  const { title, keyStage, subject } = document;
+  if (!title || !keyStage || !subject) {
+    throw new Error(
+      "Title, keyStage, and subject are all required to fetch relevant lesson plans",
+    );
+  }
+  const keyStageSlugs = keyStage ? [parseKeyStage(keyStage)] : null;
+  const subjectSlugs = subject ? parseSubjectsForRagSearch(subject) : null;
+
+  const relevantLessonPlans = await getRelevantLessonPlans({
+    title,
+    keyStageSlugs,
+    subjectSlugs,
+  });
+
+  return {
+    ragLessonPlans: relevantLessonPlans.map((l) => ({
+      ...l.lessonPlan,
+      id: l.ragLessonPlanId,
+    })),
+  };
+}

--- a/packages/aila/src/lib/agents/rag/fetchReleventLessons.agent.ts
+++ b/packages/aila/src/lib/agents/rag/fetchReleventLessons.agent.ts
@@ -1,17 +1,14 @@
 import { parseKeyStage } from "@oakai/core/src/data/parseKeyStage";
 import { getRelevantLessonPlans, parseSubjectsForRagSearch } from "@oakai/rag";
+import type { RagLessonPlanResult } from "@oakai/rag/types";
 
 import type { LooseLessonPlan } from "protocol/schema";
-
-import type { RagLessonPlan } from "../../../utils/rag/fetchRagContent";
 
 export async function fetchRelevantLessonPlans({
   document,
 }: {
   document: LooseLessonPlan;
-}): Promise<{
-  ragLessonPlans: RagLessonPlan[];
-}> {
+}): Promise<RagLessonPlanResult[]> {
   const { title, keyStage, subject } = document;
   if (!title || !keyStage || !subject) {
     throw new Error(
@@ -27,10 +24,5 @@ export async function fetchRelevantLessonPlans({
     subjectSlugs,
   });
 
-  return {
-    ragLessonPlans: relevantLessonPlans.map((l) => ({
-      ...l.lessonPlan,
-      id: l.ragLessonPlanId,
-    })),
-  };
+  return relevantLessonPlans;
 }

--- a/packages/aila/src/lib/agents/rag/fetchReleventLessons.agent.ts
+++ b/packages/aila/src/lib/agents/rag/fetchReleventLessons.agent.ts
@@ -2,7 +2,7 @@ import { parseKeyStage } from "@oakai/core/src/data/parseKeyStage";
 import { getRelevantLessonPlans, parseSubjectsForRagSearch } from "@oakai/rag";
 import type { RagLessonPlanResult } from "@oakai/rag/types";
 
-import type { LooseLessonPlan } from "protocol/schema";
+import type { LooseLessonPlan } from "../../../protocol/schema";
 
 export async function fetchRelevantLessonPlans({
   document,

--- a/packages/aila/src/lib/agents/router.ts
+++ b/packages/aila/src/lib/agents/router.ts
@@ -3,7 +3,10 @@ import { createOpenAIClient } from "@oakai/core/src/llm/openai";
 import { zodTextFormat } from "openai/helpers/zod";
 import { z } from "zod";
 
-import { type LooseLessonPlan } from "../../protocol/schema";
+import {
+  type AilaRagRelevantLesson,
+  type LooseLessonPlan,
+} from "../../protocol/schema";
 import { sectionKeysSchema } from "./lessonPlanSectionGroups";
 import { routerInstructions } from "./prompts";
 

--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -456,7 +456,7 @@ export const chatSchema = z
     title: z.string(),
     userId: z.string(),
     lessonPlan: LessonPlanSchemaWhilstStreaming,
-    relevantLessons: z.array(AilaRagRelevantLessonSchema).optional(),
+    relevantLessons: z.array(AilaRagRelevantLessonSchema).nullish(),
     isShared: z.boolean().optional(),
     createdAt: z.union([z.date(), z.number()]),
     updatedAt: z.union([z.date(), z.number()]).optional(),

--- a/packages/rag/getRagLessonPlansByIds/getRagLessonPlansByIds.ts
+++ b/packages/rag/getRagLessonPlansByIds/getRagLessonPlansByIds.ts
@@ -1,0 +1,27 @@
+import { prisma } from "@oakai/db";
+
+import {
+  type CompletedLessonPlan,
+  CompletedLessonPlanSchema,
+} from "../../aila/src/protocol/schema";
+
+/**
+ * @todo Implement cache strategy for this function
+ */
+export async function getRagLessonPlansByIds({
+  lessonPlanIds,
+}: {
+  lessonPlanIds: string[];
+}): Promise<CompletedLessonPlan[]> {
+  const lessonPlans = await prisma.ragLessonPlan.findMany({
+    where: {
+      id: {
+        in: lessonPlanIds,
+      },
+    },
+  });
+
+  return lessonPlans.map((lp) =>
+    CompletedLessonPlanSchema.parse(lp.lessonPlan),
+  );
+}

--- a/packages/rag/index.ts
+++ b/packages/rag/index.ts
@@ -1,2 +1,3 @@
 export { getRelevantLessonPlans } from "./getRelevantLessonPlans/getRelevantLessonPlans";
+export { getRagLessonPlansByIds } from "./getRagLessonPlansByIds/getRagLessonPlansByIds";
 export { parseSubjectsForRagSearch } from "./utils/parseSubjectsForRagSearch";


### PR DESCRIPTION
## Description

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to https://oak-ai-lesson-assistant-nlkirxqw4.vercel-preview.thenational.academy
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
