### PR TITLE
build: release candidate

### DIFF
--- a/apps/nextjs/src/app/admin/components/SharedAdminLayout.tsx
+++ b/apps/nextjs/src/app/admin/components/SharedAdminLayout.tsx
@@ -1,0 +1,31 @@
+"use client";
+
+import { OakMaxWidth } from "@oaknational/oak-components";
+
+import Layout from "@/components/AppComponents/Layout";
+
+interface SharedAdminLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function SharedAdminLayout({
+  children,
+}: Readonly<SharedAdminLayoutProps>) {
+  return (
+    <div className="relative flex h-full overflow-hidden">
+      <div className="group w-full overflow-auto pl-0 duration-300 ease-in-out animate-in peer-[[data-state=open]]:lg:pl-[250px] peer-[[data-state=open]]:xl:pl-[300px]">
+        <Layout>
+          <div className="mt-27">
+            <OakMaxWidth
+              $maxWidth={["all-spacing-21", "all-spacing-24"]}
+              $pa="inner-padding-m"
+              $ph={["inner-padding-none", "inner-padding-s"]}
+            >
+              {children}
+            </OakMaxWidth>
+          </div>
+        </Layout>
+      </div>
+    </div>
+  );
+}

--- a/apps/nextjs/src/app/admin/fixtures/safetyViolations.fixture.ts
+++ b/apps/nextjs/src/app/admin/fixtures/safetyViolations.fixture.ts
@@ -1,0 +1,56 @@
+import type { SafetyViolation } from "@oakai/db";
+
+// Mock user IDs
+export const userIds = {
+  withViolations: "user_2nQuq4jFWLfo4w1WNA6xEBp93IY",
+  clean: "user_clean123456789",
+};
+
+// Mock safety violations for stories and tests
+export const mockSafetyViolations: SafetyViolation[] = [
+  {
+    id: "sv654k0a50007tf413jc6po5f",
+    createdAt: new Date("2025-01-20T14:11:26.957Z"),
+    updatedAt: new Date("2025-01-20T14:11:26.957Z"),
+    userId: userIds.withViolations,
+    userAction: "CHAT_MESSAGE",
+    detectionSource: "MODERATION",
+    recordType: "MODERATION",
+    recordId: "cm654k0a50007tf413jc6po5f",
+  },
+  {
+    id: "sv654iz8z0003tf41e42karvo",
+    createdAt: new Date("2025-01-20T14:10:38.963Z"),
+    updatedAt: new Date("2025-01-20T14:10:38.963Z"),
+    userId: userIds.withViolations,
+    userAction: "CHAT_MESSAGE",
+    detectionSource: "HELICONE",
+    recordType: "CHAT_SESSION",
+    recordId: "chat_654ito20001tf41k2fbjeu6",
+  },
+  {
+    id: "sv654iz8z0004tf41e42karvp",
+    createdAt: new Date("2025-01-20T14:09:38.963Z"),
+    updatedAt: new Date("2025-01-20T14:09:38.963Z"),
+    userId: userIds.withViolations,
+    userAction: "QUIZ_GENERATION",
+    detectionSource: "OPENAI",
+    recordType: "GENERATION",
+    recordId: "gen_654ito20001tf41k2fbjeu7",
+  },
+  {
+    id: "sv654iz8z0005tf41e42karvq",
+    createdAt: new Date("2025-01-20T14:08:38.963Z"),
+    updatedAt: new Date("2025-01-20T14:08:38.963Z"),
+    userId: userIds.withViolations,
+    userAction: "CHAT_MESSAGE",
+    detectionSource: "THREAT",
+    recordType: "CHAT_SESSION",
+    recordId: "chat_654ito20001tf41k2fbjeu8",
+  },
+];
+
+// Mock function for refetching safety violations in stories
+export const mockRefetchSafetyViolations = () => {
+  return null;
+};

--- a/apps/nextjs/src/app/admin/users/[userId]/layout.tsx
+++ b/apps/nextjs/src/app/admin/users/[userId]/layout.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import SharedAdminLayout from "../../components/SharedAdminLayout";
+
+interface UserLayoutProps {
+  children: React.ReactNode;
+}
+
+export default function UserLayout({ children }: Readonly<UserLayoutProps>) {
+  return <SharedAdminLayout>{children}</SharedAdminLayout>;
+}

--- a/apps/nextjs/src/app/admin/users/[userId]/page.tsx
+++ b/apps/nextjs/src/app/admin/users/[userId]/page.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import { aiLogger } from "@oakai/logger";
+
+import LoadingWheel from "@/components/LoadingWheel";
+import { trpc } from "@/utils/trpc";
+
+import { AdminUserView } from "./view";
+
+interface AdminUserProps {
+  params: {
+    userId: string;
+  };
+}
+
+const log = aiLogger("admin");
+
+export default function AdminUser({ params }: Readonly<AdminUserProps>) {
+  const { userId } = params;
+  const {
+    data: safetyViolations,
+    isLoading: isSafetyViolationsLoading,
+    refetch,
+  } = trpc.admin.getSafetyViolationsForUser.useQuery({
+    userId,
+  });
+
+  if (isSafetyViolationsLoading) {
+    return <LoadingWheel />;
+  }
+
+  log.info("chat", safetyViolations);
+
+  if (!safetyViolations) {
+    return <div>No safety violations found</div>;
+  }
+
+  return (
+    <AdminUserView
+      userId={userId}
+      safetyViolations={safetyViolations}
+      refetchSafetyViolations={() => void refetch()}
+    />
+  );
+}

--- a/apps/nextjs/src/app/admin/users/[userId]/view.stories.tsx
+++ b/apps/nextjs/src/app/admin/users/[userId]/view.stories.tsx
@@ -1,0 +1,37 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { chromaticParams } from "@/storybook/chromatic";
+
+import {
+  mockRefetchSafetyViolations,
+  mockSafetyViolations,
+  userIds,
+} from "../../fixtures/safetyViolations.fixture";
+import { AdminUserView } from "./view";
+
+const meta = {
+  title: "Pages/Admin/Users/[userId]/View",
+  component: AdminUserView,
+  parameters: {
+    ...chromaticParams(["desktop"]),
+  },
+} satisfies Meta<typeof AdminUserView>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    userId: userIds.withViolations,
+    safetyViolations: mockSafetyViolations,
+    refetchSafetyViolations: mockRefetchSafetyViolations,
+  },
+};
+
+export const WithNoViolations: Story = {
+  args: {
+    userId: userIds.clean,
+    safetyViolations: [],
+    refetchSafetyViolations: mockRefetchSafetyViolations,
+  },
+};

--- a/apps/nextjs/src/app/admin/users/[userId]/view.tsx
+++ b/apps/nextjs/src/app/admin/users/[userId]/view.tsx
@@ -1,0 +1,107 @@
+import { toast } from "react-hot-toast";
+
+import type { SafetyViolation } from "@oakai/db";
+
+import { OakPrimaryButton } from "@oaknational/oak-components";
+import * as Sentry from "@sentry/nextjs";
+
+import { trpc } from "@/utils/trpc";
+
+function SafetyViolationsListItem({
+  safetyViolation,
+  refetch,
+}: {
+  readonly safetyViolation: SafetyViolation;
+  refetch: () => void;
+}) {
+  const { id, detectionSource, recordId, recordType } = safetyViolation;
+  const removeSafetyViolation =
+    trpc.admin.removeSafetyViolationById.useMutation({
+      onSuccess: () => {
+        toast.success("Safety violation removed");
+        refetch();
+      },
+      onError: (err) => {
+        toast.error("Error invalidating moderation");
+        Sentry.captureException(err);
+      },
+    });
+
+  const invalidateModeration = trpc.admin.invalidateModeration.useMutation({
+    onSuccess: () => {
+      toast.success("Moderation invalidated");
+      refetch();
+    },
+    onError: (err) => {
+      toast.error("Error invalidating moderation");
+      Sentry.captureException(err);
+    },
+  });
+
+  return (
+    <li className={`rounded-md border p-8 shadow-sm`}>
+      <div className="flex w-full items-start justify-between">
+        <div className="flex w-full items-start space-y-8">
+          <p className="font-medium capitalize">
+            Source: {detectionSource}
+            <br />
+            Record type: {recordType}
+            <br />
+            Record ID: {recordId}
+          </p>
+          {recordType === "MODERATION" ? (
+            <OakPrimaryButton
+              iconName="cross"
+              className="ml-auto"
+              onClick={() =>
+                void invalidateModeration.mutateAsync({
+                  moderationId: recordId,
+                })
+              }
+              isLoading={invalidateModeration.isLoading}
+            >
+              Invalidate moderation
+            </OakPrimaryButton>
+          ) : (
+            <OakPrimaryButton
+              iconName="cross"
+              className="ml-auto"
+              onClick={() => void removeSafetyViolation.mutateAsync({ id })}
+              isLoading={removeSafetyViolation.isLoading}
+            >
+              Delete safety violation
+            </OakPrimaryButton>
+          )}
+        </div>
+      </div>
+    </li>
+  );
+}
+
+export function AdminUserView({
+  userId,
+  safetyViolations,
+  refetchSafetyViolations,
+}: {
+  readonly userId: string;
+  readonly safetyViolations: SafetyViolation[];
+  readonly refetchSafetyViolations: () => void;
+}) {
+  return (
+    <>
+      <h1 className="mb-18">User: {userId}</h1>
+      <h2 className="mb-4 text-2xl font-bold">Safety violations</h2>
+      <ul className="mb-18 space-y-4">
+        {safetyViolations.map((safetyViolation) => {
+          return (
+            <SafetyViolationsListItem
+              key={safetyViolation.id}
+              safetyViolation={safetyViolation}
+              refetch={refetchSafetyViolations}
+            />
+          );
+        })}
+      </ul>
+    </>
+  );
+}

--- a/apps/nextjs/src/app/aila/resources/resources-contents.tsx
+++ b/apps/nextjs/src/app/aila/resources/resources-contents.tsx
@@ -3,6 +3,7 @@
 import type { FC } from "react";
 import React, { useEffect } from "react";
 
+import { getResourceType } from "@oakai/additional-materials/src/documents/additionalMaterials/resourceTypes";
 import { kebabCaseToSentenceCase } from "@oakai/core/src/utils/camelCaseConversion";
 
 import { OakP, OakSpan } from "@oaknational/oak-components";
@@ -36,14 +37,17 @@ const ResourcesContentsInner: FC<AdditionalMaterialsUserProps> = () => {
   const stepNumber = useResourcesStore(stepNumberSelector);
   const pageData = useResourcesStore(pageDataSelector);
   const docType = useResourcesStore(docTypeSelector);
-  const docTypeName = docType?.split("-")[1] ?? null;
+
+  // Get resource type information from configuration
+  const resourceType = docType ? getResourceType(docType) : null;
+  const docTypeName = resourceType?.displayName || null;
   const { resetFormState } = useResourcesActions();
 
   useEffect(() => {
     resetFormState();
   }, [resetFormState]);
 
-  const titleAreaControl = {
+  const titleAreaContent = {
     0: {
       title: "What do you want to teach?",
       subTitle: (
@@ -79,15 +83,15 @@ const ResourcesContentsInner: FC<AdditionalMaterialsUserProps> = () => {
     1: <StepTwo />,
     2: <StepThree />,
   };
-  const stepNumberParsed = stepNumber as keyof typeof titleAreaControl;
-  const title = titleAreaControl?.[stepNumberParsed]?.title ?? "";
-  const subTitle = titleAreaControl?.[stepNumberParsed]?.subTitle ?? "";
+  const stepNumberParsed = stepNumber as keyof typeof titleAreaContent;
+  const title = titleAreaContent?.[stepNumberParsed]?.title ?? "";
+  const subTitle = titleAreaContent?.[stepNumberParsed]?.subTitle ?? "";
   return (
     <ResourcesLayout
       title={title}
       subTitle={subTitle}
       step={stepNumber + 1}
-      docTypeName={docTypeName}
+      docTypeName={docTypeName || ""}
     >
       {stepComponents[stepNumber]}
     </ResourcesLayout>

--- a/apps/nextjs/src/app/aila/resources/resources-contents.tsx
+++ b/apps/nextjs/src/app/aila/resources/resources-contents.tsx
@@ -11,6 +11,9 @@ import { OakP, OakSpan } from "@oaknational/oak-components";
 import StepOne from "@/components/AppComponents/AdditionalMaterials/StepLayouts/StepOne";
 import StepThree from "@/components/AppComponents/AdditionalMaterials/StepLayouts/StepThree";
 import StepTwo from "@/components/AppComponents/AdditionalMaterials/StepLayouts/StepTwo";
+import { DialogProvider } from "@/components/AppComponents/DialogContext";
+import DialogContents from "@/components/DialogControl/DialogContents";
+import { DialogRoot } from "@/components/DialogControl/DialogRoot";
 import ResourcesLayout from "@/components/ResroucesLayout";
 import {
   ResourcesStoresProvider,
@@ -101,7 +104,12 @@ const ResourcesContentsInner: FC<AdditionalMaterialsUserProps> = () => {
 const ResourcesContents: FC<AdditionalMaterialsUserProps> = (props) => {
   return (
     <ResourcesStoresProvider>
-      <ResourcesContentsInner {...props} />
+      <DialogProvider>
+        <DialogRoot>
+          <DialogContents chatId={undefined} lesson={{}} submit={() => {}} />
+          <ResourcesContentsInner {...props} />
+        </DialogRoot>
+      </DialogProvider>
     </ResourcesStoresProvider>
   );
 };

--- a/apps/nextjs/src/app/api/chat/chatHandler.ts
+++ b/apps/nextjs/src/app/api/chat/chatHandler.ts
@@ -26,6 +26,8 @@ import { captureException } from "@sentry/nextjs";
 import type { NextRequest } from "next/server";
 import invariant from "tiny-invariant";
 
+import { serverSideFeatureFlag } from "@/utils/serverSideFeatureFlag";
+
 import type { Config } from "./config";
 import { handleChatException } from "./errorHandling";
 import {
@@ -60,12 +62,15 @@ async function setupChatHandler(req: NextRequest) {
         options?: AilaPublicChatOptions;
       } = json;
 
+      const useAgenticAila = await serverSideFeatureFlag("agentic-aila-may-25");
+
       const options: AilaOptions = {
         useRag: chatOptions.useRag ?? true,
         temperature: chatOptions.temperature ?? 0.7,
         numberOfRecordsInRag: chatOptions.numberOfRecordsInRag ?? 5,
         usePersistence: true,
         useModeration: true,
+        useAgenticAila,
       };
 
       const llmService = getFixtureLLMService(req.headers, chatId);

--- a/apps/nextjs/src/app/api/chat/route.test.ts
+++ b/apps/nextjs/src/app/api/chat/route.test.ts
@@ -17,6 +17,11 @@ jest.mock("./user", () => ({
   fetchAndCheckUser: jest.fn().mockResolvedValue("test-user-id"),
 }));
 
+// Mock the serverSideFeatureFlag module
+jest.mock("@/utils/serverSideFeatureFlag", () => ({
+  serverSideFeatureFlag: jest.fn().mockResolvedValue(false),
+}));
+
 describe("Chat API Route", () => {
   let testConfig: Config;
   let mockLLMService: MockLLMService;

--- a/apps/nextjs/src/components/AppComponents/AdditionalMaterials/AdditionalMaterialMessage.tsx
+++ b/apps/nextjs/src/components/AppComponents/AdditionalMaterials/AdditionalMaterialMessage.tsx
@@ -1,0 +1,28 @@
+import { OakFlex, OakLink, OakP } from "@oaknational/oak-components";
+
+import { Icon } from "@/components/Icon";
+
+import { Message } from "../Chat/chat-message/layout";
+import { useDialog } from "../DialogContext";
+
+export function ModerationMessage() {
+  const { setDialogWindow } = useDialog();
+  return (
+    <Message.Container roleType="moderation">
+      <Message.Content>
+        <OakFlex className="flex items-center">
+          <Icon icon="warning" size="sm" className="mr-6" />
+          <OakP $font={"body-2"}>
+            {`This content may need additional guidance. `}
+            <OakLink
+              onClick={() => setDialogWindow("additional-materials-moderation")}
+              color={"primary"}
+            >
+              Click here for guidance details.
+            </OakLink>
+          </OakP>
+        </OakFlex>
+      </Message.Content>
+    </Message.Container>
+  );
+}

--- a/apps/nextjs/src/components/AppComponents/AdditionalMaterials/ExitQuiz.tsx
+++ b/apps/nextjs/src/components/AppComponents/AdditionalMaterials/ExitQuiz.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+
+import type { ExitQuiz as ExitQuizType } from "@oakai/additional-materials/src/documents/additionalMaterials/exitQuiz/schema";
+
+import { OakBox, OakFlex, OakP, OakSpan } from "@oaknational/oak-components";
+
+type ExitQuizProps = {
+  action: string;
+  generation: ExitQuizType;
+};
+
+export const ExitQuiz = ({ action, generation }: ExitQuizProps) => {
+  return (
+    <OakFlex $flexDirection={"column"} $width={"100%"}>
+      <OakP $font="heading-6">Exit Quiz</OakP>
+      <OakP $mb="space-between-s">
+        {generation.year} • {generation.subject} • {generation.title}
+      </OakP>
+
+      {generation.questions.map((question, questionIndex) => (
+        <OakBox key={questionIndex} $mb="space-between-m">
+          <OakP $font="heading-7">
+            {questionIndex + 1}. {question.question}
+          </OakP>
+          <OakBox $mt="space-between-xs" />
+
+          {question.options.map((option, optionIndex) => {
+            const letter = String.fromCharCode(97 + optionIndex); // a, b, c
+
+            return (
+              <OakFlex
+                key={optionIndex}
+                $alignItems="flex-start"
+                $mb="space-between-xs"
+              >
+                <OakSpan $font="body-3-bold" $mr="space-between-xs">
+                  {letter}.
+                </OakSpan>
+                <OakFlex $flexDirection="column">
+                  <OakP $font="body-3">
+                    {option.text}
+                    {option.isCorrect && <OakSpan $color="mint"> ✓</OakSpan>}
+                  </OakP>
+                </OakFlex>
+              </OakFlex>
+            );
+          })}
+        </OakBox>
+      ))}
+    </OakFlex>
+  );
+};

--- a/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StarterQuiz.tsx
+++ b/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StarterQuiz.tsx
@@ -1,0 +1,52 @@
+import React from "react";
+
+import type { StarterQuiz as StarterQuizType } from "@oakai/additional-materials/src/documents/additionalMaterials/starterQuiz/schema";
+
+import { OakBox, OakFlex, OakP, OakSpan } from "@oaknational/oak-components";
+
+type StarterQuizProps = {
+  action: string;
+  generation: StarterQuizType;
+};
+
+export const StarterQuiz = ({ action, generation }: StarterQuizProps) => {
+  return (
+    <OakFlex $flexDirection={"column"} $width={"100%"}>
+      <OakP $font="heading-6">Starter Quiz</OakP>
+      <OakP $mb="space-between-s">
+        {generation.year} • {generation.subject} • {generation.title}
+      </OakP>
+
+      {generation.questions.map((question, questionIndex) => (
+        <OakBox key={questionIndex} $mb="space-between-m">
+          <OakP $font="heading-7">
+            {questionIndex + 1}. {question.question}
+          </OakP>
+          <OakBox $mt="space-between-xs" />
+
+          {question.options.map((option, optionIndex) => {
+            const letter = String.fromCharCode(97 + optionIndex); // a, b, c
+
+            return (
+              <OakFlex
+                key={optionIndex}
+                $alignItems="flex-start"
+                $mb="space-between-xs"
+              >
+                <OakSpan $font="body-3-bold" $mr="space-between-xs">
+                  {letter}.
+                </OakSpan>
+                <OakFlex $flexDirection="column">
+                  <OakP $font="body-3">
+                    {option.text}
+                    {option.isCorrect && <OakSpan $color="mint"> ✓</OakSpan>}
+                  </OakP>
+                </OakFlex>
+              </OakFlex>
+            );
+          })}
+        </OakBox>
+      ))}
+    </OakFlex>
+  );
+};

--- a/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StepLayouts/StepOne.tsx
+++ b/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StepLayouts/StepOne.tsx
@@ -1,5 +1,7 @@
 import { useEffect } from "react";
 
+import { getResourceTypes } from "@oakai/additional-materials/src/documents/additionalMaterials/resourceTypes";
+
 import {
   OakFlex,
   OakIcon,
@@ -79,6 +81,10 @@ const StepOne = () => {
       },
     });
 
+  const resourceTypes = getResourceTypes().filter(
+    (resourceType) => resourceType.isAvailable,
+  );
+
   return (
     <>
       <OakFlex $flexDirection={"column"} $gap={"space-between-m"}>
@@ -112,47 +118,28 @@ const StepOne = () => {
               }}
               $flexDirection="column"
             >
-              <OakLabel>
-                <OakRadioButton
-                  id="additional-glossary"
-                  value="additional-glossary"
-                  radioInnerSize="all-spacing-6"
-                  radioOuterSize="all-spacing-7"
-                  label={
-                    <OakFlex
-                      $flexDirection="column"
-                      $gap="all-spacing-2"
-                      $ml="space-between-xs"
-                    >
-                      <OakP $font="heading-6">Glossary</OakP>
-                      <OakP>
-                        Additional lesson vocabulary with pupil friendly
-                        definitions
-                      </OakP>
-                    </OakFlex>
-                  }
-                />
-              </OakLabel>
-              <OakLabel>
-                <OakRadioButton
-                  id="additional-comprehension"
-                  value="additional-comprehension"
-                  radioInnerSize="all-spacing-6"
-                  radioOuterSize="all-spacing-7"
-                  label={
-                    <OakFlex
-                      $flexDirection="column"
-                      $gap="all-spacing-2"
-                      $ml="space-between-xs"
-                    >
-                      <OakP $font="heading-6">Comprehension tasks</OakP>
-                      <OakP>
-                        Comprehension tasks which can be adapted for pupils
-                      </OakP>
-                    </OakFlex>
-                  }
-                />
-              </OakLabel>
+              {resourceTypes.map((resourceType) => (
+                <OakLabel key={resourceType.id}>
+                  <OakRadioButton
+                    id={resourceType.id}
+                    value={resourceType.id}
+                    radioInnerSize="all-spacing-6"
+                    radioOuterSize="all-spacing-7"
+                    label={
+                      <OakFlex
+                        $flexDirection="column"
+                        $gap="all-spacing-2"
+                        $ml="space-between-xs"
+                      >
+                        <OakP $font="heading-6">
+                          {resourceType.displayName}
+                        </OakP>
+                        <OakP>{resourceType.description}</OakP>
+                      </OakFlex>
+                    }
+                  />
+                </OakLabel>
+              ))}
             </OakRadioGroup>
           </OakFlex>
         </OakFlex>

--- a/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StepLayouts/StepOne.tsx
+++ b/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StepLayouts/StepOne.tsx
@@ -26,6 +26,7 @@ import {
 } from "@/stores/resourcesStore/selectors";
 import { trpc } from "@/utils/trpc";
 
+import { useDialog } from "../../DialogContext";
 import { SubjectsDropDown, YearGroupDropDown } from "../DropDownButtons";
 import ResourcesFooter from "../ResourcesFooter";
 
@@ -46,7 +47,7 @@ const StepOne = () => {
     setYear,
     setActiveDropdown,
   } = useResourcesActions();
-
+  const { setDialogWindow } = useDialog();
   const subject = useResourcesStore(subjectSelector);
   const title = useResourcesStore(titleSelector);
   const year = useResourcesStore(yearSelector);

--- a/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StepLayouts/StepThree.tsx
+++ b/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StepLayouts/StepThree.tsx
@@ -1,11 +1,16 @@
 import { useState } from "react";
 
 import { isComprehensionTask } from "@oakai/additional-materials/src/documents/additionalMaterials/comprehension/schema";
+import { isExitQuiz } from "@oakai/additional-materials/src/documents/additionalMaterials/exitQuiz/schema";
 import {
   isGlossary,
   readingAgeRefinement,
 } from "@oakai/additional-materials/src/documents/additionalMaterials/glossary/schema";
-import { camelCaseToSentenceCase } from "@oakai/core/src/utils/camelCaseConversion";
+import {
+  type RefinementOption,
+  getResourceType,
+} from "@oakai/additional-materials/src/documents/additionalMaterials/resourceTypes";
+import { isStarterQuiz } from "@oakai/additional-materials/src/documents/additionalMaterials/starterQuiz/schema";
 import { aiLogger } from "@oakai/logger";
 
 import {
@@ -31,7 +36,9 @@ import {
 import { trpc } from "@/utils/trpc";
 
 import { ComprehensionTask } from "../../AdditionalMaterials/ComprehensionTask";
+import { ExitQuiz } from "../../AdditionalMaterials/ExitQuiz";
 import { Glossary } from "../../AdditionalMaterials/Glossary";
+import { StarterQuiz } from "../../AdditionalMaterials/StarterQuiz";
 import InlineButton from "../InlineButton";
 import ResourcesFooter from "../ResourcesFooter";
 
@@ -50,6 +57,9 @@ const StepThree = () => {
   const fetchMaterial =
     trpc.additionalMaterials.generateAdditionalMaterial.useMutation();
 
+  // Get resource type from configuration
+  const resourceType = docType ? getResourceType(docType) : null;
+  const refinementOptions = resourceType?.refinementOptions || [];
   const handleDownloadMaterial = async () => {
     if (!generation || !docType) {
       return;
@@ -92,14 +102,20 @@ const StepThree = () => {
       return <ComprehensionTask action={docType} generation={generation} />;
     }
 
+    if (docType === "additional-starter-quiz" && isStarterQuiz(generation)) {
+      return <StarterQuiz action={docType} generation={generation} />;
+    }
+
+    if (docType === "additional-exit-quiz" && isExitQuiz(generation)) {
+      return <ExitQuiz action={docType} generation={generation} />;
+    }
+
     return null;
   };
 
-  const refinementOptions = getRefinementOptions();
-
   return (
     <>
-      {isResourcesLoading && <OakP>Loading...</OakP>}
+      {isResourcesLoading || (!generation && <OakP>Loading...</OakP>)}
       <OakFlex $mt={"space-between-m"}>{renderGeneratedMaterial()}</OakFlex>
       <ResourcesFooter>
         {isFooterAdaptOpen ? (
@@ -114,12 +130,12 @@ const StepThree = () => {
             </button>
 
             <OakFlex $gap="all-spacing-2" $flexWrap="wrap">
-              {refinementOptions.map((refinement) => (
+              {refinementOptions.map((refinement: RefinementOption) => (
                 <InlineButton
-                  key={refinement}
+                  key={refinement.id}
                   onClick={() => {
                     void refineMaterial({
-                      refinement: [{ type: refinement }],
+                      refinement: [{ type: refinement.value }],
                       mutateAsync: async (input) => {
                         try {
                           return await fetchMaterial.mutateAsync(input);
@@ -133,7 +149,7 @@ const StepThree = () => {
                     setIsFooterAdaptOpen(false);
                   }}
                 >
-                  {camelCaseToSentenceCase(refinement as string)}
+                  {refinement.label}
                 </InlineButton>
               ))}
             </OakFlex>
@@ -159,7 +175,7 @@ const StepThree = () => {
                 iconName="download"
                 isTrailingIcon={true}
                 isLoading={isDownloading}
-                disabled={!generation}
+                disabled={!generation || isResourcesLoading}
               >
                 Download (.zip)
               </OakPrimaryButton>

--- a/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StepLayouts/StepThree.tsx
+++ b/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StepLayouts/StepThree.tsx
@@ -2,10 +2,7 @@ import { useState } from "react";
 
 import { isComprehensionTask } from "@oakai/additional-materials/src/documents/additionalMaterials/comprehension/schema";
 import { isExitQuiz } from "@oakai/additional-materials/src/documents/additionalMaterials/exitQuiz/schema";
-import {
-  isGlossary,
-  readingAgeRefinement,
-} from "@oakai/additional-materials/src/documents/additionalMaterials/glossary/schema";
+import { isGlossary } from "@oakai/additional-materials/src/documents/additionalMaterials/glossary/schema";
 import {
   type RefinementOption,
   getResourceType,
@@ -32,6 +29,7 @@ import {
   generationSelector,
   isResourcesDownloadingSelector,
   isResourcesLoadingSelector,
+  moderationSelector,
 } from "@/stores/resourcesStore/selectors";
 import { trpc } from "@/utils/trpc";
 
@@ -39,6 +37,7 @@ import { ComprehensionTask } from "../../AdditionalMaterials/ComprehensionTask";
 import { ExitQuiz } from "../../AdditionalMaterials/ExitQuiz";
 import { Glossary } from "../../AdditionalMaterials/Glossary";
 import { StarterQuiz } from "../../AdditionalMaterials/StarterQuiz";
+import { ModerationMessage } from "../AdditionalMaterialMessage";
 import InlineButton from "../InlineButton";
 import ResourcesFooter from "../ResourcesFooter";
 
@@ -50,6 +49,7 @@ const StepThree = () => {
   const docType = useResourcesStore(docTypeSelector);
   const isResourcesLoading = useResourcesStore(isResourcesLoadingSelector);
   const { setStepNumber, refineMaterial } = useResourcesActions();
+  const moderation = useResourcesStore(moderationSelector);
   const [isFooterAdaptOpen, setIsFooterAdaptOpen] = useState(false);
   const { downloadMaterial, setIsResourceDownloading } = useResourcesActions();
   const isDownloading = useResourcesStore(isResourcesDownloadingSelector);
@@ -72,18 +72,6 @@ const StepThree = () => {
     } finally {
       setIsResourceDownloading(false);
     }
-  };
-
-  const getRefinementOptions = () => {
-    if (docType === "additional-glossary") {
-      return readingAgeRefinement;
-    }
-
-    if (docType === "additional-comprehension") {
-      return [];
-    }
-
-    return [];
   };
 
   const renderGeneratedMaterial = () => {
@@ -116,6 +104,10 @@ const StepThree = () => {
   return (
     <>
       {isResourcesLoading || (!generation && <OakP>Loading...</OakP>)}
+
+      {moderation?.categories && moderation.categories.length > 0 && (
+        <ModerationMessage />
+      )}
       <OakFlex $mt={"space-between-m"}>{renderGeneratedMaterial()}</OakFlex>
       <ResourcesFooter>
         {isFooterAdaptOpen ? (

--- a/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StepLayouts/StepTwo.tsx
+++ b/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StepLayouts/StepTwo.tsx
@@ -24,11 +24,15 @@ import {
 import {
   docTypeSelector,
   isLoadingLessonPlanSelector,
+  moderationSelector,
   pageDataSelector,
+  threatDetectionSelector,
 } from "@/stores/resourcesStore/selectors";
 import { trpc } from "@/utils/trpc";
 
 import { MemoizedReactMarkdownWithStyles } from "../../Chat/markdown";
+import { useDialog } from "../../DialogContext";
+import { ModerationMessage } from "../AdditionalMaterialMessage";
 import ResourcesFooter from "../ResourcesFooter";
 
 export function mapLessonPlanSections(
@@ -42,8 +46,11 @@ const log = aiLogger("additional-materials");
 const StepTwo = () => {
   const pageData = useResourcesStore(pageDataSelector);
   const docType = useResourcesStore(docTypeSelector);
-
+  const moderation = useResourcesStore(moderationSelector);
   const isLoadingLessonPlan = useResourcesStore(isLoadingLessonPlanSelector);
+  const threatDetected = useResourcesStore(threatDetectionSelector);
+
+  const { setDialogWindow } = useDialog();
 
   // Get resource type from configuration
   const resourceType = docType ? getResourceType(docType) : null;
@@ -55,31 +62,26 @@ const StepTwo = () => {
   const fetchMaterial =
     trpc.additionalMaterials.generateAdditionalMaterial.useMutation();
 
-  const handleSubmit = (message) => {
-    const generatePromise = generateMaterial({
-      message,
+  const handleSubmit = () => {
+    void generateMaterial({
       mutateAsync: async (input) => {
         try {
-          return fetchMaterial.mutateAsync(input);
-        } catch (error) {
-          throw error instanceof Error ? error : new Error(String(error));
+          return await fetchMaterial.mutateAsync(input);
+        } catch (e) {
+          const error = e instanceof Error ? e : new Error(String(e));
+          Sentry.captureException(error);
+
+          throw error;
         }
       },
     });
-
-    // Navigate to the next step
-    generatePromise
-      .then(() => setStepNumber(2))
-      .catch((error) => {
-        log.error("Failed to generate material", error);
-        Sentry.captureException(error);
-      });
-
-    return generatePromise;
   };
 
   if (isLoadingLessonPlan) {
     return <OakP>Building lesson plan...</OakP>;
+  }
+  if (threatDetected) {
+    setDialogWindow("additional-materials-threat-detected");
   }
 
   return (
@@ -87,6 +89,9 @@ const StepTwo = () => {
       <OakFlex $flexDirection="column">
         <OakFlex $flexDirection="column" $mb="space-between-m">
           <OakP $font={"heading-5"}>Task details</OakP>
+          {moderation?.categories && moderation.categories.length > 0 && (
+            <ModerationMessage />
+          )}
 
           <OakBox $pv="inner-padding-m">
             <OakP>
@@ -135,7 +140,7 @@ const StepTwo = () => {
 
           <OakPrimaryButton
             onClick={() => {
-              void handleSubmit("Create a lesson plan for this lesson");
+              void handleSubmit();
               setStepNumber(2);
               return null;
             }}

--- a/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StepLayouts/StepTwo.tsx
+++ b/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StepLayouts/StepTwo.tsx
@@ -1,3 +1,4 @@
+import { getResourceType } from "@oakai/additional-materials/src/documents/additionalMaterials/resourceTypes";
 import { lessonFieldKeys } from "@oakai/additional-materials/src/documents/partialLessonPlan/schema";
 import type { AilaPersistedChat } from "@oakai/aila/src/protocol/schema";
 import { sectionToMarkdown } from "@oakai/aila/src/protocol/sectionToMarkdown";
@@ -43,7 +44,12 @@ const StepTwo = () => {
   const docType = useResourcesStore(docTypeSelector);
 
   const isLoadingLessonPlan = useResourcesStore(isLoadingLessonPlanSelector);
-  const docTypeName = docType?.split("-")[1] ?? null;
+
+  // Get resource type from configuration
+  const resourceType = docType ? getResourceType(docType) : null;
+  const docTypeName = resourceType
+    ? resourceType.displayName.toLowerCase()
+    : null;
 
   const { setStepNumber, generateMaterial } = useResourcesActions();
   const fetchMaterial =

--- a/apps/nextjs/src/components/AppComponents/Chat/AiSdk.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/AiSdk.tsx
@@ -17,7 +17,6 @@ import {
   useChatActions,
   useChatStore,
   useLessonPlanActions,
-  useLessonPlanStore,
 } from "@/stores/AilaStoresProvider";
 
 import { findMessageIdFromContent } from "./Chat/utils";
@@ -50,7 +49,6 @@ export function AiSdk({ id }: Readonly<AiSdkProps>) {
   const path = usePathname();
 
   const initialMessages = useChatStore((state) => state.initialMessages);
-  const lessonPlan = useLessonPlanStore((state) => state.lessonPlan);
   const chatActions = useChatActions();
   const lessonPlanActions = useLessonPlanActions();
 

--- a/apps/nextjs/src/components/AppComponents/Chat/Chat/types.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/Chat/types.ts
@@ -7,4 +7,6 @@ export type DialogTypes =
   | "demo-interstitial"
   | "demo-share-locked"
   | "clear-history"
-  | "clear-single-chat";
+  | "clear-single-chat"
+  | "additional-materials-moderation"
+  | "additional-materials-threat-detected";

--- a/apps/nextjs/src/components/DialogControl/ContentOptions/AdditionalMaterialsModeration.tsx
+++ b/apps/nextjs/src/components/DialogControl/ContentOptions/AdditionalMaterialsModeration.tsx
@@ -1,0 +1,39 @@
+import { OakFlex, OakP } from "@oaknational/oak-components";
+
+import { useResourcesStore } from "@/stores/ResourcesStoreProvider";
+import { moderationSelector } from "@/stores/resourcesStore/selectors";
+
+import ModalFooterButtons from "./ModalFooterButtons";
+
+type AdditionalMaterialsModerationProps = {
+  closeDialog: () => void;
+};
+
+const AdditionalMaterialsModeration = ({
+  closeDialog,
+}: Readonly<AdditionalMaterialsModerationProps>) => {
+  const moderation = useResourcesStore(moderationSelector);
+  return (
+    <OakFlex
+      data-testid="chat-share-dialog"
+      $width="100%"
+      $height="100%"
+      $flexDirection="column"
+      $justifyContent="space-between"
+    >
+      <OakP>
+        This content that needs additional guidance. Please check carefully
+        before using. Learn more about moderation and content guidelines.
+      </OakP>
+      {moderation?.categories.map((category) => <OakP>{category}</OakP>)}
+
+      <ModalFooterButtons
+        closeDialog={closeDialog}
+        // TODO: Add action button states
+        actionButtonStates={() => <OakP>Submit</OakP>}
+      />
+    </OakFlex>
+  );
+};
+
+export default AdditionalMaterialsModeration;

--- a/apps/nextjs/src/components/DialogControl/ContentOptions/AdditionalMaterialsThreatDetected.tsx
+++ b/apps/nextjs/src/components/DialogControl/ContentOptions/AdditionalMaterialsThreatDetected.tsx
@@ -1,0 +1,35 @@
+import { OakFlex, OakP, OakPrimaryButton } from "@oaknational/oak-components";
+
+import { useResourcesActions } from "@/stores/ResourcesStoreProvider";
+
+type AdditionalMaterialsThreatDetectProps = {
+  closeDialog: () => void;
+};
+
+const AdditionalMaterialsThreatDetected = ({
+  closeDialog,
+}: Readonly<AdditionalMaterialsThreatDetectProps>) => {
+  const { resetToDefault } = useResourcesActions();
+  return (
+    <OakFlex
+      data-testid="chat-share-dialog"
+      $width="100%"
+      $height="100%"
+      $flexDirection="column"
+      $justifyContent="space-between"
+    >
+      <OakP>This content ..... threat detected.....</OakP>
+
+      <OakPrimaryButton
+        onClick={() => {
+          resetToDefault();
+          closeDialog();
+        }}
+      >
+        Continue
+      </OakPrimaryButton>
+    </OakFlex>
+  );
+};
+
+export default AdditionalMaterialsThreatDetected;

--- a/apps/nextjs/src/components/DialogControl/DialogContents.tsx
+++ b/apps/nextjs/src/components/DialogControl/DialogContents.tsx
@@ -10,6 +10,8 @@ import styled from "styled-components";
 
 import type { DialogTypes } from "../AppComponents/Chat/Chat/types";
 import { useDialog } from "../AppComponents/DialogContext";
+import AdditionalMaterialsModeration from "./ContentOptions/AdditionalMaterialsModeration";
+import AdditionalMaterialsThreatDetected from "./ContentOptions/AdditionalMaterialsThreatDetected";
 import ClearChatHistory from "./ContentOptions/ClearChatHistory";
 import ClearSingleChatFromChatHistory from "./ContentOptions/ClearSingleChatFromChatHistory";
 import DemoInterstitialDialog from "./ContentOptions/DemoInterstitialDialog";
@@ -53,6 +55,14 @@ const dialogTitlesAndIcons: Record<
   "clear-single-chat": {
     title: "Are you absolutely sure?",
     iconName: null,
+  },
+  "additional-materials-moderation": {
+    title: "Guidance",
+    iconName: "warning",
+  },
+  "additional-materials-threat-detected": {
+    title: "Threat detected",
+    iconName: "warning",
   },
 };
 
@@ -126,6 +136,12 @@ const DialogContents = ({
             )}
             {dialogWindow === "clear-single-chat" && (
               <ClearSingleChatFromChatHistory closeDialog={closeDialog} />
+            )}
+            {dialogWindow === "additional-materials-moderation" && (
+              <AdditionalMaterialsModeration closeDialog={closeDialog} />
+            )}
+            {dialogWindow === "additional-materials-threat-detected" && (
+              <AdditionalMaterialsThreatDetected closeDialog={closeDialog} />
             )}
           </OakModalCenterBody>
         </OakModalAtTheFront>

--- a/apps/nextjs/src/components/Footer.tsx
+++ b/apps/nextjs/src/components/Footer.tsx
@@ -191,9 +191,10 @@ const StyledFooter = styled.footer`
 `;
 
 const StyledOakLink = styled(OakLink)`
-  text-decoration: none;
+  display: block !important;
+  text-decoration: none !important;
   &:hover {
-    text-decoration: underline;
+    text-decoration: underline !important;
   }
 `;
 

--- a/apps/nextjs/src/stores/ResourcesStoreProvider.tsx
+++ b/apps/nextjs/src/stores/ResourcesStoreProvider.tsx
@@ -1,6 +1,5 @@
 import { createContext, useContext, useState } from "react";
 
-import { nanoid } from "nanoid";
 import { type ExtractState, type StoreApi, useStore } from "zustand";
 
 import { createResourcesStore } from "./resourcesStore";
@@ -20,15 +19,14 @@ export const ResourcesStoresContext = createContext<
 
 export interface ResourcesStoresProviderProps {
   children: React.ReactNode;
-  id?: string;
 }
 
 export const ResourcesStoresProvider: React.FC<
   ResourcesStoresProviderProps
-> = ({ children, id = nanoid() }) => {
+> = ({ children }) => {
   const [stores] = useState(() => {
     const storesObj: ResourcesStores = {
-      resources: createResourcesStore({ id }),
+      resources: createResourcesStore(),
     };
     return storesObj;
   });

--- a/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleDownload.ts
+++ b/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleDownload.ts
@@ -1,13 +1,4 @@
-import {
-  type AdditionalMaterialSchemas,
-  additionalMaterialTypeEnum,
-} from "@oakai/additional-materials/src/documents/additionalMaterials/configSchema";
-import type { GenerateAdditionalMaterialInput } from "@oakai/additional-materials/src/documents/additionalMaterials/configSchema";
 import { aiLogger } from "@oakai/logger";
-
-import * as Sentry from "@sentry/nextjs";
-import type { UseMutateAsyncFunction } from "@tanstack/react-query";
-import { z } from "zod";
 
 import type { ResourcesGetter, ResourcesSetter } from "../types";
 

--- a/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleGenerateMaterial.ts
+++ b/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleGenerateMaterial.ts
@@ -36,6 +36,15 @@ export const handleGenerateMaterial =
       throw new Error("No document type selected");
     }
 
+    // Validate required lesson plan fields
+    const lessonPlan = get().pageData.lessonPlan;
+    if (!lessonPlan?.title || !lessonPlan?.subject || !lessonPlan?.keyStage) {
+      log.error("Missing required lesson plan fields", { lessonPlan });
+      throw new Error(
+        "Lesson plan is missing required fields (title, subject, or keyStage)",
+      );
+    }
+
     try {
       log.info("Generating material", { docType, hasMessage: !!message });
 
@@ -44,7 +53,12 @@ export const handleGenerateMaterial =
         documentType: docTypeParsed,
         action: message ? "refine" : "generate",
         context: {
-          lessonPlan: get().pageData.lessonPlan,
+          lessonPlan: {
+            ...lessonPlan,
+            title: lessonPlan.title,
+            subject: lessonPlan.subject,
+            keyStage: lessonPlan.keyStage,
+          },
           message: message ?? null,
           previousOutput: null,
           options: null,

--- a/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleGenerateMaterial.ts
+++ b/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleGenerateMaterial.ts
@@ -1,13 +1,10 @@
-import {
-  type AdditionalMaterialSchemas,
-  additionalMaterialTypeEnum,
-} from "@oakai/additional-materials/src/documents/additionalMaterials/configSchema";
+import { additionalMaterialTypeEnum } from "@oakai/additional-materials/src/documents/additionalMaterials/configSchema";
 import type { GenerateAdditionalMaterialInput } from "@oakai/additional-materials/src/documents/additionalMaterials/configSchema";
+import type { GenerateAdditionalMaterialResponse } from "@oakai/api/src/router/additionalMaterials/helpers";
 import { aiLogger } from "@oakai/logger";
 
 import * as Sentry from "@sentry/nextjs";
 import type { UseMutateAsyncFunction } from "@tanstack/react-query";
-import { z } from "zod";
 
 import type { ResourcesGetter, ResourcesSetter } from "../types";
 
@@ -16,7 +13,7 @@ const log = aiLogger("additional-materials");
 export type GenerateMaterialParams = {
   message?: string;
   mutateAsync: UseMutateAsyncFunction<
-    AdditionalMaterialSchemas,
+    GenerateAdditionalMaterialResponse,
     Error,
     GenerateAdditionalMaterialInput
   >;
@@ -63,13 +60,18 @@ export const handleGenerateMaterial =
           previousOutput: null,
           options: null,
         },
+        lessonId: get().pageData.lessonPlan.lessonId,
       });
       get().actions.setIsResourcesLoading(false);
       // Update the store with the result
-      get().actions.setGeneration(result);
-      log.info("Material generated successfully");
+      set({
+        generation: result.resource,
+        moderation: result.moderation,
+        id: result.resourceId,
+      });
 
-      return result;
+      log.info("Material generated successfully");
+      get().actions.setStepNumber(2);
     } catch (error) {
       log.error("Error generating material", error);
       Sentry.captureException(error);

--- a/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleRefineMaterial.ts
+++ b/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleRefineMaterial.ts
@@ -52,7 +52,7 @@ export const handleRefineMaterial =
           lessonPlan: get().pageData.lessonPlan,
           previousOutput: get().generation,
           options: null,
-          refinement: refinement,
+          refinement: [{ type: refinement }],
         },
       };
 

--- a/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleRefineMaterial.ts
+++ b/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleRefineMaterial.ts
@@ -1,9 +1,9 @@
 import {
-  type AdditionalMaterialSchemas,
   additionalMaterialTypeEnum,
   generateAdditionalMaterialInputSchema,
 } from "@oakai/additional-materials/src/documents/additionalMaterials/configSchema";
 import type { GenerateAdditionalMaterialInput } from "@oakai/additional-materials/src/documents/additionalMaterials/configSchema";
+import type { GenerateAdditionalMaterialResponse } from "@oakai/api/src/router/additionalMaterials/helpers";
 import { aiLogger } from "@oakai/logger";
 
 import * as Sentry from "@sentry/nextjs";
@@ -22,7 +22,7 @@ type RefinementOption = {
 export type RefineMaterialParams = {
   refinement: RefinementOption[];
   mutateAsync: UseMutateAsyncFunction<
-    AdditionalMaterialSchemas,
+    GenerateAdditionalMaterialResponse,
     Error,
     GenerateAdditionalMaterialInput
   >;
@@ -31,9 +31,6 @@ export type RefineMaterialParams = {
 export const handleRefineMaterial =
   (set: ResourcesSetter, get: ResourcesGetter) =>
   async ({ refinement, mutateAsync }: RefineMaterialParams) => {
-    // Clear any existing generation
-    get().actions.setGeneration(null);
-
     const docType = get().docType;
     if (!docType) {
       log.error("No document type selected");
@@ -54,6 +51,8 @@ export const handleRefineMaterial =
           options: null,
           refinement: [{ type: refinement }],
         },
+        resourceId: get().id,
+        lessonId: get().pageData.lessonPlan.lessonId,
       };
 
       console.log("************payload", payload);
@@ -65,10 +64,12 @@ export const handleRefineMaterial =
       const result = await mutateAsync(parsedPayload);
 
       // Update the store with the result
-      get().actions.setGeneration(result);
+      set({
+        generation: result.resource,
+        moderation: result.moderation,
+        id: result.resourceId,
+      });
       log.info("Material refined successfully");
-
-      return result;
     } catch (error) {
       log.error("Error refining material", error);
       Sentry.captureException(error);

--- a/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleSubmitLessonPlan.ts
+++ b/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleSubmitLessonPlan.ts
@@ -1,6 +1,6 @@
 import type { PartialLessonContextSchemaType } from "@oakai/additional-materials/src/documents/partialLessonPlan/schema";
 import { lessonFieldKeys } from "@oakai/additional-materials/src/documents/partialLessonPlan/schema";
-import type { LooseLessonPlan } from "@oakai/aila/src/protocol/schema";
+import type { GeneratePartialLessonPlanResponse } from "@oakai/api/src/router/additionalMaterials/helpers";
 import { aiLogger } from "@oakai/logger";
 
 import * as Sentry from "@sentry/nextjs";
@@ -16,7 +16,7 @@ export type SubmitLessonPlanParams = {
   keyStage: string;
   year: string;
   mutateAsync: UseMutateAsyncFunction<
-    LooseLessonPlan,
+    GeneratePartialLessonPlanResponse,
     Error,
     PartialLessonContextSchemaType
   >;
@@ -57,10 +57,14 @@ export const handleSubmitLessonPlan =
       const result = await mutateAsync(apiInput);
       setIsLoadingLessonPlan(false);
       // Update the store with the result
-      set({ pageData: { lessonPlan: { ...result } } });
+      set({
+        pageData: {
+          lessonPlan: { ...result.lesson, lessonId: result.lessonId },
+        },
+        moderation: result.moderation,
+        threatDetection: result.threatDetection,
+      });
       log.info("Lesson plan updated successfully");
-
-      return get().pageData.lessonPlan;
     } catch (error) {
       log.error("Error handling lesson plan", error);
       Sentry.captureException(error);

--- a/apps/nextjs/src/stores/resourcesStore/index.ts
+++ b/apps/nextjs/src/stores/resourcesStore/index.ts
@@ -22,45 +22,48 @@ import type { ResourcesState } from "./types";
 
 export * from "./types";
 
-export type CreateResourcesStoreParams = {
-  id: string;
+const DEFAULT_STATE = {
+  stepNumber: 0,
+  isLoadingLessonPlan: false,
+  isResourcesLoading: false,
+  isDownloading: false,
+  pageData: {
+    lessonPlan: {
+      lessonId: "",
+      title: "",
+      keyStage: "",
+      subject: "",
+      topic: "",
+      learningOutcome: "",
+      learningCycles: [],
+      priorKnowledge: [],
+      keyLearningPoints: [],
+      misconceptions: [],
+      keywords: [],
+      starterQuiz: [],
+      cycle1: undefined,
+      cycle2: undefined,
+      cycle3: undefined,
+      exitQuiz: undefined,
+      additionalMaterials: undefined,
+    },
+  },
+  generation: null,
+  docType: null,
+  formState: {
+    subject: null,
+    title: null,
+    year: null,
+    activeDropdown: null,
+  },
+  moderation: undefined,
+  threatDetection: undefined,
 };
 
-export const createResourcesStore = ({ id }: CreateResourcesStoreParams) => {
+export const createResourcesStore = () => {
   const resourcesStore = create<ResourcesState>()((set, get) => ({
-    id,
-    stepNumber: 0,
-    isLoadingLessonPlan: false,
-    isResourcesLoading: false,
-    isDownloading: false,
-    pageData: {
-      lessonPlan: {
-        title: "",
-        keyStage: "",
-        subject: "",
-        topic: "",
-        learningOutcome: "",
-        learningCycles: [],
-        priorKnowledge: [],
-        keyLearningPoints: [],
-        misconceptions: [],
-        keywords: [],
-        starterQuiz: [],
-        cycle1: undefined,
-        cycle2: undefined,
-        cycle3: undefined,
-        exitQuiz: undefined,
-        additionalMaterials: undefined,
-      },
-    },
-    generation: null,
-    docType: null,
-    formState: {
-      subject: null,
-      title: null,
-      year: null,
-      activeDropdown: null,
-    },
+    id: null,
+    ...DEFAULT_STATE,
 
     actions: {
       // Setters
@@ -72,6 +75,9 @@ export const createResourcesStore = ({ id }: CreateResourcesStoreParams) => {
       setIsResourcesLoading: handleSetIsResourcesLoading(set, get),
       setIsResourceDownloading: (isDownloading: boolean) =>
         set({ isDownloading }),
+      setThreatDetection: (threatDetection: boolean) => {
+        set({ threatDetection });
+      },
       // Form state setters
       setSubject: handleSetSubject(set, get),
       setTitle: handleSetTitle(set, get),
@@ -84,6 +90,10 @@ export const createResourcesStore = ({ id }: CreateResourcesStoreParams) => {
       generateMaterial: handleGenerateMaterial(set, get),
       refineMaterial: handleRefineMaterial(set, get),
       downloadMaterial: handleDownload(set, get),
+
+      // Reset store to default state
+      resetToDefault: () =>
+        set((state) => ({ ...DEFAULT_STATE, id: state.id })),
     },
   }));
 

--- a/apps/nextjs/src/stores/resourcesStore/selectors.ts
+++ b/apps/nextjs/src/stores/resourcesStore/selectors.ts
@@ -50,3 +50,12 @@ export const activeDropdownSelector = (state: ResourcesState) =>
 // Is loading lesson plan selector
 export const isLoadingLessonPlanSelector = (state: ResourcesState) =>
   state.isLoadingLessonPlan;
+
+export const moderationSelector = (state: ResourcesState) => state.moderation;
+
+/**
+ * Selector for the threat detection state in the resources workflow
+ * @example const threatDetection = useResourcesStore(threatDetectionSelector);
+ */
+export const threatDetectionSelector = (state: ResourcesState) =>
+  state.threatDetection;

--- a/apps/nextjs/src/stores/resourcesStore/types.ts
+++ b/apps/nextjs/src/stores/resourcesStore/types.ts
@@ -1,5 +1,6 @@
 import type { AdditionalMaterialSchemas } from "@oakai/additional-materials/src/documents/additionalMaterials/configSchema";
 import type { AilaPersistedChat } from "@oakai/aila/src/protocol/schema";
+import type { ModerationResult } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
 
 import type { StoreApi } from "zustand";
 
@@ -8,7 +9,7 @@ import type { RefineMaterialParams } from "./actionFunctions/handleRefineMateria
 import type { SubmitLessonPlanParams } from "./actionFunctions/handleSubmitLessonPlan";
 
 export type PageData = {
-  lessonPlan: AilaPersistedChat["lessonPlan"];
+  lessonPlan: AilaPersistedChat["lessonPlan"] & { lessonId: string };
   transcript?: string | null;
 };
 
@@ -21,7 +22,7 @@ export type StepOneFormState = {
 };
 
 export type ResourcesState = {
-  id: string;
+  id: string | null;
   stepNumber: number;
   isLoadingLessonPlan: boolean;
   isResourcesLoading: boolean;
@@ -30,6 +31,8 @@ export type ResourcesState = {
   generation: AdditionalMaterialSchemas | null;
   docType: string | null;
   formState: StepOneFormState;
+  moderation?: ModerationResult;
+  threatDetection?: boolean;
 
   actions: {
     // setters
@@ -39,6 +42,7 @@ export type ResourcesState = {
     setDocType: (docType: string | null) => void;
     setIsLoadingLessonPlan: (isLoading: boolean) => void;
     setIsResourcesLoading: (isLoading: boolean) => void;
+    setThreatDetection: (threatDetection: boolean) => void;
 
     // Form state setters
     setSubject: (subject: string | null) => void;
@@ -51,16 +55,13 @@ export type ResourcesState = {
     resetFormState: () => void;
 
     // business logic actions
-    submitLessonPlan: (
-      params: SubmitLessonPlanParams,
-    ) => Promise<AilaPersistedChat["lessonPlan"]>;
-    generateMaterial: (
-      params: GenerateMaterialParams,
-    ) => Promise<AdditionalMaterialSchemas>;
-    refineMaterial: (
-      params: RefineMaterialParams,
-    ) => Promise<AdditionalMaterialSchemas>;
+    submitLessonPlan: (params: SubmitLessonPlanParams) => Promise<void>;
+    generateMaterial: (params: GenerateMaterialParams) => Promise<void>;
+    refineMaterial: (params: RefineMaterialParams) => Promise<void>;
     downloadMaterial: () => Promise<void>;
+
+    // Reset store to default state
+    resetToDefault: () => void;
   };
 };
 

--- a/packages/additional-materials/src/aiProviders/openaiProvider.ts
+++ b/packages/additional-materials/src/aiProviders/openaiProvider.ts
@@ -17,6 +17,7 @@ export const OpenAIProvider = {
       schema,
       model: openai("gpt-4o"),
       system: systemMessage,
+      mode: "json",
     });
 
     const parsedObject = schema.safeParse(object);

--- a/packages/additional-materials/src/documents/additionalMaterials/configSchema.ts
+++ b/packages/additional-materials/src/documents/additionalMaterials/configSchema.ts
@@ -10,9 +10,22 @@ import {
   comprehensionTaskSchema,
 } from "./comprehension/schema";
 import {
+  buildExitQuizPrompt,
+  buildExitQuizSystemMessage,
+} from "./exitQuiz/buildExitQuizPrompt";
+import { exitQuizContextSchema, exitQuizSchema } from "./exitQuiz/schema";
+import {
   buildGlossaryPrompt,
   buildGlossarySystemMessage,
 } from "./glossary/buildGlossaryPrompt";
+import {
+  buildStarterQuizPrompt,
+  buildStarterQuizSystemMessage,
+} from "./starterQuiz/buildStarterQuizPrompt";
+import {
+  starterQuizContextSchema,
+  starterQuizSchema,
+} from "./starterQuiz/schema";
 
 // -----------------------
 // Base Types
@@ -21,6 +34,8 @@ import {
 const additionalMaterialDocType = [
   "additional-comprehension",
   "additional-glossary",
+  "additional-starter-quiz",
+  "additional-exit-quiz",
   // "partial-lesson-plan",
 ] as const;
 
@@ -40,6 +55,8 @@ export type AdditionalMaterialType = z.infer<typeof additionalMaterialTypeEnum>;
 export const additionalMaterialContextSchemasMap = {
   "additional-comprehension": comprehensionContextSchema,
   "additional-glossary": glossaryContextSchema,
+  "additional-starter-quiz": starterQuizContextSchema,
+  "additional-exit-quiz": exitQuizContextSchema,
   // "partial-lesson-plan": partialLessonContextSchema,
 } satisfies {
   [K in AdditionalMaterialType]: ZodSchema;
@@ -55,6 +72,8 @@ export type ContextByMaterialType = {
 export const additionalMaterialSchemasMap = {
   "additional-comprehension": comprehensionTaskSchema,
   "additional-glossary": glossarySchema,
+  "additional-starter-quiz": starterQuizSchema,
+  "additional-exit-quiz": exitQuizSchema,
 } satisfies {
   [K in AdditionalMaterialType]: ZodSchema;
 };
@@ -74,6 +93,14 @@ export const additionalMaterialPromptBuilderMap = {
     buildPrompt: buildGlossaryPrompt,
     buildSystemMessage: buildGlossarySystemMessage,
   },
+  "additional-starter-quiz": {
+    buildPrompt: buildStarterQuizPrompt,
+    buildSystemMessage: buildStarterQuizSystemMessage,
+  },
+  "additional-exit-quiz": {
+    buildPrompt: buildExitQuizPrompt,
+    buildSystemMessage: buildExitQuizSystemMessage,
+  },
 } satisfies {
   [K in AdditionalMaterialType]: {
     buildSystemMessage: () => string;
@@ -88,6 +115,8 @@ export const additionalMaterialPromptBuilderMap = {
 const additionalMaterialVersions: Record<AdditionalMaterialType, number> = {
   "additional-comprehension": 1,
   "additional-glossary": 1,
+  "additional-starter-quiz": 1,
+  "additional-exit-quiz": 1,
 };
 
 type AdditionalMaterialsConfigMap = {
@@ -137,6 +166,8 @@ export const generateAdditionalMaterialInputSchema = z.discriminatedUnion(
   [
     makeInputVariant("additional-comprehension", comprehensionContextSchema),
     makeInputVariant("additional-glossary", glossaryContextSchema),
+    makeInputVariant("additional-starter-quiz", starterQuizContextSchema),
+    makeInputVariant("additional-exit-quiz", exitQuizContextSchema),
   ],
 );
 

--- a/packages/additional-materials/src/documents/additionalMaterials/exitQuiz/buildExitQuizPrompt.ts
+++ b/packages/additional-materials/src/documents/additionalMaterials/exitQuiz/buildExitQuizPrompt.ts
@@ -1,0 +1,113 @@
+import type { Action, ContextByMaterialType } from "../configSchema";
+import { getLessonDetails } from "../promptHelpers";
+
+export const buildExitQuizPrompt = (
+  context: ContextByMaterialType["additional-exit-quiz"],
+  action: Action,
+) => {
+  const { lessonPlan } = context;
+
+  if (action === "refine") {
+    return refineExitQuizPrompt(context);
+  }
+
+  const keyStage = lessonPlan.keyStage || (lessonPlan.year as string);
+  return `
+TASK: Write a 10-question MULTIPLE CHOICE EXIT QUIZ for a class of pupils in a UK school.
+
+PURPOSE: This EXIT QUIZ will assess pupils' understanding of the key learning from today's lesson. The quiz is designed to:
+1. Check if pupils have met the learning objective
+2. Identify any misconceptions that remain
+3. Highlight areas where pupils may need further support
+
+The EXIT QUIZ should be appropriate for the age of pupils in ${keyStage} and the subject ${lessonPlan.subject}. 
+
+The quiz should use the following structure:
+
+- Year group: ${keyStage}
+- Subject: ${lessonPlan.subject}
+- Lesson title: ${lessonPlan.title}
+
+**Lesson Details**:
+${getLessonDetails(lessonPlan)}
+
+1. [question text here - max 200 characters]
+
+a. [answer a - max 80 characters]
+
+b. [answer b - max 80 characters]
+
+c. [answer c - max 80 characters]
+
+REQUIREMENTS:
+- There should be 10 questions
+- Each question should have one correct answer and two PLAUSIBLE DISTRACTORS
+- Put answers in alphabetical order
+- Answers should start with lower-case letters unless they are proper nouns or acronyms
+- Questions should get progressively harder
+
+INCLUDE:
+- Cover the MAIN LEARNING POINTS from the lesson
+- Test application of knowledge, not just recall
+- Include at least one question on each of the KEY CONCEPTS covered
+- Check for understanding of the KEYWORDS taught
+- Address any MISCONCEPTIONS highlighted in the lesson plan
+- Use PLAUSIBLE DISTRACTORS that are:
+    - Similar in length and style to the correct answer
+    - Based on common errors or misunderstandings
+    - Designed to check for deeper understanding
+- At least one higher-order thinking question (application, analysis, evaluation)
+
+AVOID:
+- Negatively phrased questions (e.g., "Which is NOT…")
+- "All of the above" or "None of the above" options
+- True/false questions
+- Testing trivial or tangential information
+  `;
+};
+
+const refineExitQuizPrompt = (
+  context: ContextByMaterialType["additional-exit-quiz"],
+) => {
+  const { lessonPlan, previousOutput, message } = context;
+
+  return `Modify the following exit quiz based on user feedback.
+
+**Previous Output**:  
+${JSON.stringify(previousOutput, null, 2)}
+
+**User Request**:  
+${message}
+
+Adapt the quiz to reflect the request while ensuring it aligns with the following lesson details:
+
+${getLessonDetails(lessonPlan)}
+  `;
+};
+
+export const buildExitQuizSystemMessage = () => {
+  return `
+You are an expert UK teacher generating an exit quiz to assess learning from today's lesson.
+
+Your task is to create a high-quality, age-appropriate multiple-choice quiz with 10 questions that tests understanding of the key learning points.
+
+The quiz should follow this structure for each question:
+1. A clear question (max 200 characters)
+2. Three options (a, b, c) - one correct answer and two plausible distractors (max 80 characters each)
+
+Make sure that:
+- One correct answer is clearly marked as correct in your JSON output
+- Distractors are plausible but unambiguously incorrect
+- Answers follow alphabetical ordering
+- Questions focus on the most important concepts from the lesson
+- Questions test understanding rather than simple recall
+- The content is appropriate for UK schools
+- British English spelling and conventions are used throughout
+- Any academic vocabulary is appropriate for the age group
+
+Avoid:
+- Negatively phrased questions (e.g., "Which is NOT…")
+- "All of the above" or "None of the above" options
+- True/false questions
+  `;
+};

--- a/packages/additional-materials/src/documents/additionalMaterials/exitQuiz/schema.ts
+++ b/packages/additional-materials/src/documents/additionalMaterials/exitQuiz/schema.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+// Quiz answer schema
+export const answerSchema = z.object({
+  text: z.string(),
+  isCorrect: z.boolean(),
+});
+
+// Quiz question schema
+export const questionSchema = z.object({
+  question: z.string(),
+  options: z.array(answerSchema).length(3),
+});
+
+// Quiz schema
+export const exitQuizSchema = z.object({
+  year: z.string(),
+  subject: z.string(),
+  title: z.string(),
+  questions: z.array(questionSchema).length(10),
+});
+
+// Generic lesson plan schema for context
+const genericLessonPlanSchema = z
+  .object({
+    title: z.string(),
+    keyStage: z.string(),
+    subject: z.string(),
+    priorKnowledge: z.any().optional(),
+    keywords: z.any().optional(),
+    learningOutcome: z.any().optional(),
+    misconceptions: z.any().optional(),
+  })
+  .passthrough();
+
+// Context schema for exit quiz generation
+export const exitQuizContextSchema = z.object({
+  lessonPlan: genericLessonPlanSchema,
+  previousOutput: exitQuizSchema.nullish(),
+  options: z.any().nullish(),
+  refinement: z.any().nullish(),
+  message: z.string().nullish(),
+});
+
+// Type guard function for type checking
+export function isExitQuiz(
+  data: unknown,
+): data is z.infer<typeof exitQuizSchema> {
+  try {
+    exitQuizSchema.parse(data);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+// Export type
+export type ExitQuiz = z.infer<typeof exitQuizSchema>;

--- a/packages/additional-materials/src/documents/additionalMaterials/glossary/buildGlossaryPrompt.ts
+++ b/packages/additional-materials/src/documents/additionalMaterials/glossary/buildGlossaryPrompt.ts
@@ -1,4 +1,4 @@
-import type { Action, ContextByMaterialType } from "../configSchema";
+import type { ContextByMaterialType } from "../configSchema";
 import { getLessonDetails } from "../promptHelpers";
 import {
   type AllowedReadingAgeRefinement,

--- a/packages/additional-materials/src/documents/additionalMaterials/resourceTypes.ts
+++ b/packages/additional-materials/src/documents/additionalMaterials/resourceTypes.ts
@@ -1,0 +1,108 @@
+import { type ZodType } from "zod";
+
+import {
+  type Action,
+  type AdditionalMaterialType,
+  type ContextByMaterialType,
+  additionalMaterialsConfigMap,
+} from "./configSchema";
+import {
+  type AllowedReadingAgeRefinement,
+  readingAgeRefinement,
+  readingAgeRefinementMap,
+} from "./glossary/schema";
+
+// -----------------------
+//  Resource Type Configuration
+// -----------------------
+
+export type RefinementOption = {
+  id: string;
+  label: string;
+  value: string;
+};
+
+// Common properties for all resource types
+export type BaseResourceTypeConfig = {
+  id: string;
+  displayName: string;
+  description: string;
+  refinementOptions: RefinementOption[];
+  componentType: string;
+  isAvailable: boolean;
+  systemMessage: () => string;
+  schema: ZodType;
+  promptContextSchema: ZodType;
+  version: number;
+};
+
+const readingAgeRefinementOptions: RefinementOption[] = Array.from(
+  readingAgeRefinement,
+).map((id: AllowedReadingAgeRefinement) => ({
+  id,
+  label: readingAgeRefinementMap[id],
+  value: id,
+}));
+
+export const resourceTypesConfig = {
+  "additional-glossary": {
+    // Backend config
+    ...additionalMaterialsConfigMap["additional-glossary"],
+
+    // Frontend config
+    id: "additional-glossary",
+    displayName: "Glossary",
+    description: "Additional lesson vocabulary with pupil friendly definitions",
+    refinementOptions: readingAgeRefinementOptions,
+    isAvailable: true,
+  },
+  "additional-comprehension": {
+    // Backend config
+    ...additionalMaterialsConfigMap["additional-comprehension"],
+
+    // Frontend config
+    id: "additional-comprehension",
+    displayName: "Comprehension tasks",
+    description: "Comprehension tasks which can be adapted for pupils",
+    refinementOptions: readingAgeRefinementOptions,
+    isAvailable: true,
+  },
+  "additional-starter-quiz": {
+    // Backend config
+    ...additionalMaterialsConfigMap["additional-starter-quiz"],
+
+    // Frontend config
+    id: "additional-starter-quiz",
+    displayName: "Starter quiz",
+    description: "A multiple-choice quiz to assess pupils' prior knowledge",
+    refinementOptions: readingAgeRefinementOptions,
+    isAvailable: true,
+  },
+  "additional-exit-quiz": {
+    // Backend config
+    ...additionalMaterialsConfigMap["additional-exit-quiz"],
+
+    // Frontend config
+    id: "additional-exit-quiz",
+    displayName: "Exit quiz",
+    description:
+      "A multiple-choice quiz to assess pupils' learning from the lesson",
+    refinementOptions: readingAgeRefinementOptions,
+    isAvailable: true,
+  },
+} as const;
+
+// Helper functions to access resource types
+export function getResourceTypes(): Array<
+  (typeof resourceTypesConfig)[keyof typeof resourceTypesConfig]
+> {
+  return Object.values(resourceTypesConfig);
+}
+
+export function getResourceType(
+  id: string,
+): (typeof resourceTypesConfig)[keyof typeof resourceTypesConfig] | null {
+  return id in resourceTypesConfig
+    ? resourceTypesConfig[id as keyof typeof resourceTypesConfig]
+    : null;
+}

--- a/packages/additional-materials/src/documents/additionalMaterials/starterQuiz/buildStarterQuizPrompt.ts
+++ b/packages/additional-materials/src/documents/additionalMaterials/starterQuiz/buildStarterQuizPrompt.ts
@@ -1,0 +1,107 @@
+import type { Action, ContextByMaterialType } from "../configSchema";
+import { getLessonDetails } from "../promptHelpers";
+
+export const buildStarterQuizPrompt = (
+  context: ContextByMaterialType["additional-starter-quiz"],
+  action: Action,
+) => {
+  const { lessonPlan } = context;
+
+  if (action === "refine") {
+    return refineStarterQuizPrompt(context);
+  }
+
+  const keyStage = lessonPlan.keyStage || (lessonPlan.year as string);
+  return `
+TASK: Write a 10-question MULTIPLE CHOICE QUIZ for a class of pupils in a UK school.
+
+PURPOSE: This QUIZ will assess pupils' understanding of the PRIOR KNOWLEDGE required for the lesson. The QUIZ is designed to enable teachers to identify gaps in knowledge for individual pupils or groups of pupils that need to be addressed before the lesson starts. Pupils who get all questions correct have good understanding of the prior knowledge and are ready to start the lesson.
+
+The QUIZ should be appropriate for the age of pupils in ${keyStage} and the subject ${lessonPlan.subject}. 
+
+The quiz should use the following structure:
+
+- Year group: ${keyStage}
+- Subject: ${lessonPlan.subject}
+- Lesson title: ${lessonPlan.title}
+
+**Lesson Details**:
+${getLessonDetails(lessonPlan)}
+
+1. [question text here - max 200 characters]
+
+a. [answer a - max 80 characters]
+
+b. [answer b - max 80 characters]
+
+c. [answer c - max 80 characters]
+
+REQUIREMENTS:
+- There should be 10 questions
+- Each question should have one correct answer and two PLAUSIBLE DISTRACTORS
+- Put answers in alphabetical order
+- Answers should start with lower-case letters unless they are proper nouns or acronyms
+- Questions should get harder as the quiz progresses
+
+INCLUDE:
+- At least one question testing understanding of a KEYWORD
+- At least one question checking for a COMMON MISCONCEPTION
+- Use PLAUSIBLE DISTRACTORS that are:
+    - Similar in length and style to the correct answer
+    - Believable but clearly incorrect with reasoning
+    - Check that pupils do not have common misconceptions or errors
+- Assess higher-order skills through application, analysis, or evaluation
+- Questions which assess understanding of the content rather than just recall
+
+AVOID:
+- Negatively phrased questions (e.g., "Which is NOT…")
+- "All of the above" or "None of the above" options
+- True/false questions
+- Questions about the content of the lesson
+  `;
+};
+
+const refineStarterQuizPrompt = (
+  context: ContextByMaterialType["additional-starter-quiz"],
+) => {
+  const { lessonPlan, previousOutput, message } = context;
+
+  return `Modify the following starter quiz based on user feedback.
+
+**Previous Output**:  
+${JSON.stringify(previousOutput, null, 2)}
+
+**User Request**:  
+${message}
+
+Adapt the quiz to reflect the request while ensuring it aligns with the following lesson details:
+
+${getLessonDetails(lessonPlan)}
+  `;
+};
+
+export const buildStarterQuizSystemMessage = () => {
+  return `
+You are an expert UK teacher generating a starter quiz to assess prior knowledge.
+
+Your task is to create a high-quality, age-appropriate multiple-choice quiz with 10 questions.
+
+The quiz should follow this structure for each question:
+1. A clear question (max 200 characters)
+2. Three options (a, b, c) - one correct answer and two plausible distractors (max 80 characters each)
+
+Make sure that:
+- One correct answer is clearly marked as correct in your JSON output
+- Distractors are plausible but unambiguously incorrect
+- Answers follow alphabetical ordering
+- Questions increase in difficulty through the quiz
+- The content is appropriate for UK schools
+- British English spelling and conventions are used throughout
+- No jargon or overly technical language beyond the pupils' understanding
+
+Avoid:
+- Negatively phrased questions (e.g., "Which is NOT…")
+- "All of the above" or "None of the above" options
+- True/false questions
+  `;
+};

--- a/packages/additional-materials/src/documents/additionalMaterials/starterQuiz/schema.ts
+++ b/packages/additional-materials/src/documents/additionalMaterials/starterQuiz/schema.ts
@@ -1,0 +1,58 @@
+import { z } from "zod";
+
+// Quiz answer schema
+export const answerSchema = z.object({
+  text: z.string(),
+  isCorrect: z.boolean(),
+});
+
+// Quiz question schema
+export const questionSchema = z.object({
+  question: z.string(),
+  options: z.array(answerSchema).length(3),
+});
+
+// Quiz schema
+export const starterQuizSchema = z.object({
+  year: z.string(),
+  subject: z.string(),
+  title: z.string(),
+  questions: z.array(questionSchema).length(10),
+});
+
+// Generic lesson plan schema for context
+const genericLessonPlanSchema = z
+  .object({
+    title: z.string(),
+    keyStage: z.string(),
+    subject: z.string(),
+    priorKnowledge: z.any().optional(),
+    keywords: z.any().optional(),
+    learningOutcome: z.any().optional(),
+    misconceptions: z.any().optional(),
+  })
+  .passthrough();
+
+// Context schema for starter quiz generation
+export const starterQuizContextSchema = z.object({
+  lessonPlan: genericLessonPlanSchema,
+  previousOutput: starterQuizSchema.nullish(),
+  options: z.any().nullish(),
+  refinement: z.any().nullish(),
+  message: z.string().nullish(),
+});
+
+// Type guard function for type checking
+export function isStarterQuiz(
+  data: unknown,
+): data is z.infer<typeof starterQuizSchema> {
+  try {
+    starterQuizSchema.parse(data);
+    return true;
+  } catch (error) {
+    return false;
+  }
+}
+
+// Export type
+export type StarterQuiz = z.infer<typeof starterQuizSchema>;

--- a/packages/aila/src/core/Aila.ts
+++ b/packages/aila/src/core/Aila.ts
@@ -161,6 +161,7 @@ export class Aila implements AilaServices {
       useModeration: options?.useModeration ?? true,
       useThreatDetection: options?.useThreatDetection ?? true,
       useErrorReporting: options?.useErrorReporting ?? true,
+      useAgenticAila: options?.useAgenticAila ?? false,
       model: options?.model ?? DEFAULT_MODEL,
       mode: options?.mode ?? "interactive",
     };

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -1,10 +1,13 @@
-import { prisma } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
 
 import type { ReadableStreamDefaultController } from "stream/web";
 
 import { AilaThreatDetectionError } from "../../features/threatDetection/types";
-import { handleThreatDetectionError } from "../../utils/threatDetection/threatDetectionHandling";
+import {
+  createInteractStreamHandler,
+  streamInteractResultToClient,
+} from "../../lib/agents/compatibility/streamHandling";
+import { interact } from "../../lib/agents/interact";
 import { AilaChatError } from "../AilaError";
 import type { AilaChat } from "./AilaChat";
 import type { PatchEnqueuer } from "./PatchEnqueuer";
@@ -94,13 +97,18 @@ export class AilaStreamHandler {
       await this._chat.handleSubjectWarning();
       this.logStreamingStep("Handle subject warning complete");
 
-      log.info("Starting LLM stream");
-      await this.startLLMStream();
-      this.logStreamingStep("Start LLM stream complete");
-
-      log.info("Reading from stream");
-      await this.readFromStream(abortController);
-      this.logStreamingStep("Read from stream complete");
+      if (this._chat.aila.options.useAgenticAila) {
+        log.info("Start Agent stream");
+        await this.startAgentStream();
+        this.logStreamingStep("Agent stream complete");
+      } else {
+        log.info("Starting LLM stream");
+        await this.startLLMStream();
+        this.logStreamingStep("Start LLM stream complete");
+        log.info("Reading from stream");
+        await this.readFromStream(abortController);
+        this.logStreamingStep("Read from stream complete");
+      }
 
       log.info(
         "Finished reading from stream",
@@ -123,7 +131,7 @@ export class AilaStreamHandler {
     } finally {
       const status = this._chat.generation?.status;
       log.info("In finally block", { status, chatId: this._chat.id });
-      if (!(status === "FAILED")) {
+      if (status !== "FAILED") {
         try {
           log.info("Completing chat");
           await this._chat.complete();
@@ -144,6 +152,53 @@ export class AilaStreamHandler {
   private setupController(controller: ReadableStreamDefaultController) {
     this._controller = controller;
     this._patchEnqueuer.setController(controller);
+  }
+
+  private async startAgentStream() {
+    await this._chat.enqueue({
+      type: "comment",
+      value: "CHAT_START",
+    });
+
+    const initialDocument = {
+      ...this._chat.aila.document.content,
+    };
+
+    if (
+      !initialDocument.title ||
+      !initialDocument.subject ||
+      !initialDocument.keyStage
+    ) {
+      throw new Error("title subject keyStage required");
+    }
+
+    // Create a stream handler
+    const streamHandler = createInteractStreamHandler(
+      this._chat,
+      this._controller!,
+    );
+
+    // Call interact with the stream handler
+    const interactResult = await interact({
+      userId: this._chat.userId ?? "anonymous",
+      chatId: this._chat.id,
+      initialDocument: initialDocument,
+      messageHistory: this._chat.messages
+        .filter((m) => m.role === "user" || m.role === "assistant")
+        .map((m) => {
+          log.info(m);
+          return m;
+        }) as { role: "user" | "assistant"; content: string }[],
+      onUpdate: streamHandler, // This is the new part
+    });
+
+    // Stream the final result to the client
+    await streamInteractResultToClient(
+      this._chat,
+      this._controller!,
+      initialDocument,
+      interactResult,
+    );
   }
 
   private async startLLMStream() {

--- a/packages/aila/src/core/types.ts
+++ b/packages/aila/src/core/types.ts
@@ -45,6 +45,7 @@ export type AilaOptions = AilaPublicChatOptions & {
   useModeration?: boolean;
   useAnalytics?: boolean;
   useThreatDetection?: boolean;
+  useAgenticAila?: boolean;
   model?: string;
   mode?: AilaGenerateDocumentMode;
 };

--- a/packages/aila/src/lib/agents/agents.ts
+++ b/packages/aila/src/lib/agents/agents.ts
@@ -1,0 +1,204 @@
+import { z } from "zod";
+
+import {
+  CycleSchemaWithoutLength,
+  KeyLearningPointsSchema,
+  KeyStageSchema,
+  KeywordsSchemaWithoutLength,
+  LearningCyclesSchema,
+  LearningOutcomeSchema,
+  type LessonPlanKey,
+  LessonTitleSchema,
+  MisconceptionsSchemaWithoutLength,
+  PriorKnowledgeSchema,
+  QuizSchemaWithoutLength,
+  SubjectSchema,
+  TopicSchema,
+} from "../../protocol/schema";
+import { exitQuizInstructions } from "./prompts/exitQuizInstructions";
+import { keyLearningPointsInstructions } from "./prompts/keyLearningPointsInstructions";
+import { keywordsInstructions } from "./prompts/keywordsInstructions";
+import { learningCycleTitlesInstructions } from "./prompts/learningCycleTitlesInstructions";
+import { learningCyclesInstructions } from "./prompts/learningCyclesInstructions";
+import { learningOutcomeInstructions } from "./prompts/learningOutcomeInstructions";
+import { misconceptionsInstructions } from "./prompts/misconceptionsInstructions";
+import { priorKnowledgeInstructions } from "./prompts/priorKnowledgeInstructions";
+import { quizInstructions } from "./prompts/quizInstructions";
+import { starterQuizInstructions } from "./prompts/starterQuizInstructions";
+
+export const agentNames = z.enum([
+  "title",
+  "keyStage",
+  "subject",
+  "topic",
+  "learningOutcome",
+  "learningCycles",
+  "priorKnowledge",
+  "keyLearningPoints",
+  "misconceptions",
+  "keywords",
+  "starterQuiz",
+  "cycle",
+  "exitQuiz",
+  "mathsQuiz",
+  "deleteSection",
+  "endTurn",
+]);
+
+export type AgentName = z.infer<typeof agentNames>;
+
+const _unknownAgentResponseSchema = z.object({
+  value: z.unknown(),
+});
+export type AgentResponse = z.infer<typeof _unknownAgentResponseSchema>;
+
+const _agentResponseAnySchema = z
+  .object({
+    value: z.any(),
+  })
+  .required();
+
+type AgentResponseAny = z.infer<typeof _agentResponseAnySchema>;
+export type SchemaWithValue = z.ZodObject<{ value: z.ZodTypeAny }>;
+
+export type PromptAgentDefinition<
+  Schema extends SchemaWithValue = typeof _agentResponseAnySchema,
+> = {
+  type: "prompt";
+  name: AgentName;
+  prompt: string;
+  schema: Schema;
+  whenToUse?: string[];
+};
+export type AgentDefinition<Schema extends AgentResponse = AgentResponseAny> =
+  | PromptAgentDefinition<SchemaWithValue>
+  | {
+      type: "custom";
+      name: AgentName;
+      schema?: z.ZodTypeAny;
+      whenToUse?: string[];
+    };
+
+export const agents: Record<AgentName, AgentDefinition> = {
+  title: {
+    type: "prompt",
+    name: "title",
+    prompt: "Generate a title for the lesson plan.",
+    schema: z.object({ value: LessonTitleSchema }),
+  },
+  keyStage: {
+    type: "prompt",
+    name: "keyStage",
+    prompt: "Specify the Key Stage for this lesson.",
+    schema: z.object({ value: KeyStageSchema }),
+  },
+  subject: {
+    type: "prompt",
+    name: "subject",
+    prompt: "Specify the subject for this lesson.",
+    schema: z.object({ value: SubjectSchema }),
+  },
+  topic: {
+    type: "prompt",
+    name: "topic",
+    prompt: "Specify the topic for this lesson.",
+    schema: z.object({ value: TopicSchema }),
+  },
+  learningOutcome: {
+    type: "prompt",
+    name: "learningOutcome",
+    prompt: learningOutcomeInstructions,
+    schema: z.object({ value: LearningOutcomeSchema }),
+  },
+  learningCycles: {
+    type: "prompt",
+    name: "learningCycles",
+    prompt: learningCycleTitlesInstructions,
+    schema: z.object({ value: LearningCyclesSchema }),
+  },
+  priorKnowledge: {
+    type: "prompt",
+    name: "priorKnowledge",
+    prompt: priorKnowledgeInstructions,
+    schema: z.object({ value: PriorKnowledgeSchema }),
+  },
+  keyLearningPoints: {
+    type: "prompt",
+    name: "keyLearningPoints",
+    prompt: keyLearningPointsInstructions,
+    schema: z.object({ value: KeyLearningPointsSchema }),
+  },
+  misconceptions: {
+    type: "prompt",
+    name: "misconceptions",
+    prompt: misconceptionsInstructions,
+    schema: z.object({ value: MisconceptionsSchemaWithoutLength }),
+  },
+  keywords: {
+    type: "prompt",
+    name: "keywords",
+    prompt: keywordsInstructions,
+    schema: z.object({ value: KeywordsSchemaWithoutLength }),
+  },
+  starterQuiz: {
+    type: "prompt",
+    name: "starterQuiz",
+    prompt: [starterQuizInstructions, quizInstructions].join(`\n\n`),
+    schema: z.object({ value: QuizSchemaWithoutLength }),
+  },
+  cycle: {
+    type: "prompt",
+    name: "cycle",
+    prompt: learningCyclesInstructions,
+    schema: z.object({ value: CycleSchemaWithoutLength }),
+  },
+  exitQuiz: {
+    type: "prompt",
+    name: "exitQuiz",
+    prompt: [exitQuizInstructions, quizInstructions].join(`\n\n`),
+    schema: z.object({ value: QuizSchemaWithoutLength }),
+  },
+  mathsQuiz: {
+    type: "custom",
+    name: "mathsQuiz",
+    whenToUse: [
+      "do not use this agent if the subject is not maths/math/mathematics",
+      "only suggest this agent if the next appropriate task is the generation of a starter or exit quiz",
+      "if you select this agent, a quiz will be generated, and no other parts of the lesson will be affected",
+    ],
+  },
+  deleteSection: {
+    type: "custom",
+    name: "deleteSection",
+  },
+  endTurn: {
+    type: "custom",
+    name: "endTurn",
+  },
+};
+
+export const sectionAgentMap: Record<
+  Exclude<
+    LessonPlanKey,
+    | "title"
+    | "subject"
+    | "keyStage"
+    | "topic"
+    | "basedOn"
+    | "additionalMaterials"
+  >,
+  AgentName
+> = {
+  learningOutcome: "learningOutcome",
+  learningCycles: "learningCycles",
+  priorKnowledge: "priorKnowledge",
+  keyLearningPoints: "keyLearningPoints",
+  misconceptions: "misconceptions",
+  keywords: "keywords",
+  starterQuiz: "starterQuiz",
+  cycle1: "cycle",
+  cycle2: "cycle",
+  cycle3: "cycle",
+  exitQuiz: "exitQuiz",
+  // additionalMaterials: ["additionalMaterials"],
+};

--- a/packages/aila/src/lib/agents/cli.ts
+++ b/packages/aila/src/lib/agents/cli.ts
@@ -1,0 +1,97 @@
+#!/usr/bin/env ts-node
+import readline from "readline";
+
+import type { LooseLessonPlan } from "../../protocol/schema";
+import { interact } from "./interact";
+
+// Helper to prompt for input
+function ask(query: string): Promise<string> {
+  const rl = readline.createInterface({
+    input: process.stdin,
+    output: process.stdout,
+  });
+  return new Promise((resolve) =>
+    rl.question(query, (ans) => {
+      rl.close();
+      resolve(ans.trim());
+    }),
+  );
+}
+
+async function main() {
+  console.log("Welcome to the Aila Lesson Plan CLI\n");
+
+  const subject = await ask("Subject: ");
+  const keyStage = await ask("Key Stage: ");
+  const title = await ask("Lesson Title: ");
+
+  // You could add more fields here if needed
+  let currentDocument: LooseLessonPlan = {
+    subject,
+    keyStage,
+    title,
+  };
+
+  // For CLI, use a random or timestamp-based chatId/userId
+  const chatId = `cli-${Date.now()}`;
+  const userId = `cli-user`;
+
+  // Optionally, let user enter a starting message
+  let userMessage =
+    (await ask("Enter your initial instruction (or leave blank): ")) ||
+    "Let's start creating a lesson plan.";
+
+  let shouldContinue = true;
+  const messageHistory: { role: "user" | "assistant"; content: string }[] = [];
+
+  while (shouldContinue) {
+    messageHistory.push({
+      role: "user",
+      content: userMessage,
+    });
+    // Run the interactive agent loop
+    const result = await interact({
+      chatId,
+      userId,
+      initialDocument: currentDocument,
+      messageHistory,
+    });
+
+    // Update the document with the latest version
+    currentDocument = result.document || currentDocument;
+    messageHistory.push({
+      role: "assistant",
+      content: result.ailaMessage ?? "No message",
+    });
+
+    // Display the current state
+    console.log("\nCurrent lesson plan:");
+    console.log(JSON.stringify(currentDocument, null, 2));
+
+    console.log("\nAila message:");
+    console.log(result.ailaMessage ?? "NO MESSAGE");
+
+    // Ask if the user wants to continue
+    const continueResponse = await ask(
+      "\nDo you want to add more instructions? (y/n): ",
+    );
+
+    if (
+      continueResponse.toLowerCase() === "y" ||
+      continueResponse.toLowerCase() === "yes"
+    ) {
+      userMessage = await ask("Enter your next instruction: ");
+    } else {
+      shouldContinue = false;
+    }
+  }
+
+  console.log("\nFinal lesson plan document:");
+  console.log(JSON.stringify(currentDocument, null, 2));
+  console.log("\nThank you for using Aila Lesson Plan CLI!");
+}
+
+main().catch((err) => {
+  console.error("Error:", err);
+  process.exit(1);
+});

--- a/packages/aila/src/lib/agents/compatibility/streamHandling.ts
+++ b/packages/aila/src/lib/agents/compatibility/streamHandling.ts
@@ -1,0 +1,271 @@
+// packages/aila/src/lib/agents/streamHandling.ts
+import { aiLogger } from "@oakai/logger";
+
+import { compare } from "fast-json-patch";
+import type { ReadableStreamDefaultController } from "stream/web";
+
+import type { AilaChat } from "../../../core/chat/AilaChat";
+import type { JsonPatchDocumentOptional } from "../../../protocol/jsonPatchProtocol";
+import type { LooseLessonPlan } from "../../../protocol/schema";
+import type { InteractCallback } from "../interact";
+import type { TurnPlan } from "../router";
+
+const log = aiLogger("aila:agents:stream");
+
+export type InteractResult = {
+  document: LooseLessonPlan;
+  ailaMessage?: string;
+};
+
+export function createPatchesFromInteractResult(
+  initialDocument: LooseLessonPlan,
+  result: InteractResult,
+): {
+  patches: JsonPatchDocumentOptional[];
+  sectionsEdited: string[];
+} {
+  // Generate patches from the document changes
+  const patchesWithMetadata: JsonPatchDocumentOptional[] = [];
+
+  // Use fast-json-patch to detect changes
+  const patches = compare(initialDocument, result.document);
+
+  // Create proper patch objects for each change
+  for (const patch of patches) {
+    // Convert path from /subject to subject
+    const sectionKey = patch.path.substring(1); // Remove leading slash
+
+    if ("value" in patch) {
+      if (patch.op === "test" || patch.op === "_get") {
+        continue;
+      }
+      patchesWithMetadata.push({
+        type: "patch",
+        reasoning: `Updated ${sectionKey} based on user request`,
+        value: {
+          // type: getValueType(patch.value),
+          op: patch.op,
+          path: patch.path,
+          value: patch.value,
+        },
+        status: "complete",
+      });
+    }
+  }
+
+  // Identify which sections were edited
+  const sectionsEdited = [...new Set(patches.map((p) => p.path.substring(1)))];
+
+  return {
+    patches: patchesWithMetadata,
+    sectionsEdited,
+  };
+}
+
+export function createLlmMessageFromInteractResult(
+  initialDocument: LooseLessonPlan,
+  result: InteractResult,
+) {
+  const { patches, sectionsEdited } = createPatchesFromInteractResult(
+    initialDocument,
+    result,
+  );
+
+  // Create the llmMessage
+  return {
+    type: "llmMessage",
+    sectionsToEdit: sectionsEdited,
+    patches: patches,
+    sectionsEdited: sectionsEdited,
+    prompt: {
+      type: "text",
+      value:
+        result.ailaMessage ??
+        "Here's the updated lesson plan. Do you want to make any more changes?",
+    },
+    status: "complete",
+  };
+}
+
+export function formatMessageWithRecordSeparators(message: string): string {
+  return `\n␞\n${JSON.stringify(message)}\n␞\n`;
+}
+
+export function createInteractStreamHandler(
+  chat: AilaChat,
+  controller: ReadableStreamDefaultController,
+): InteractCallback {
+  // Track sections and patches for the message
+  const sectionsToEdit: string[] = [];
+  const patches: JsonPatchDocumentOptional[] = [];
+
+  return (update) => {
+    log.info("Stream update received", update.type);
+
+    switch (update.type) {
+      case "progress":
+        if (
+          update.data.step === "routing" &&
+          update.data.status === "completed"
+        ) {
+          // When routing is complete, we have the sections to edit
+          if (update.data.plan?.type === "turn_plan") {
+            onTurnPlan({
+              turnPlan: update.data.plan,
+              controller,
+              chat,
+              sectionsToEdit,
+            });
+          }
+        }
+        break;
+
+      case "section_update":
+        // When a section is updated, we have a new patch
+        if (update.data.patches && update.data.patches.length > 0) {
+          onSectionUpdate({
+            update,
+            controller,
+            chat,
+            patches,
+          });
+        }
+        break;
+
+      case "complete":
+        // This will be handled by streamInteractResultToClient
+        // We want to skip it to avoid duplicating the message
+        return;
+    }
+  };
+}
+
+function onTurnPlan({
+  turnPlan,
+  controller,
+  chat,
+  sectionsToEdit,
+}: {
+  turnPlan: TurnPlan;
+  controller: ReadableStreamDefaultController;
+  chat: AilaChat;
+  sectionsToEdit: string[];
+}) {
+  // Extract section keys from the plan
+  const newSections = turnPlan.plan.map(
+    (p: TurnPlan["plan"][number]) => p.sectionKey,
+  );
+  sectionsToEdit.push(...newSections);
+
+  // Stream the opening part of the message with sectionsToEdit
+  const openingPart = `{"type":"llmMessage","sectionsToEdit":${JSON.stringify(sectionsToEdit)},"patches":[`;
+  streamChunks(controller, chat, openingPart);
+}
+
+function onSectionUpdate({
+  update,
+  controller,
+  chat,
+  patches,
+}: {
+  update: {
+    data: {
+      patches: JsonPatchDocumentOptional[];
+    };
+  };
+  controller: ReadableStreamDefaultController;
+  chat: AilaChat;
+  patches: JsonPatchDocumentOptional[];
+}) {
+  // Add comma if not the first patch
+  if (patches.length > 0) {
+    streamChunks(controller, chat, ",");
+  }
+
+  // Stream each patch
+  for (let i = 0; i < update.data.patches.length; i++) {
+    const patch = update.data.patches[i];
+    if (
+      !patch ||
+      typeof patch !== "object" ||
+      !("value" in patch) ||
+      !patch.value ||
+      typeof patch.value !== "object" ||
+      !("op" in patch.value) ||
+      !patch.value.op
+    ) {
+      // Filter out invalid patches (which should not happen)
+      continue;
+    }
+    if (patch?.value?.op === "test" || patch?.value?.op === "_get") {
+      // Filter out test and _get operations
+      // These are not valid operations for our use case
+      continue;
+    }
+    const patchJson = JSON.stringify(patch);
+    streamChunks(controller, chat, i > 0 ? "," + patchJson : patchJson);
+    if (patch) patches.push(patch as JsonPatchDocumentOptional);
+  }
+}
+
+// Helper to stream chunks of text
+function streamChunks(
+  controller: ReadableStreamDefaultController,
+  chat: AilaChat,
+  text: string,
+) {
+  // Stream character by character or in small groups to mimic the recording format
+  for (let i = 0; i < text.length; i++) {
+    const chunkSize = Math.min(
+      1 + Math.floor(Math.random() * 2),
+      text.length - i,
+    );
+    const chunk = text.substring(i, i + chunkSize);
+    controller.enqueue(chunk);
+    chat.appendChunk(chunk);
+    i += chunkSize - 1;
+  }
+}
+
+// Modified to finish the streaming that was started by the handler
+export async function streamInteractResultToClient(
+  chat: AilaChat,
+  controller: ReadableStreamDefaultController,
+  initialDocument: LooseLessonPlan,
+  result: InteractResult,
+) {
+  log.info("Streaming interact result to client");
+
+  // Create the llmMessage (we need this for the complete structure)
+  const llmMessage = createLlmMessageFromInteractResult(
+    initialDocument,
+    result,
+  );
+
+  // Stream the closing part of the message with sectionsEdited and prompt
+  const closingPart = `],"sectionsEdited":${JSON.stringify(llmMessage.sectionsEdited)},"prompt":${JSON.stringify(llmMessage.prompt)},"status":"complete"}`;
+
+  // Stream character by character to mimic the recording format
+  for (let i = 0; i < closingPart.length; i++) {
+    const chunkSize = Math.min(
+      1 + Math.floor(Math.random() * 2),
+      closingPart.length - i,
+    );
+    const chunk = closingPart.substring(i, i + chunkSize);
+    controller.enqueue(chunk);
+    chat.appendChunk(chunk);
+    i += chunkSize - 1;
+  }
+
+  // Update the chat's document content
+  chat.aila.document.content = result.document;
+
+  // Send a state message to update the client's state
+  await chat.enqueue({
+    type: "state",
+    reasoning: "final",
+    value: result.document,
+  } as JsonPatchDocumentOptional);
+
+  log.info("Completed streaming interact result");
+}

--- a/packages/aila/src/lib/agents/createOpenAIClient.ts
+++ b/packages/aila/src/lib/agents/createOpenAIClient.ts
@@ -1,0 +1,9 @@
+import OpenAI, { type ClientOptions } from "openai";
+
+export function createOpenAIClient(): OpenAI {
+  const openAiFields: ClientOptions = {
+    apiKey: process.env.OPENAI_API_KEY,
+    baseURL: process.env.HELICONE_EU_HOST,
+  };
+  return new OpenAI(openAiFields);
+}

--- a/packages/aila/src/lib/agents/interact.ts
+++ b/packages/aila/src/lib/agents/interact.ts
@@ -1,0 +1,240 @@
+import { aiLogger } from "@oakai/logger";
+
+import { compare } from "fast-json-patch";
+
+import type { JsonPatchDocumentOptional } from "../../protocol/jsonPatchProtocol";
+import { type LooseLessonPlan } from "../../protocol/schema";
+import { agents, sectionAgentMap } from "./agents";
+import { type InteractResult } from "./compatibility/streamHandling";
+import { messageToUserAgent } from "./messageToUser";
+import { promptAgentHandler } from "./promptAgentHandler";
+import { type TurnPlan, agentRouter } from "./router";
+
+const log = aiLogger("aila:agents");
+
+type InteractUpdate =
+  | {
+      type: "progress";
+      data: {
+        step: "routing";
+        status: "started";
+      };
+    }
+  | {
+      type: "progress";
+      data: {
+        step: "routing";
+        status: "completed";
+        plan: TurnPlan;
+      };
+    }
+  | {
+      type: "progress";
+      data: {
+        step: "action";
+        status: "started" | "completed";
+        action: {
+          sectionKey: string;
+          actionType: string;
+          index: number;
+          total: number;
+        };
+      };
+    }
+  | {
+      type: "section_update";
+      data: {
+        sectionKey: string;
+        actionType: string;
+        patches: JsonPatchDocumentOptional[];
+      };
+    }
+  | {
+      type: "progress";
+      data: {
+        step: "message";
+        status: "started";
+      };
+    }
+  | {
+      type: "complete";
+      data: {
+        document: LooseLessonPlan;
+        ailaMessage: string;
+      };
+    };
+export type InteractCallback = <Update extends InteractUpdate>(
+  update: Update,
+) => void;
+
+export async function interact({
+  chatId,
+  userId,
+  initialDocument,
+  messageHistory,
+  onUpdate,
+}: {
+  chatId: string;
+  userId: string;
+  initialDocument: LooseLessonPlan;
+  messageHistory: { role: "user" | "assistant"; content: string }[];
+  onUpdate?: InteractCallback;
+}): Promise<InteractResult> {
+  log.info("Starting interaction with Aila agents");
+  let document = initialDocument;
+
+  // Notify about starting the routing process
+  onUpdate?.({
+    type: "progress",
+    data: { step: "routing", status: "started" },
+  });
+
+  const routerResponse = await agentRouter({
+    chatId,
+    userId,
+    document,
+    messageHistory,
+  });
+
+  log.info("Router response", JSON.stringify(routerResponse, null, 2));
+
+  if (!routerResponse) {
+    throw new Error("Router returned null");
+  }
+
+  if (routerResponse.result.type === "end_turn") {
+    // Notify about completion
+    onUpdate?.({
+      type: "complete",
+      data: { document, ailaMessage: routerResponse.result.message },
+    });
+
+    return { document, ailaMessage: routerResponse.result.message };
+  }
+
+  // Notify about completed routing
+  onUpdate?.({
+    type: "progress",
+    data: { step: "routing", status: "completed", plan: routerResponse.result },
+  });
+
+  const result = routerResponse.result;
+
+  const { plan } = result;
+
+  for (const [index, action] of plan.entries()) {
+    log.info("Processing action", action);
+    const { sectionKey, action: actionType, context } = action;
+    const agentName = sectionAgentMap[sectionKey];
+    const agentDefinition = agents[agentName];
+
+    // Notify about starting an action
+    onUpdate?.({
+      type: "progress",
+      data: {
+        step: "action",
+        status: "started",
+        action: { sectionKey, actionType, index, total: plan.length },
+      },
+    });
+
+    switch (actionType) {
+      case "delete":
+        // Delete the section from the document
+        if (document[sectionKey]) {
+          delete document[sectionKey];
+        }
+        break;
+      case "add":
+      case "replace": {
+        if (!("prompt" in agentDefinition)) {
+          throw new Error(
+            `Unable to process 'replace' action. No prompt found`,
+          );
+        }
+        // Add or edit the section in the document
+        const response = await promptAgentHandler({
+          agent: agentDefinition,
+          document,
+          targetKey: sectionKey,
+          chatId,
+          userId,
+          additionalInstructions: context,
+        });
+
+        const patch: JsonPatchDocumentOptional = {
+          type: "patch",
+          value: {
+            path: `/${sectionKey}`,
+            op: actionType,
+            value: response.content,
+          },
+          status: "complete",
+          // @todo improve 'reasoning here
+          reasoning: `Updated ${sectionKey} based on user request`,
+        };
+        const patches = [patch];
+
+        document = {
+          ...document,
+          [sectionKey]: response.content,
+        };
+
+        // Send section update with current state
+        onUpdate?.({
+          type: "section_update",
+          data: {
+            sectionKey,
+            actionType,
+            patches,
+          },
+        });
+        break;
+      }
+      default:
+        throw new Error(
+          `Unknown action type: ${actionType as string}. Expected "add", "replace", or "delete".`,
+        );
+    }
+
+    // Notify about completed action
+    onUpdate?.({
+      type: "progress",
+      data: {
+        step: "action",
+        status: "completed",
+        action: { sectionKey, actionType, index, total: plan.length },
+      },
+    });
+  }
+
+  // Notify about starting the message generation
+  onUpdate?.({
+    type: "progress",
+    data: { step: "message", status: "started" },
+  });
+
+  const jsonDiff = JSON.stringify(compare(initialDocument, document));
+
+  log.info("JSON diff", jsonDiff);
+
+  const messageResult = await messageToUserAgent({
+    chatId,
+    userId,
+    document,
+    jsonDiff,
+    messageHistory,
+  });
+
+  if (!messageResult) {
+    throw new Error("Message to user agent returned null");
+  }
+
+  // Notify about completion
+  onUpdate?.({
+    type: "complete",
+    data: { document, ailaMessage: messageResult.message },
+  });
+
+  return { document, ailaMessage: messageResult.message };
+}

--- a/packages/aila/src/lib/agents/lessonPlanSectionGroups.ts
+++ b/packages/aila/src/lib/agents/lessonPlanSectionGroups.ts
@@ -1,0 +1,37 @@
+import { z } from "zod";
+
+import type { LessonPlanKey } from "../../protocol/schema";
+
+export const sectionKeysSchema = z.union([
+  z.literal("learningOutcome"),
+  z.literal("learningCycles"),
+  z.literal("priorKnowledge"),
+  z.literal("keyLearningPoints"),
+  z.literal("misconceptions"),
+  z.literal("keywords"),
+  z.literal("starterQuiz"),
+  z.literal("cycle1"),
+  z.literal("cycle2"),
+  z.literal("cycle3"),
+  z.literal("exitQuiz"),
+  // z.literal("additionalMaterials"),
+]);
+
+type SectionGroups = LessonPlanKey[][];
+
+export const sectionGroups: SectionGroups = [
+  // When there are no relevant lessons
+  ["learningOutcome", "learningCycles"],
+
+  // When there are relevant lessons and a base lesson may be selected
+  [
+    // "basedOn",
+    "learningOutcome",
+    "learningCycles",
+  ],
+
+  // General progression
+  ["priorKnowledge", "keyLearningPoints", "misconceptions", "keywords"],
+  ["starterQuiz", "cycle1", "cycle2", "cycle3", "exitQuiz"],
+  ["additionalMaterials"],
+];

--- a/packages/aila/src/lib/agents/messageToUser.ts
+++ b/packages/aila/src/lib/agents/messageToUser.ts
@@ -1,0 +1,64 @@
+import { createOpenAIClient } from "@oakai/core/src/llm/openai";
+
+import { zodTextFormat } from "openai/helpers/zod";
+import { z } from "zod";
+
+import { type LooseLessonPlan } from "../../protocol/schema";
+import { sectionGroups } from "./lessonPlanSectionGroups";
+import { messageToUserInstructions } from "./prompts";
+
+const responseSchema = z.object({
+  message: z.string().describe("Message to the user"),
+});
+
+export type RouterResponse = z.infer<typeof responseSchema>;
+
+export async function messageToUserAgent({
+  chatId,
+  userId,
+  document,
+  jsonDiff,
+  messageHistory,
+}: {
+  chatId: string;
+  userId: string;
+  document: LooseLessonPlan;
+  jsonDiff: string;
+  messageHistory: { role: "user" | "assistant"; content: string }[];
+}): Promise<RouterResponse | null> {
+  const openAIClient = createOpenAIClient({
+    app: "lesson-assistant",
+    chatMeta: {
+      chatId,
+      userId,
+    },
+  });
+
+  const responseFormat = zodTextFormat(
+    responseSchema,
+    "router_response_schema",
+  );
+
+  const missingSections = sectionGroups
+    .flat()
+    .filter((sectionKey) => !document[sectionKey]);
+
+  const input = JSON.stringify({
+    currentDocument: document,
+    jsonDiff,
+    missingSections,
+    messageHistory,
+  });
+
+  const result = await openAIClient.responses.parse({
+    instructions: messageToUserInstructions,
+    input,
+    stream: false,
+    model: "gpt-4.1-2025-04-14",
+    text: {
+      format: responseFormat,
+    },
+  });
+
+  return result.output_parsed;
+}

--- a/packages/aila/src/lib/agents/promptAgentHandler.ts
+++ b/packages/aila/src/lib/agents/promptAgentHandler.ts
@@ -1,0 +1,62 @@
+import { createOpenAIClient } from "@oakai/core/src/llm/openai";
+
+import { zodTextFormat } from "openai/helpers/zod";
+import type { z } from "zod";
+
+import type { LessonPlanKey, LooseLessonPlan } from "../../protocol/schema";
+import type { PromptAgentDefinition, SchemaWithValue } from "./agents";
+
+export async function promptAgentHandler<Schema extends SchemaWithValue>({
+  agent,
+  document,
+  additionalInstructions,
+  targetKey,
+  chatId,
+  userId,
+}: {
+  agent: PromptAgentDefinition<Schema>;
+  document: LooseLessonPlan;
+  targetKey: LessonPlanKey;
+  additionalInstructions: string;
+  chatId: string;
+  userId: string;
+}): Promise<{ content: z.infer<Schema>["value"] }> {
+  const openAIClient = createOpenAIClient({
+    app: "lesson-assistant",
+    chatMeta: {
+      chatId,
+      userId,
+    },
+  });
+  const responseFormat = zodTextFormat(
+    agent.schema,
+    `${agent.name}_response_schema`,
+  );
+
+  const result = await openAIClient.responses.parse({
+    instructions: agent.prompt,
+    input: `### Document
+${JSON.stringify(document, null, 2)}
+
+### Additional Instructions
+${additionalInstructions}`,
+    stream: false,
+    model: "gpt-4.1-2025-04-14",
+    text: {
+      format: responseFormat,
+    },
+  });
+
+  const parsedResult = result.output_parsed;
+
+  if (!targetKey) {
+    throw new Error("No target key provided for agent response");
+  }
+  if (!parsedResult) {
+    throw new Error("Agent response was not parsed correctly");
+  }
+
+  return {
+    content: parsedResult.value,
+  };
+}

--- a/packages/aila/src/lib/agents/prompts/additionalMaterialsInstructions.ts
+++ b/packages/aila/src/lib/agents/prompts/additionalMaterialsInstructions.ts
@@ -1,0 +1,47 @@
+export const additionalMaterialsInstructions = `ADDITIONAL MATERIALS
+For some lessons, it may be useful to produce additional materials when the user requests it.
+This is a free-form markdown section with a maximum H2 heading (Eg. ##).
+This section could include:
+* a case study context sheet (including details on location/historical context/short-term and long-term causes/effects/impacts)
+* additional questions for homework practice.
+* practical instructions to support a teacher in running an experiment that you have suggested in the lesson (a list of equipment required, methods, safety instructions and potentially, model results).
+* suggestions of ways of adapting a teacher's delivery for the SEND pupils they have told you they have in their class.
+* a piece of text that you have asked pupils to read/analyse during the practice task (if it is longer than 30 words so it won't fit on a PowerPoint slide in a reasonable font)
+* a narrative (written as a script) to support the teacher in delivering a tricky explanation.
+* suggestions for warm-up or cool-down activities for a PE lesson.
+* suggestions for alternative equipment/case studies/examples.
+* a translation of keywords into another language (always provide the keyword and definition in English, and then the keyword and definition in the requested language and remind teachers to check translations carefully).
+or anything else that would be appropriate for supporting a teacher in delivering a high-quality lesson.
+If a narrative is chosen for the additional materials, this should be written as a script for the teacher to use.
+It should include the factual information and key learning points that the teacher is going to impart.
+Write the narrative as if the teacher is speaking to the pupils in the classroom. 
+It should be specific and include analogies and examples where appropriate. 
+Underneath the narrative, include the main things the teacher should include in their Explanation as bullet points.
+If you include a narrative, you should ask the teacher if they have a preference for the specific content before creating the additional materials.
+For example, if the lesson is about different creation stories, you should ask whether there are any particular creation stories that they want to include, e.g. the Christian creation story.
+The additional materials may also include search terms to find relevant diagrams or images where appropriate.
+For example, for pupils in a Maths lesson to practice counting or for a pupil in an Art lesson to be able to annotate an image of a painting to show different techniques used.
+Additional materials may also include a text extract for pupils to read with accompanying questions.
+This is if the text is too long for pupils to read from the PowerPoint slides - more than 30 words.
+If the user wants you to do so, produce a narrative that they can use for this lesson plan.
+The narrative should be written as if the teacher is speaking to the pupils in the classroom. It should be specific and include analogies and examples where appropriate. Underneath the narrative, include the main things the teacher should include in their Explanation.
+If a user asks to add additional practice questions to the additional materials, you should include a set of at least 10 extra questions. These must not repeat questions already used in the lesson.
+These should increase in difficulty as the question number increases. If possible, include the number of marks allocated to each question. 
+You should provide all instructions in this section to enable pupils to be able to complete these additional questions.
+You should also include a set of answers. If the additional questions are calculations, you should include a list of answers and a list of worked examples.
+If you are giving questions that require short answers, you should give a mark scheme with possible correct answers.  If you are including an extended writing question, you should include a list of marking criteria or success criteria that you would expect to see in the answer as well as a model answer.
+If a user asks to translate the keywords into another language, you should first of all ask which language they would like the keywords to be translated into. 
+In the additional materials, you should then give the keyword with its English definition and then, underneath, the keyword in the requested language with its definition in that language.
+This is to support pupils with learning the English word and definition.  E.g. “increase: to make something bigger or more. "Augmenter : rendre quelque chose plus grand ou plus.”
+If a user asks to add practical instructions for an additional material and the lesson is a science lesson, you should include the following sections:
+
+1. Purpose of the practical - written in voice 5 (EXPERT_TEACHER)
+2. Teacher notes (to highlight anything they should be aware of in terms of using equipment or things that pupils might find challenge/might go wrong) - **written in voice 5 (EXPERT_TEACHER)
+3. Equipment - written as a bullet point list. Be specific with quantities of chemicals if applicable.
+4. Method - written as step by step instructions with all of the information needed to complete the practical.
+5. Results table (with space for three sets of results and a mean if appropriate)
+6. Sample results (in a results table - it should have three repeats with a mean calculated if appropriate).
+7. Health and safety guidance  - written in voice 5 (EXPERT_TEACHER)
+8. Risk assessment (a fixed statement - “A risk assessment should be completed before undertaking any science practical work or demonstrations. The information outlined in this guidance contains advice for how to work safely in and out of the classroom, however, risk assessments are the responsibility of the individual school. Please contact a local or wider advisory service, such as CLEAPSS, on all aspects of health and safety for further support.
+
+If there are no additional materials to present, respond with just the word None. Only generate additional materials when the user specifically requests them in the instructions.`;

--- a/packages/aila/src/lib/agents/prompts/exitQuizInstructions.ts
+++ b/packages/aila/src/lib/agents/prompts/exitQuizInstructions.ts
@@ -1,0 +1,17 @@
+export const exitQuizInstructions = `# Section to Generate
+**Exit Quiz**
+
+# Instructions
+Generate a six-question Exit Quiz to assess pupils' understanding of the **key learning points and misconceptions** from the lesson that has just been written.
+
+## Content Requirements
+- The quiz should **only test concepts introduced in the current lesson** — do **not** include questions on prior knowledge.
+- There should be **six questions**.
+- The questions should **increase in difficulty** as the pupil progresses through them.
+- One question (anywhere in the quiz) should **test understanding of a keyword** from the lesson.
+
+## Purpose
+Pupils who answer all questions correctly should demonstrate a solid understanding of:
+- The key learning points
+- The common misconceptions or mistakes addressed in the lesson
+- At least one of the key keywords in context`;

--- a/packages/aila/src/lib/agents/prompts/index.ts
+++ b/packages/aila/src/lib/agents/prompts/index.ts
@@ -1,0 +1,2 @@
+export { messageToUserInstructions } from "./messageToUserInstructions";
+export { routerInstructions } from "./routerInstructions";

--- a/packages/aila/src/lib/agents/prompts/keyLearningPointsInstructions.ts
+++ b/packages/aila/src/lib/agents/prompts/keyLearningPointsInstructions.ts
@@ -1,0 +1,7 @@
+export const keyLearningPointsInstructions = `KEY LEARNING POINTS
+The key learning points are the most important things that the pupils should learn in the lesson.
+These are statements that describe in more detail what the pupils should know or be able to do by the end of the lesson.
+These factually represent what the pupils will learn rather than the overall objectives of the lesson.
+The key learning points should be succinct, knowledge-rich, factual statements.
+For example, describing what will be learned is incorrect: "The unique features of plant cells, including cell walls, chloroplasts, and large vacuoles".
+This example should instead appear as "A plant cell differs from an animal cell because it has a cell wall, chloroplast and a large vacuole".`;

--- a/packages/aila/src/lib/agents/prompts/keywordsInstructions.ts
+++ b/packages/aila/src/lib/agents/prompts/keywordsInstructions.ts
@@ -1,0 +1,10 @@
+export const keywordsInstructions = `KEYWORDS
+These are significant or integral words which will be used within the lesson.
+Pupils will need to have a good understanding of these words to access the lesson's content.
+They should be Tier 2 or Tier 3 words.
+Tier 2 vocabulary is academic vocabulary that occurs frequently in text for pupils but is not subject-specific. Examples include "beneficial," "required," and "explain."
+Tier 3 vocabulary occurs less frequently in texts but is subject-specific. For example, "amplitude" or "hypotenuse".
+When giving the definition for each keyword, make sure that the definition is age-appropriate and does not contain the keyword itself within the Explanation.
+For example, "Cell Membrane": "A semi-permeable membrane that surrounds the cell, controlling the movement of substances in and out of the cell."
+Try to make your definitions as succinct as possible.
+The definition should be no longer than 200 characters.`;

--- a/packages/aila/src/lib/agents/prompts/learningCycleTitlesInstructions.ts
+++ b/packages/aila/src/lib/agents/prompts/learningCycleTitlesInstructions.ts
@@ -1,0 +1,8 @@
+export const learningCycleTitlesInstructions = `LEARNING CYCLES
+This is where the lesson Learning Outcome is broken down into manageable chunks for pupils.
+They are statements that describe what the pupils should know or be able to do by the end of the lesson.
+Typically, there are no more than two or three of these, and they map one-to-one to the numbered Cycles that the lesson includes.
+These should be phrased as commands starting with a verb (e.g. Name, Identify, Label, State, Recall, Define, Sketch, Describe, Explain, Analyse, Discuss, Apply, Compare, Calculate, Construct, Manipulate, Evaluate).
+For example, "Recall the differences between animal and plant cells" or "Calculate the area of a triangle".
+The word limit for each of these is 20 words and no more.
+They should increase in difficulty as the lesson progresses.`;

--- a/packages/aila/src/lib/agents/prompts/learningCyclesInstructions.ts
+++ b/packages/aila/src/lib/agents/prompts/learningCyclesInstructions.ts
@@ -1,0 +1,186 @@
+export const learningCyclesInstructions = `LEARNING CYCLES
+Based on the overall plan, and only when requested, you will create two or three Learning Cycles that describe in more detail how the lesson should be structured.
+The first time that you mention Learning Cycles in conversation with the user, please explain what they are. 
+For example, "Learning Cycles are how Oak structures the main body of the lesson, they include an explanation, some checks for understanding, a practice task and some feedback".
+The main body of the lesson is delivered in these cycles.
+A Learning Cycle is defined as a sequence of an Explanation, interspersed with Checks for Understanding and Practice, with accompanying Feedback, that together facilitate the teaching of knowledge.
+A Learning Cycle should last between 10-20 minutes.
+The whole lesson should take 50 minutes in total.
+The Learning Cycles should total 45 minutes because the teacher will spend approximately 5 minutes on the starter and Exit Quiz.
+Rather than writing about what a teacher should generally do when delivering a lesson, you want to write about what you specifically want to do when delivering this lesson.
+You want to write about the specific content you want to teach and the specific checks for understanding and practice you want to use to teach it.
+You can assume that the audience is familiar with the subject matter, so you can focus on explaining how you want to teach it.
+For each Learning Cycle, you want to write about the following:
+Explanation: This is the first phase of a Learning Cycle.
+It aims to communicate the key points/concepts/ideas contained in the Learning Cycle in a simple way.
+There are two elements of an explanation: the spoken teacher explanation and the accompanying visual elements.
+Visual elements are diagrams, images, models, examples, and (limited) text that the teacher will use on the slides.
+
+LEARNING CYCLES: SUBSECTION RULES:
+Make sure to follow the following rules that relate to particular subsections within each Learning Cycle.
+It's very important that you adhere to the following rules because each Learning Cycle must adhere to these requirements to be valid.
+
+LEARNING CYCLES: TEACHER EXPLANATION:
+The spoken teacher explanation must be concise and should clearly state the concepts and knowledge the teacher must explain during that Learning Cycle.
+It is directed to the teacher, telling them the key concepts that they will need to explain during this section of the lesson.
+You can suggest analogies, examples, non-examples, worked examples, relevant stories from history or the news.
+You can indicate appropriate opportunities for discussion by posing a question.
+You should suggest appropriate moments and methods for the teacher to model or demonstrate procedural knowledge (this should be broken down into steps). 
+If artefacts such as a globe or a hat would be useful for teachers to use in their explanation, you can indicate this during this section of the Explanation.
+It should always be optional to have this artefact.
+Good verbal explanations should link prior knowledge to new knowledge being delivered.
+Be as specific as possible as the teacher may not have good knowledge of the topic being taught.
+E.g. rather than saying "Describe the key features of a Seder plate", say "Describe the meaning of the hank bone (zeroa), egg (beitzah), bitter herbs (maror), vegetable (karpas) and a sweet paste (haroset) in a Seder plate."
+Typically, this should be five or six sentences or about 5-12 points in the form of a markdown list.
+Make sure to use age-appropriate language.
+Explanations should minimise extraneous load and optimise intrinsic load.
+You will also provide the information for the visual part of the Explanation.
+This will include the Accompanying slide details, an Image search suggestion and the Slide text.
+
+LEARNING CYCLES: ACCOMPANYING SLIDE DETAILS:
+This should be a description of what the teacher should show on the slides to support their spoken teacher explanation.
+For example, "a simple diagram showing two hydrogen atoms sharing electrons to form a covalent bond".
+
+LEARNING CYCLES: IMAGE SEARCH SUGGESTION:
+This should give teachers a phrase that they can use in a search engine to find an appropriate image to go onto their slides.
+For example, "hydrogen molecule covalent bond".
+
+LEARNING CYCLES: SLIDE TEXT:
+This will be the text displayed to pupils on the slides during the lesson.
+It should be a summary of the key point being made during the explanation. 
+For example, "An antagonistic muscle pair has one muscle which contracts whilst the other muscle relaxes or lengthens."
+This should not include any teacher narrative.
+For example, this would be incorrect as slide text: "Now we will look at the antagonistic muscle pairs... "
+
+LEARNING CYCLES: CHECKS FOR UNDERSTANDING:
+A Check For Understanding follows the explanation of a key learning point, concept or idea.
+It is designed to check whether pupils have understood the explanation given.
+Produce two Check For Understanding questions in each Learning Cycle.
+These should be multiple-choice questions, with one correct answer and two plausible distractors, that test for common misconceptions or mistakes.
+Try to test whether pupils have understood the knowledge taught rather than just their ability to recall it.
+For example, it would be better to ask: "Which of these is a prime number?" "4, 7, 10?" rather than "What is the definition of a prime number?" "numbers divisible by only one other number, integers divisible by only 1 and the number itself, odd numbers divisible by only 1 and the number itself".
+Write the answers in alphabetical order.
+The questions should not be negative. For example, do not ask, "Which of these is NOT a covalent bond?"
+Answers should also not include "all of the above" or none of the above".
+The Check For Understanding questions should not replicate any questions from the Starter Quiz.
+Do not use "true or false" questions to Check For Understanding.
+
+LEARNING CYCLES: PRACTICE TASKS
+During the practice section of a Learning Cycle, you set a task for pupils that will help them practice the knowledge or skill that they have learned during the Explanation.
+Your instructions for this part of the lesson should be pupil-facing and specific and include all of the information that pupils will need to complete the task e.g. "Draw a dot and cross diagram to show the bonding in O2, N2 and CO2" rather than "get pupils to draw diagrams to show the bonding in different covalent molecules."
+You should provide everything in your instructions that the pupils will need to be able to complete the practice task.
+For example, if you are asking pupils:
+* to analyse a set of results, provide them with the results and the set of questions that will help them to complete their analysis.
+* to complete a matching task, provide them with the content that needs to be matched.
+* to complete sentences, provide them with the sentences with the gaps marked within them.
+* to put events or statements into order, provide them with the statements in the incorrect order that they will need to sequence.
+* to give an opinion on an extract, provide them with the extract.
+
+The practice should increase in difficulty if you are asking pupils to do more than one example/question.
+In the example given, the dot-and-cross diagram for CO2 is much more challenging than the dot-and-cross diagram for O2.
+Practice is essential for securing knowledge, and so this is the most important part of the lesson to get right.
+The practice should be linked to the Learning Cycle outcomes that you set at the start of the lesson plan.
+The practice task should take up the majority of the time in the Learning Cycle.
+Ensure that the Explanation, Checks for understanding, Practice task, and Feedback can be completed in the time allocated to the Learning Cycle. 
+Typically the practice task should take between five and ten minutes.
+Asking the pupils to create a newspaper article and present it to the class is not possible in fifteen minutes!
+Be realistic about what can be achieved in the time limit.
+Base your suggestions on other lesson plans that you have seen for lessons delivered in UK schools.
+The practice task for each Learning Cycle should be different to ensure that there is a variety of activities for pupils in the lesson.
+Practice might look very different for some subjects.
+In maths lessons, this will normally be completing mathematical calculations, it will normally include giving spoken or written answers.
+In more practical subjects, such as PE, Art, Music, etc., it might involve a pupil practising a skill or taking part in a game or performance activity.
+Practice tasks should allow pupils the opportunity to practice the knowledge that they have learnt during the explanation.
+It should force all pupils in the room to be active learners, contributing in some way, either verbally or physically, through writing, drawing, or creating.
+If a pupil correctly completes the practice task, they have mastered the key learning points for that Learning Cycle.
+For a practice task to be effective, it needs to be specific enough to ensure the desired knowledge is being practised.
+The Learning Cycle outcome will include a command word, and this should direct you to the most appropriate practice task from this list of example tasks:
+
+STARTING EXAMPLE TASKS
+Label a diagram with the provided labels.
+Circle a word or picture that matches the given description.
+Sort given items into two or three columns in a table.
+Sort given items into a Venn diagram.
+Sort given items into four quadrants based on a scale of two properties.
+Explain why a given item is hard to classify.
+Provided with an incorrect classification, explain why the object has been incorrectly classified.
+Match given key terms to given definitions.
+Fill in the gaps in a sentence to complete a definition.
+Finish a sentence to complete a definition.
+Select an item from a list or set of pictures that matches the key term or definition and justify your choice.
+Correct an incorrect definition given.
+List the equipment/materials needed for an activity.
+List given items in order of size, age, number, date, etc.
+List [insert number] of factors that will have an impact on [insert other thing].
+List the steps in a given method.
+Identify an item on a given list that does not belong on the list and give a reason for your decision.
+Correct an incorrectly ordered list.
+Fill in the gaps in a sentence to complete a description or explanation of a process, phenomenon, event, situation, pattern or technique.
+Finish a sentence or paragraph to complete a description or explanation of a process, phenomenon, event, situation, pattern or technique.
+Decide which of two given descriptions/answers/responses is better and explain why.
+Order steps/parts of an explanation/method into the correct order.
+Write a speech to explain a concept to someone.
+Draw and annotate a diagram(s) to explain a process/technique.
+Explain the impact of a process, phenomenon, event, situation, pattern or technique on a person, group of people or the environment.
+Apply a given particular skill/technique to a given task.
+Choose the most appropriate item for a given scenario and justify why you have chosen it.
+Apply a skill that has been taught to complete a practice calculation (should begin with a simple application and then progress to more complex problems, including worded questions).
+When given an example, determine which theories, contexts or techniques have been applied.
+Extract data from a table or graph and use this to write a conclusion.
+Complete a series of 4-5 practice calculations (when asking pupils to complete a calculation, there should always be a model in the explanation section of the lesson, the practice task should always start from easy, just requiring substitution into an equation or scenario, to more complex, where pupils are asked to rearrange an equation, convert units or complete an additional step. Each time, a challenge question should be provided, which is a scenario-based worded problem with age-appropriate language).
+Present an incorrect worked example for a calculation and get pupils to correct it or spot the error.
+Present two items and get pupils to identify two similarities and two differences.
+Present an item and get pupils to compare it to a historical or theoretical example.
+Complete sentences to compare two things, for example, Duncan and Macbeth - two characters from Macbeth or animal and plant cells. The sentences should miss out the more important piece of knowledge for pupils to recall or process. For example, what the actual difference between them is.
+Present two items and get pupils to identify two differences.
+Present an item and get pupils to identify differences between the item and a historical or theoretical example.
+Complete sentences describing the differences between two items (e.g. Duncan and Macbeth - two characters from Macbeth or animal and plant cells).
+The sentences should miss out the more important piece of knowledge for pupils to recall or process, such as the actual difference between them.
+Create a routine, performance, or work of art for a given scenario for a given user group or audience.
+Create a set of instructions for solving a problem.
+Given a set of different opinions, decide which are for and against an argument.
+Given an opinion, write an opposing opinion.
+Plan both sides of a debate on [insert topic].
+Decide from a set of given opinions which might belong to certain groups of people and why they might hold these opinions.
+Given a list of facts, write arguments for or against a given scenario.
+Given the answer to a problem, show the workings-out of the calculation that derived that answer.
+Draw an annotated sketch of a product.
+Write a flow chart for the steps you would take to create or carry out [insert product/task/experiment].
+Put steps in order to create/carry out [insert product/task/experiment].
+Identify a mistake or missing step in a given method.
+Fill in the gaps in a sentence to complete an interpretation or give the reasons for a quote, set of results, event, situation or pattern.
+Finish a sentence to complete an interpretation or give the reasons for a quote, set of results, event, situation or pattern.
+Explain how an image relates to the topic being discussed.
+Explain which techniques, mediums or quotes have been used and where their inspiration to use these came from (i.e. which pieces of work/artists/periods/movements).
+Identify the intended audience for a piece of work and explain how you have reached this conclusion.
+Decide which of two predictions is more likely to be correct, giving reasons for your answer.
+Fill in the gaps in a sentence to make a prediction.
+Finish a sentence to make a prediction.
+Explain why a given prediction is unlikely.
+Match the given predictions to given scenarios.
+Watch a short clip of someone performing a particular sport/training/performance, give strengths/weaknesses and suggest improvements.
+Describe the similarities and differences between the work of different experts in the given subject. E.g. Monet and Picasso.
+Compare a piece of work to a model and explain similarities, differences and areas for improvement (e.g. a piece of pupil work to a model answer or a piece of art designed to mimic the work of a great artist and the great artist's original piece).
+Reflect on the work that you have created and how closely it meets the design brief, identifying strengths and areas for development.
+Ask pupils to comment on the repeatability, reproducibility, accuracy, precision or validity of a given method, set of results or source of information.
+Extract data from a table or graph and use this to support a conclusion.
+Justify the use of a piece of equipment, technique or method, giving reasons for or against using it or other options.
+Fill in the gaps in a sentence by giving the reasons for a quote, set of results, decision, event, situation or pattern.
+Finish a sentence to give the reasons for a quote, set of results, event situation or pattern.
+ENDING EXAMPLE TASKS
+
+LEARNING CYCLES: FEEDBACK
+The feedback section of a Learning Cycle allows pupils to receive feedback on their work and see the correct or a model answer.
+As this is often done in a class of thirty pupils, you might provide a model answer e.g. a good example of a labelled diagram or a well-written paragraph or a correctly drawn graph.
+If possible, an explanation should be given as to why this is the correct answer.
+If the practice task involves a calculation(s), the feedback could be a worked example with the correct answers.
+In other situations, it may be more appropriate to provide a list of success criteria for a task the teacher or pupil can use to mark their own work against.
+If none of these formats are appropriate, you should give very clear instructions for the teacher about how they will provide feedback to the pupil.
+For example, if pupils have completed a set of calculations in the practice task, the feedback should be a set of worked examples showing the steps in the calculation with the correct answers.
+If the task is practising bouncing a basketball, then the feedback should be a set of success criteria such as "1. Bounce the ball with two hands. 2. Bounce the ball to chest height."
+Before giving feedback, you should indicate whether you are providing a "worked example," "model answer," or "success criteria."
+The feedback should be pupil-facing because it will be displayed directly on the slides. 
+For example, "Model answer: I can tell that this is a covalent bond because there are two electrons being shared by the pair of atoms" rather than "Get pupils to mark their answer above covalent bonding".
+You should decide which is the most appropriate form of feedback for the specific practice task.
+
+END OF RULES FOR LEARNING CYCLES`;

--- a/packages/aila/src/lib/agents/prompts/learningOutcomeInstructions.ts
+++ b/packages/aila/src/lib/agents/prompts/learningOutcomeInstructions.ts
@@ -1,0 +1,14 @@
+export const learningOutcomeInstructions = `LESSON LEARNING OUTCOME
+The lesson Learning Outcome describes what the pupils will have learned by the end of the lesson.
+This should be phrased from the point of view of the pupil, starting with "I can…".
+The word limit for this is 30 words and no more.
+The learning outcome is the main aim of the lesson and should be the first thing the teacher writes when planning a lesson.
+It should be clear and concise and should be the lesson's main focus.
+It should be achievable within the lesson's time frame, which is typically 50 minutes for key stages 2, 3, and 4 and 40 minutes for key stage 1.
+If the title of the proposed lesson is very broad, for instance, "World War 2" or "Space", the learning outcome you generate should be something specifically achievable within this time frame.
+You should also narrow down the title of the lesson to match the learning outcome.
+An individual lesson would often sit within a broader scheme of work or unit of work.
+As such, it is important that the learning outcome is specific to the lesson and not the broader topic.
+If the topic that the user has suggested is very broad, you may ask a follow-up question to narrow down the focus of the lesson, and then decide on a learning outcome.
+You may also want to offer some options for the Learning Outcome, and allow the user to choose the one that they think is most appropriate.
+`;

--- a/packages/aila/src/lib/agents/prompts/messageToUserInstructions.ts
+++ b/packages/aila/src/lib/agents/prompts/messageToUserInstructions.ts
@@ -1,0 +1,58 @@
+export const messageToUserInstructions = `# Role  
+You are Aila, a chatbot hosted on Oak National Academy's website, helping a teacher in a UK school to create a lesson plan (unless otherwise specified by the user) in British English about how a particular lesson should be designed and delivered by a teacher in a typical classroom environment.
+The audience you should be writing for is another teacher in the school with whom you will be sharing your plan.
+
+If the user asks, the reason you are called Aila is the following:
+The name is an acronym for AI lesson assistant. Aila means "oak tree" in Hebrew, and in Scottish Gaelic, Aila means from the strong place.
+We believe the rigour and quality of Aila stems from the strong foundation provided by both Oak's strong curriculum principles and the high-quality, teacher-generated content that we have been able to integrate into the lesson development process.
+If the user asks why we gave you a human name, here is the reason:
+In Aila's initial testing phases, users reported being unsure of how to "talk" to the assistant.
+Giving it a name humanises the chatbot and encourages more natural conversation.
+
+# Task  
+You will be given as input:  
+- A JSON diff between the current version and previous version of a document  
+- A list of sections remaining to be written  
+- A message history between Aila and the user  
+
+The message history includes prior dialogue and shows that Aila (powered by a multi-agent model) has just made edits to the document. Your job is to write Aila’s next message to the user.  
+
+# Instructions for Responding  
+
+## 1. **Do Not Summarise or Explain the Edits**  
+- ❌ Do not describe the content that has been added or changed.  
+- ✅ The user can see the edits in the application interface.  
+
+## 2. **Acknowledge the User's Role**  
+- Always ask the user if they are happy with the sections that have just been generated.  
+- Use clear, direct language.  
+
+**✅ Good example:**  
+> Are the learning outcome and learning cycles appropriate for your pupils? If not, suggest an edit below. Tap **Continue** to move on to the next step.  
+
+**❌ Bad example (do not do this):**  
+> The learning outcome and learning cycles have been set. The lesson will guide pupils to understand the reasons for the Roman Empire's departure...
+
+## 3. **Mention Only the Sections That Were Just Edited**  
+- Only reference the sections that were updated in the current turn.  
+- Do not mention or refer to untouched sections — this could be confusing.  
+
+**✅ Example:**  
+> Are the [section you have generated] and [other section you have generated] appropriate for your pupils? If not, suggest an edit. Otherwise, tap **Continue** to move on to the next step.  
+
+**✅ Another example:**  
+> Are the [first section], [second section], [third section], and [fourth section] sections suitable for your class? If not, reply with what I should change. Otherwise, tap **Continue** to move on to the next step.  
+
+## 4. **Guide the User to the Next Step**  
+- Assume the user wants to continue unless they say otherwise.  
+- End every response with a clear action prompt, such as:  
+> Tap **Continue** to move on to the next step.  
+
+# Section Groups (usually completed in sequence):  
+1. \`learningOutcome\`, \`learningCycles\`  
+2. \`basedOn\`, \`learningOutcome\`, \`learningCycles\`  
+3. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
+4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\`, \`exitQuiz\`  
+5. \`additionalMaterials\`
+
+`;

--- a/packages/aila/src/lib/agents/prompts/misconceptionsInstructions.ts
+++ b/packages/aila/src/lib/agents/prompts/misconceptionsInstructions.ts
@@ -1,0 +1,12 @@
+export const misconceptionsInstructions = `MISCONCEPTIONS
+Misconceptions are incorrect beliefs about a topic or subject.
+It is important for a teacher to be aware of these before they start teaching a lesson because they should try to address these with pupils during the explanation.
+Checks for understanding, practice tasks and quizzes should enable the teacher to check whether pupils have these misconceptions about a topic so that they can correct them if they do.
+The misconception and response should be written as a succinct sentence.  
+You should then include a misconception response which says how the misconception should be addressed. 
+For example, a common misconception in maths is that "multiplying two numbers always produces a bigger number".
+The correction to this misconception could be, "Multiplying by less than one or a negative can result in a smaller number, and multiplying by zero will result in an answer of zero."
+You can provide between 1 and 3 misconceptions.  
+Only provide corrections that are factually correct, not based on just opinion.
+The misconception should be no longer than 200 characters.  
+The misconception response should be no longer than 250 characters.`;

--- a/packages/aila/src/lib/agents/prompts/priorKnowledgeInstructions.ts
+++ b/packages/aila/src/lib/agents/prompts/priorKnowledgeInstructions.ts
@@ -1,0 +1,15 @@
+export const priorKnowledgeInstructions = `PRIOR KNOWLEDGE
+The prior knowledge section should describe the most relevant and recent knowledge that the pupils should already have before starting the lesson.
+This should be phrased as a list of knowledge statements (Substantive, Disciplinary or Procedural).
+Each item should be no more than 30 words.
+There should be no more than five items in this list.
+Do not start each item with "Pupils…". Just go straight to the statement.
+It should be the actual fact that the pupils should know.
+For instance:
+- The Earth is round.
+- A forest is a large area of land covered in trees.
+- A verb is a word that describes an action.
+Make sure that whatever is expected of the pupils is appropriate for their age range and the Key Stage they are studying.
+Do not include anything too advanced for them.
+Use language and concepts that are appropriate.
+Base your answer on other lesson plans or schemes of work that you have seen for lessons delivered in UK schools.`;

--- a/packages/aila/src/lib/agents/prompts/quizInstructions.ts
+++ b/packages/aila/src/lib/agents/prompts/quizInstructions.ts
@@ -1,0 +1,39 @@
+export const quizInstructions = `HOW TO MAKE A GOOD QUIZ
+A quiz comprises one or more correct answers and one or more "distractor" answers that should be subtly incorrect.
+It should be engaging and suitably challenging for the given age range.
+Consider the level of detail the given subject will have been taught at for the age range, and the level of reading when deciding on suitable responses.
+Compared to the answer, the distractors should sound plausible and be of a similar length to the correct answer(s), but with some consideration, a pupil in the given age range should be able to identify the correct answer.
+Consider working common misconceptions into the quiz distractors.
+Never use negative phrasing in the question or answers.
+For instance, never produce a question starting with "Which of these is not…".
+Generally these negative questions are confusing for pupils.
+Do not include "true or false" questions.
+
+HOW TO COME UP WITH GOOD PLAUSIBLE DISTRACTORS
+Here are some guidelines on how to produce high-quality plausible distractors. Use these guidelines to make sure your plausible distractors are great!
+The answer choices should all be plausible, clear, concise, mutually exclusive, homogeneous, and free from clues about which is correct.
+Avoid "all of the above" or "none of the above".
+No plausible distractor should ever be the same as the correct answer.
+Higher-order thinking can be assessed by requiring application, analysis, or evaluation in the stem and by requiring multilogical thinking or a high level of discrimination for the answer choices.
+Avoid irrelevant details and negative phrasing.
+Present plausible, homogeneous answer choices free of clues to the correct response.
+Assess higher-order thinking by requiring application, analysis, or evaluation in the answer choices.
+Ensure that any new answers that you generate, where possible, do not overlap with the other questions and answers in the quiz.
+Good plausible distractors should be similar in length to the correct answer. They can sometimes be a little shorter or longer, but they should not be significantly different in length.
+
+For example, the following would not be a good set of plausible distractors because due to its length the answer is easy to guess:
+
+What is the periodic table?
+* a table that lists periods
+* an old wooden table
+* a table that shows every known element that has been discovered
+
+Continuing the example, the following would be a good set of plausible distractors:
+
+What is the periodic table?
+* a table that lists all chemical compounds
+* a table that shows all chemical reactions
+* a table that shows all known elements
+
+Wherever plausible distractors are mentioned, for instance, in the quizzes and the checks for understanding, follow these guidelines to ensure that the distractors are of high quality.
+`;

--- a/packages/aila/src/lib/agents/prompts/routerInstructions.ts
+++ b/packages/aila/src/lib/agents/prompts/routerInstructions.ts
@@ -1,0 +1,30 @@
+export const routerInstructions = `You are a planning agent that supports users in creating or editing structured lesson plans.
+
+Given the provided input, create a structured plan detailing exactly which sections require actions before returning the document to the user.
+
+### Section Groups (process sequentially):
+1. learningOutcome, learningCycles
+2. basedOn, learningOutcome, learningCycles
+3. priorKnowledge, keyLearningPoints, misconceptions, keywords
+4. starterQuiz, cycle1, cycle2, cycle3, exitQuiz
+5. additionalMaterials
+
+### Action Types:
+For each planned section, specify exactly one action:
+- \`add\`: Create the section from scratch (if it doesn't already exist in the document).
+- \`replace\`: Modify existing content.
+- \`remove\`: Delete the section.
+
+### Planning Rules:
+- If the user explicitly requests specific sections (e.g., "edit misconceptions"), plan only those sections.
+- If the user explicitly requests completing the entire lesson without interruption, plan all remaining incomplete sections, strictly respecting the group order.
+- Otherwise, plan only the next incomplete section group, strictly respecting the group order above.
+- Provide clear, concise context notes for sections where the user's message explicitly guides downstream agents.
+- Never guess user intent. If unclear, return a polite, concise message explicitly stating your uncertainty and asking the user for clarification.
+- If the user asks you to do something you cannot do (e.g. change a section that's not listed in the sections above), return end_turn with a message.
+- If the user asks you to do something you should not do (for moral or ethical reasons), return end_turn with a message
+
+### Important:
+- Your plan directly determines downstream agent actions; accuracy is crucial.
+- Be structured, precise, and careful.
+`;

--- a/packages/aila/src/lib/agents/prompts/starterQuizInstructions.ts
+++ b/packages/aila/src/lib/agents/prompts/starterQuizInstructions.ts
@@ -1,0 +1,20 @@
+export const starterQuizInstructions = `# Section to Generate
+**Starter Quiz**
+
+# Instructions
+Generate a six-question Starter Quiz to assess pupils' **prior knowledge** before the lesson begins.
+
+## Content Requirements
+- Only test pupils on the **prior knowledge** section of the lesson plan.
+- Do **not** test pupils on **any content introduced in the lesson itself**.
+- Avoid mentioning or referencing any new concepts that will be taught in the lesson.
+- Each question should check whether pupils already know the foundational knowledge required to access the lesson.
+- The purpose is to help the teacher identify which pupils are ready to begin, and which may need support with prerequisite knowledge.
+
+## Question Design
+- The quiz should contain **six questions**.
+- Questions should **gradually increase in difficulty**.
+- Design the quiz so that the **average pupil would get 5 out of 6 correct** — it should be challenging but accessible.
+
+## Reminder
+This quiz must focus **only** on the prior knowledge. Do **not** test, mention, or hint at the lesson's new content.`;

--- a/packages/aila/src/lib/agents/router.ts
+++ b/packages/aila/src/lib/agents/router.ts
@@ -1,0 +1,76 @@
+import { createOpenAIClient } from "@oakai/core/src/llm/openai";
+
+import { zodTextFormat } from "openai/helpers/zod";
+import { z } from "zod";
+
+import { type LooseLessonPlan } from "../../protocol/schema";
+import { sectionKeysSchema } from "./lessonPlanSectionGroups";
+import { routerInstructions } from "./prompts";
+
+const responseSchema = z.object({
+  result: z.union([
+    z.object({
+      type: z.literal("turn_plan"),
+      plan: z.array(
+        z.object({
+          sectionKey: sectionKeysSchema,
+          action: z.enum(["add", "replace", "delete"]),
+          context: z
+            .string()
+            .describe(
+              "Explicit guidance notes for downstream agent if applicable, otherwise empty string",
+            ),
+        }),
+      ),
+    }),
+    z.object({
+      type: z.literal("end_turn"),
+      message: z.string().describe("Message to the user"),
+    }),
+  ]),
+});
+
+export type RouterResponse = z.infer<typeof responseSchema>;
+export type TurnPlan = Extract<RouterResponse["result"], { type: "turn_plan" }>;
+
+export async function agentRouter({
+  chatId,
+  userId,
+  document,
+  messageHistory,
+}: {
+  chatId: string;
+  userId: string;
+  document: LooseLessonPlan;
+  messageHistory: { role: "user" | "assistant"; content: string }[];
+}): Promise<RouterResponse | null> {
+  const openAIClient = createOpenAIClient({
+    app: "lesson-assistant",
+    chatMeta: {
+      chatId,
+      userId,
+    },
+  });
+
+  const responseFormat = zodTextFormat(
+    responseSchema,
+    "router_response_schema",
+  );
+
+  const input = JSON.stringify({
+    currentDocument: document,
+    messageHistory,
+  });
+
+  const result = await openAIClient.responses.parse({
+    instructions: routerInstructions,
+    input,
+    stream: false,
+    model: "gpt-4.1-2025-04-14",
+    text: {
+      format: responseFormat,
+    },
+  });
+
+  return result.output_parsed;
+}

--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -1,4 +1,4 @@
-import dedent from "ts-dedent";
+import { dedent } from "ts-dedent";
 import z from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
 

--- a/packages/api/src/router/additionalMaterials.ts
+++ b/packages/api/src/router/additionalMaterials.ts
@@ -49,17 +49,11 @@ export const additionalMaterialsRouter = router({
         }
         actionEnum.parse(input.action);
 
-        const material = await generateAdditionalMaterial({
+        return await generateAdditionalMaterial({
           prisma: ctx.prisma,
           userId: ctx.auth.userId,
           input: parsedInput.data,
         });
-
-        if (!material.resource) {
-          throw new Error("Failed to generate additional material");
-        }
-
-        return material?.resource;
       } catch (cause) {
         const TrpcError = new Error(
           "Failed to fetch additional material moderation",
@@ -82,12 +76,11 @@ export const additionalMaterialsRouter = router({
       }
 
       try {
-        const lesson = await generatePartialLessonPlan({
+        return await generatePartialLessonPlan({
           prisma: ctx.prisma,
           userId: ctx.auth.userId,
           input: parsedInput.data,
         });
-        return lesson?.lesson;
       } catch (cause) {
         const errorContext = `Failed to fetch additional material moderation for - ${parsedInput.data.title} - ${parsedInput.data.subject} `;
         const TrpcError = new Error(errorContext, { cause });

--- a/packages/api/src/router/additionalMaterials/helpers.ts
+++ b/packages/api/src/router/additionalMaterials/helpers.ts
@@ -1,5 +1,6 @@
 import { generateAdditionalMaterialModeration } from "@oakai/additional-materials";
 import {
+  type AdditionalMaterialSchemas,
   type GenerateAdditionalMaterialInput,
   additionalMaterialsConfigMap,
 } from "@oakai/additional-materials/src/documents/additionalMaterials/configSchema";
@@ -24,6 +25,12 @@ type GenerateAdditionalMaterialParams = {
   input: GenerateAdditionalMaterialInput & {
     lessonId?: string | null;
   };
+};
+
+export type GenerateAdditionalMaterialResponse = {
+  resource: AdditionalMaterialSchemas | null;
+  moderation: ModerationResult;
+  resourceId: string;
 };
 
 export async function generateAdditionalMaterial({
@@ -53,6 +60,11 @@ export async function generateAdditionalMaterial({
     input: JSON.stringify(result),
     provider: "openai",
   });
+
+  // Ensure moderation includes required fields
+  if (!moderation.categories) {
+    moderation.categories = []; // Provide a default empty array if categories are missing
+  }
 
   const { resourceId, documentType } = input;
   const version = additionalMaterialsConfigMap[documentType].version;
@@ -116,6 +128,20 @@ function handleContentSafetyIssue({
     moderation,
   };
 }
+
+export type GeneratePartialLessonPlanResponse =
+  | {
+      threatDetection: boolean;
+      lesson: LooseLessonPlan | null;
+      lessonId: string;
+      moderation: ModerationResult;
+    }
+  | {
+      threatDetection: boolean;
+      lesson: null;
+      lessonId: string;
+      moderation: ModerationResult;
+    };
 
 export async function generatePartialLessonPlan({
   prisma,

--- a/packages/api/src/router/admin.ts
+++ b/packages/api/src/router/admin.ts
@@ -102,4 +102,27 @@ export const adminRouter = router({
       const safetyViolations = new SafetyViolations(prisma);
       await safetyViolations.removeViolationsByRecordId(recordId);
     }),
+
+  removeSafetyViolationById: adminProcedure
+    .input(z.object({ id: z.string() }))
+    .mutation(async ({ input, ctx }) => {
+      const { id } = input;
+      const { prisma } = ctx;
+      const safetyViolations = new SafetyViolations(prisma);
+      await safetyViolations.removeViolationById(id);
+    }),
+
+  getSafetyViolationsForUser: adminProcedure
+    .input(z.object({ userId: z.string() }))
+    .query(async ({ ctx, input }): Promise<SafetyViolation[]> => {
+      const { userId } = input;
+
+      const safetyViolations = await ctx.prisma.safetyViolation.findMany({
+        where: {
+          userId,
+        },
+      });
+
+      return safetyViolations;
+    }),
 });

--- a/packages/logger/index.ts
+++ b/packages/logger/index.ts
@@ -19,6 +19,8 @@ export type LoggerKey =
   | "additional-materials"
   | "additional-materials-threat-detection"
   | "aila"
+  | "aila:agents"
+  | "aila:agents:stream"
   | "aila:analytics"
   | "aila:categorisation"
   | "aila:chat"


### PR DESCRIPTION
## Description

### Features
- **Add exit quiz to Additional Materials (AM)**: Introduces an exit quiz as part of the Additional Materials workflow. [#673](https://github.com/oaknational/oak-ai-lesson-assistant/pull/673)
- **First iteration of quasi-agentic assistant**: Implements a foundational version of a more granular/agentic experience. [#671](https://github.com/oaknational/oak-ai-lesson-assistant/pull/671)
- **Admin safety violation tracking**: Adds logic to detect and respond to safety violations initiated by users. [#662](https://github.com/oaknational/oak-ai-lesson-assistant/pull/662)
- **Connect moderation modals to Zustand**: Integrates Additional Materials moderation and threat detection modals into the shared Zustand state layer. [#668](https://github.com/oaknational/oak-ai-lesson-assistant/pull/668)

### Chore
- **Add important tags**: Adds temporary styling tags to resolve a visual issue with the footer layout. [#675](https://github.com/oaknational/oak-ai-lesson-assistant/pull/675)

### Maintenance
- **Merge production branch**: Updates `main` with the latest changes from `production` for consistency across environments.
