### PR TITLE
fix: add admin user button to slack alert when user banned

### DIFF
--- a/packages/core/src/utils/slack.ts
+++ b/packages/core/src/utils/slack.ts
@@ -86,6 +86,14 @@ export function actionsBlock({
           },
           url: `https://dashboard.clerk.com/apps/${clerkAppId}/instances/${clerkInstanceId}/users/${userActionsProps.userId}`,
         },
+        {
+          type: "button",
+          text: {
+            type: "plain_text",
+            text: "Aila admin user",
+          },
+          url: `https://labs.thenational.academy/admin/users/${userActionsProps.userId}`,
+        },
       ]
     : [];
 


### PR DESCRIPTION
## Description

- Adds a link to the user in the Aila admin section

## How to test

- Get your user banned 
- Check the alert in Slack
- There should be a button with label "Aila admin user"
- Clicking that link should take you to the [Aila admin user page](https://github.com/oaknational/oak-ai-lesson-assistant/pull/662), where you can remove safety violations