### PR TITLE
fix: force dynamic rendering for cron job routes

### DIFF
--- a/apps/nextjs/src/app/api/cron-jobs/clerk-user-cleanup/route.ts
+++ b/apps/nextjs/src/app/api/cron-jobs/clerk-user-cleanup/route.ts
@@ -8,7 +8,7 @@ import invariant from "tiny-invariant";
 
 const log = aiLogger("cron");
 
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
 const ONE_MONTH_MS = 30 * DAY_IN_MS;

--- a/apps/nextjs/src/app/api/cron-jobs/clerk-user-cleanup/route.ts
+++ b/apps/nextjs/src/app/api/cron-jobs/clerk-user-cleanup/route.ts
@@ -8,6 +8,8 @@ import invariant from "tiny-invariant";
 
 const log = aiLogger("cron");
 
+export const dynamic = 'force-dynamic';
+
 const DAY_IN_MS = 24 * 60 * 60 * 1000;
 const ONE_MONTH_MS = 30 * DAY_IN_MS;
 

--- a/apps/nextjs/src/app/api/cron-jobs/expired-exports/route.ts
+++ b/apps/nextjs/src/app/api/cron-jobs/expired-exports/route.ts
@@ -9,7 +9,7 @@ import { isTruthy } from "remeda";
 
 const log = aiLogger("cron");
 
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 const requiredEnvVars = ["CRON_SECRET", "GOOGLE_DRIVE_OUTPUT_FOLDER_ID"];
 

--- a/apps/nextjs/src/app/api/cron-jobs/expired-exports/route.ts
+++ b/apps/nextjs/src/app/api/cron-jobs/expired-exports/route.ts
@@ -9,6 +9,8 @@ import { isTruthy } from "remeda";
 
 const log = aiLogger("cron");
 
+export const dynamic = 'force-dynamic';
+
 const requiredEnvVars = ["CRON_SECRET", "GOOGLE_DRIVE_OUTPUT_FOLDER_ID"];
 
 requiredEnvVars.forEach((envVar) => {

--- a/apps/nextjs/src/app/api/cron-jobs/google-drive-size-quota/route.ts
+++ b/apps/nextjs/src/app/api/cron-jobs/google-drive-size-quota/route.ts
@@ -10,7 +10,7 @@ import type { NextRequest } from "next/server";
 
 const log = aiLogger("cron");
 
-export const dynamic = 'force-dynamic';
+export const dynamic = "force-dynamic";
 
 const requiredEnvVars = ["CRON_SECRET", "SLACK_AI_OPS_NOTIFICATION_CHANNEL_ID"];
 

--- a/apps/nextjs/src/app/api/cron-jobs/google-drive-size-quota/route.ts
+++ b/apps/nextjs/src/app/api/cron-jobs/google-drive-size-quota/route.ts
@@ -10,6 +10,8 @@ import type { NextRequest } from "next/server";
 
 const log = aiLogger("cron");
 
+export const dynamic = 'force-dynamic';
+
 const requiredEnvVars = ["CRON_SECRET", "SLACK_AI_OPS_NOTIFICATION_CHANNEL_ID"];
 
 requiredEnvVars.forEach((envVar) => {


### PR DESCRIPTION
## Summary
• Adds `export const dynamic = 'force-dynamic';` to all three cron job API routes
• Prevents Next.js from attempting static rendering of routes that access dynamic request data
• Fixes production build errors where Next.js tries to statically render routes with authorization headers, search params, or env checks

## Test plan
- [ ] Verify production build succeeds without static rendering errors
- [ ] Confirm cron routes still function correctly in deployed environment