### PR TITLE
refactor: create material id at step 1

### DIFF
--- a/apps/nextjs/src/app/aila/resources/resources-contents.tsx
+++ b/apps/nextjs/src/app/aila/resources/resources-contents.tsx
@@ -42,13 +42,15 @@ const ResourcesContentsInner: FC<AdditionalMaterialsUserProps> = () => {
   const stepNumber = useResourcesStore(stepNumberSelector);
   const pageData = useResourcesStore(pageDataSelector);
   const docType = useResourcesStore(docTypeSelector);
+  const id = useResourcesStore((state) => state.id);
 
   // Get resource type information from configuration
   const resourceType = docType ? getResourceType(docType) : null;
   const docTypeName = resourceType?.displayName || null;
   const { resetFormState } = useResourcesActions();
 
-  const { handleSubmitLessonPlan, handleSubmit } = useStepSubmitLogic();
+  const { handleSubmitLessonPlan, handleSubmit, handleCreateSession } =
+    useStepSubmitLogic();
 
   useEffect(() => {
     resetFormState();
@@ -95,7 +97,7 @@ const ResourcesContentsInner: FC<AdditionalMaterialsUserProps> = () => {
   };
 
   const stepComponents = {
-    0: <StepOne />,
+    0: <StepOne handleCreateSession={handleCreateSession} />,
     1: <StepTwo handleSubmitLessonPlan={handleSubmitLessonPlan} />,
     2: <StepThree handleSubmit={handleSubmit} />,
     3: <StepFour />,

--- a/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StepLayouts/StepOne.tsx
+++ b/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StepLayouts/StepOne.tsx
@@ -22,8 +22,12 @@ import { useDialog } from "../../DialogContext";
 import ResourcesFooter from "../ResourcesFooter";
 import { handleDialogSelection } from "./helpers";
 
-const StepOne = () => {
-  const { setStepNumber, setDocType, setGeneration } = useResourcesActions();
+const StepOne = ({
+  handleCreateSession,
+}: {
+  handleCreateSession: ({ documentType }: { documentType: string }) => void;
+}) => {
+  const { setDocType, setGeneration } = useResourcesActions();
   const docType = useResourcesStore(docTypeSelector);
   const error = useResourcesStore((state) => state.error);
 
@@ -49,7 +53,8 @@ const StepOne = () => {
             <OakRadioGroup
               name="radio-group"
               onChange={(value) => {
-                setDocType(value.target.value);
+                const selectedDocType = value.target.value;
+                setDocType(selectedDocType);
                 setGeneration(null);
               }}
               $flexDirection="column"
@@ -84,7 +89,11 @@ const StepOne = () => {
       <ResourcesFooter>
         <OakFlex $justifyContent="flex-end" $width={"100%"}>
           <OakPrimaryButton
-            onClick={() => setStepNumber(1)}
+            onClick={() => {
+              if (docType) {
+                handleCreateSession({ documentType: docType });
+              }
+            }}
             iconName="arrow-right"
             isTrailingIcon={true}
             disabled={!docType}

--- a/apps/nextjs/src/components/AppComponents/AdditionalMaterials/hooks/useStepSubmitLogic.ts
+++ b/apps/nextjs/src/components/AppComponents/AdditionalMaterials/hooks/useStepSubmitLogic.ts
@@ -1,14 +1,25 @@
+import { aiLogger } from "@oakai/logger";
+
 import * as Sentry from "@sentry/nextjs";
 
 import { useResourcesActions } from "@/stores/ResourcesStoreProvider";
 import { trpc } from "@/utils/trpc";
 
+const log = aiLogger("additional-materials");
 const useStepSubmitLogic = () => {
-  const { submitLessonPlan, setStepNumber, generateMaterial } =
-    useResourcesActions();
+  const {
+    submitLessonPlan,
+    setStepNumber,
+    generateMaterial,
+    createMaterialSession,
+  } = useResourcesActions();
 
   const generateLessonPlan =
     trpc.additionalMaterials.generatePartialLessonPlanObject.useMutation();
+  const updateMaterialSession =
+    trpc.additionalMaterials.updateMaterialSession.useMutation();
+  const createSession =
+    trpc.additionalMaterials.createMaterialSession?.useMutation?.();
 
   // Handle submit for step 2
   const handleSubmitLessonPlan = async (params: {
@@ -32,9 +43,17 @@ const useStepSubmitLogic = () => {
             throw error instanceof Error ? error : new Error(String(error));
           }
         },
+        updateSessionMutateAsync: async (input) => {
+          try {
+            return await updateMaterialSession.mutateAsync(input);
+          } catch (error) {
+            throw error instanceof Error ? error : new Error(String(error));
+          }
+        },
       });
     } catch (error) {
-      console.error("Failed to generate lesson plan:", error);
+      log.error("Failed to generate lesson plan:", error);
+      Sentry.captureException(error);
     }
   };
 
@@ -47,8 +66,26 @@ const useStepSubmitLogic = () => {
 
     void generateMaterial({
       mutateAsync: async (input) => {
+        log.info("Submitting material generation with input:", input);
         try {
           return await fetchMaterial.mutateAsync(input);
+        } catch (e) {
+          const error = e instanceof Error ? e : new Error(String(e));
+          Sentry.captureException(error);
+          throw error;
+        }
+      },
+    });
+  };
+  // Handle submit for step 1
+  const handleCreateSession = ({ documentType }: { documentType: string }) => {
+    setStepNumber(1);
+    void createMaterialSession({
+      documentType,
+      mutateAsync: async (documentType) => {
+        log.info("Creating session with:", documentType);
+        try {
+          return await createSession.mutateAsync(documentType);
         } catch (e) {
           const error = e instanceof Error ? e : new Error(String(e));
           Sentry.captureException(error);
@@ -61,6 +98,7 @@ const useStepSubmitLogic = () => {
   return {
     handleSubmitLessonPlan,
     handleSubmit,
+    handleCreateSession,
   };
 };
 

--- a/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleCreateMaterialSession.ts
+++ b/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleCreateMaterialSession.ts
@@ -1,0 +1,38 @@
+import { aiLogger } from "@oakai/logger";
+
+import type { UseMutateAsyncFunction } from "@tanstack/react-query";
+
+import type { ResourcesGetter, ResourcesSetter } from "../types";
+import { handleStoreError } from "../utils/errorHandling";
+
+const log = aiLogger("additional-materials");
+
+export type CreateMaterialSessionParams = {
+  documentType: string;
+  mutateAsync: UseMutateAsyncFunction<
+    { resourceId: string },
+    Error,
+    { documentType: string }
+  >;
+};
+
+export const handleCreateMaterialSession =
+  (set: ResourcesSetter, get: ResourcesGetter) =>
+  async ({ documentType, mutateAsync }: CreateMaterialSessionParams) => {
+    log.info("Creating material session", { documentType });
+
+    try {
+      const result = await mutateAsync({ documentType });
+      log.info("Material session created *******", {
+        resourceId: result.resourceId,
+      });
+      set({ id: result.resourceId });
+      log.info(get().id, "ID after creation");
+    } catch (error) {
+      handleStoreError(set, error, {
+        context: "handleCreateMaterialSession",
+        documentType,
+      });
+      log.error("Error creating material session", error);
+    }
+  };

--- a/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleGenerateMaterial.ts
+++ b/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleGenerateMaterial.ts
@@ -60,6 +60,7 @@ export const handleGenerateMaterial =
           previousOutput: null,
           options: null,
         },
+        resourceId: get().id, // Use existing resourceId
         lessonId: get().pageData.lessonPlan.lessonId,
       });
       get().actions.setIsResourcesLoading(false);
@@ -67,7 +68,6 @@ export const handleGenerateMaterial =
       set({
         generation: result.resource,
         moderation: result.moderation,
-        id: result.resourceId,
         refinementGenerationHistory: [],
       });
 

--- a/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleRefineMaterial.ts
+++ b/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleRefineMaterial.ts
@@ -23,7 +23,7 @@ export type RefineMaterialParams = {
   mutateAsync: UseMutateAsyncFunction<
     GenerateAdditionalMaterialResponse,
     Error,
-    GenerateAdditionalMaterialInput
+    GenerateAdditionalMaterialInput & { adaptsOutputId?: string | null }
   >;
 };
 
@@ -32,7 +32,7 @@ export const handleRefineMaterial =
   async ({ refinement, mutateAsync }: RefineMaterialParams) => {
     const { setIsResourceRefining } = get().actions;
 
-    console.log("🔄 Setting isResourceRefining to TRUE");
+    log.info("Setting isResourceRefining to TRUE");
     setIsResourceRefining(true);
 
     const docType = get().docType;
@@ -60,7 +60,9 @@ export const handleRefineMaterial =
           options: null,
           refinement: refinement,
         },
-        resourceId: get().id,
+        // Don't pass resourceId for refinements - this will create a new record
+        // The adaptsOutputId will be set to the current material's ID
+        adaptsOutputId: get().id, // ID of the material being refined
         lessonId: get().pageData.lessonPlan.lessonId,
       };
 
@@ -91,7 +93,7 @@ export const handleRefineMaterial =
       Sentry.captureException(error);
       throw error;
     } finally {
-      console.log("🔄 Setting isResourceRefining to FALSE");
+      log.info("Setting isResourceRefining to FALSE");
       setIsResourceRefining(false);
     }
   };

--- a/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleSetDocType.ts
+++ b/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleSetDocType.ts
@@ -6,11 +6,13 @@ import type { ResourcesGetter, ResourcesSetter } from "../types";
 const log = aiLogger("additional-materials");
 
 export const handleSetDocType =
-  (set: ResourcesSetter, get: ResourcesGetter) => (docType: string | null) => {
+  (set: ResourcesSetter, _get: ResourcesGetter) => (docType: string | null) => {
     log.info("Setting docType", { docType });
 
     if (docType !== null) {
       const parsedDoctype = additionalMaterialTypeEnum.parse(docType);
       set({ docType: parsedDoctype });
+    } else {
+      set({ docType: null, id: null });
     }
   };

--- a/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleUpdateMaterialSession.ts
+++ b/apps/nextjs/src/stores/resourcesStore/actionFunctions/handleUpdateMaterialSession.ts
@@ -1,0 +1,40 @@
+import { aiLogger } from "@oakai/logger";
+
+import type { UseMutateAsyncFunction } from "@tanstack/react-query";
+
+import type { ResourcesGetter, ResourcesSetter } from "../types";
+import { handleStoreError } from "../utils/errorHandling";
+
+const log = aiLogger("additional-materials");
+
+export type UpdateMaterialSessionParams = {
+  resourceId: string;
+  lessonId: string;
+  mutateAsync: UseMutateAsyncFunction<
+    { success: boolean },
+    Error,
+    { resourceId: string; lessonId: string }
+  >;
+};
+
+export const handleUpdateMaterialSession =
+  (set: ResourcesSetter, _get: ResourcesGetter) =>
+  async ({
+    resourceId,
+    lessonId,
+    mutateAsync,
+  }: UpdateMaterialSessionParams) => {
+    log.info("Updating material session", { resourceId, lessonId });
+
+    try {
+      await mutateAsync({ resourceId, lessonId });
+      log.info("Material session updated successfully");
+    } catch (error) {
+      handleStoreError(set, error, {
+        context: "handleUpdateMaterialSession",
+        resourceId,
+        lessonId,
+      });
+      log.error("Error updating material session", error);
+    }
+  };

--- a/apps/nextjs/src/stores/resourcesStore/index.ts
+++ b/apps/nextjs/src/stores/resourcesStore/index.ts
@@ -1,6 +1,9 @@
+import { aiLogger } from "@oakai/logger";
+
 import { create } from "zustand";
 
 import { logStoreUpdates } from "../zustandHelpers";
+import { handleCreateMaterialSession } from "./actionFunctions/handleCreateMaterialSession";
 import { handleDownload } from "./actionFunctions/handleDownload";
 import {
   handleResetFormState,
@@ -101,6 +104,8 @@ export const createResourcesStore = () => {
       // History management actions
       undoRefinement: handleUndoRefinement(set, get),
 
+      createMaterialSession: handleCreateMaterialSession(set, get),
+
       // Reset store to default state
       resetToDefault: () =>
         set((state) => ({ ...DEFAULT_STATE, id: state.id })),
@@ -109,5 +114,6 @@ export const createResourcesStore = () => {
 
   // Log store updates
   logStoreUpdates(resourcesStore, "additional-materials");
+
   return resourcesStore;
 };

--- a/apps/nextjs/src/stores/resourcesStore/types.ts
+++ b/apps/nextjs/src/stores/resourcesStore/types.ts
@@ -8,9 +8,11 @@ import type { ModerationResult } from "@oakai/core/src/utils/ailaModeration/mode
 import { z } from "zod";
 import type { StoreApi } from "zustand";
 
+import type { CreateMaterialSessionParams } from "./actionFunctions/handleCreateMaterialSession";
 import type { GenerateMaterialParams } from "./actionFunctions/handleGenerateMaterial";
 import type { RefineMaterialParams } from "./actionFunctions/handleRefineMaterial";
 import type { SubmitLessonPlanParams } from "./actionFunctions/handleSubmitLessonPlan";
+import type { UpdateMaterialSessionParams } from "./actionFunctions/handleUpdateMaterialSession";
 
 export type PageData = {
   lessonPlan: AilaPersistedChat["lessonPlan"] & { lessonId: string };
@@ -72,6 +74,8 @@ export type ResourcesState = {
     resetFormState: () => void;
 
     // business logic actions
+    createMaterialSession: (params: CreateMaterialSessionParams) => Promise<void>;
+    updateMaterialSession: (params: UpdateMaterialSessionParams) => Promise<void>;
     submitLessonPlan: (params: SubmitLessonPlanParams) => Promise<void>;
     generateMaterial: (params: GenerateMaterialParams) => Promise<void>;
     refineMaterial: (params: RefineMaterialParams) => Promise<void>;

--- a/packages/additional-materials/src/documents/additionalMaterials/configSchema.ts
+++ b/packages/additional-materials/src/documents/additionalMaterials/configSchema.ts
@@ -157,6 +157,7 @@ function makeInputVariant<T extends AdditionalMaterialType>(
     context,
     resourceId: z.string().nullish(),
     lessonId: z.string().nullish(),
+    adaptsOutputId: z.string().nullish(),
   });
 }
 

--- a/packages/api/src/router/additionalMaterials.ts
+++ b/packages/api/src/router/additionalMaterials.ts
@@ -2,6 +2,10 @@ import {
   actionEnum,
   generateAdditionalMaterialInputSchema,
 } from "@oakai/additional-materials/src/documents/additionalMaterials/configSchema";
+import {
+  additionalMaterialTypeEnum,
+  additionalMaterialsConfigMap,
+} from "@oakai/additional-materials/src/documents/additionalMaterials/configSchema";
 import { partialLessonContextSchema } from "@oakai/additional-materials/src/documents/partialLessonPlan/schema";
 import {
   type OakOpenAiLessonSummary,
@@ -34,6 +38,104 @@ const log = aiLogger("additional-materials");
 const OPENAI_AUTH_TOKEN = process.env.OPENAI_AUTH_TOKEN;
 
 export const additionalMaterialsRouter = router({
+  createMaterialSession: protectedProcedure
+    .input(
+      z.object({
+        documentType: z.string(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      log.info("Creating material session", {
+        documentType: input.documentType,
+      });
+
+      try {
+        if (!ctx.auth.userId) {
+          throw new Error("No user id");
+        }
+
+        const clerkUser = await clerkClient.users.getUser(ctx.auth.userId);
+        if (clerkUser.banned) {
+          throw new UserBannedError(ctx.auth.userId);
+        }
+
+        const parsedDocType = additionalMaterialTypeEnum.parse(
+          input.documentType,
+        );
+        const version = additionalMaterialsConfigMap[parsedDocType]?.version;
+
+        if (!version) {
+          throw new Error(`Unknown document type: ${input.documentType}`);
+        }
+
+        const interaction =
+          await ctx.prisma.additionalMaterialInteraction.create({
+            data: {
+              userId: ctx.auth.userId,
+              config: {
+                resourceType: parsedDocType,
+                resourceTypeVersion: version,
+              },
+            },
+          });
+
+        log.info("Material session created", { resourceId: interaction.id });
+        return { resourceId: interaction.id };
+      } catch (cause) {
+        const TrpcError = new Error("Failed to create material session", {
+          cause,
+        });
+        log.error("Failed to create material session", cause);
+        Sentry.captureException(TrpcError);
+        throw TrpcError;
+      }
+    }),
+
+  updateMaterialSession: protectedProcedure
+    .input(
+      z.object({
+        resourceId: z.string(),
+        lessonId: z.string(),
+      }),
+    )
+    .mutation(async ({ ctx, input }) => {
+      log.info("Updating material session", {
+        resourceId: input.resourceId,
+        lessonId: input.lessonId,
+      });
+
+      try {
+        if (!ctx.auth.userId) {
+          throw new Error("No user id");
+        }
+
+        const clerkUser = await clerkClient.users.getUser(ctx.auth.userId);
+        if (clerkUser.banned) {
+          throw new UserBannedError(ctx.auth.userId);
+        }
+
+        await ctx.prisma.additionalMaterialInteraction.update({
+          where: {
+            id: input.resourceId,
+            userId: ctx.auth.userId,
+          },
+          data: {
+            derivedFromId: input.lessonId,
+          },
+        });
+
+        log.info("Material session updated", { resourceId: input.resourceId });
+        return { success: true };
+      } catch (cause) {
+        const TrpcError = new Error("Failed to update material session", {
+          cause,
+        });
+        log.error("Failed to update material session", cause);
+        Sentry.captureException(TrpcError);
+        throw TrpcError;
+      }
+    }),
+
   generateAdditionalMaterial: additionalMaterialUserBasedRateLimitProcedure
     .input(
       z.object({
@@ -41,6 +143,7 @@ export const additionalMaterialsRouter = router({
         context: z.unknown(),
         documentType: z.string(),
         resourceId: z.string().nullish(),
+        adaptsOutputId: z.string().nullish(),
         lessonId: z.string().nullish(),
       }),
     )


### PR DESCRIPTION
## Description

- To implement a avo tracking plan we need a id from step 1 => step 4 to link the tracked events, we were creating id only at the final step when the material was generated. This PR introduces a session id at step one that is updated throughout the flow.


## How to test

Additional materials works the same as before

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
