### PR TITLE
fix: moderation retry

### DIFF
--- a/packages/aila/src/features/moderation/moderators/OpenAiModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/OpenAiModerator.ts
@@ -173,9 +173,6 @@ export class OpenAiModerator extends AilaModerator {
       return await this._moderate(input, 0);
     } catch (error) {
       log.error("Moderation error: ", error);
-      if (error instanceof AilaModerationError) {
-        throw error;
-      }
       return await this._moderate(input, 1);
     }
   }


### PR DESCRIPTION
## Description

- previously moderation function was rethrowing rather than running the retry function
- this should mean that it retries once and throws if that retry fails

