### PR TITLE
fix: preserve keyword definition casing [AI-1322]

### DIFF
--- a/packages/aila/src/protocol/sectionToMarkdown.ts
+++ b/packages/aila/src/protocol/sectionToMarkdown.ts
@@ -120,7 +120,7 @@ function renderTwoKeyObjectArray(value: readonly unknown[]): string {
     .map((v) => {
       const header = v[key1] ?? "…";
       const body = v[key2] ?? "…";
-      return `### ${toSentenceCase(header)}\n\n${toSentenceCase(body)}`;
+      return `### ${toSentenceCase(header)}\n\n${body}`;
     })
     .join("\n\n");
 }


### PR DESCRIPTION
## Description

- It's been noted that the keyword definition is always sentence case, however it should not be.
- The first letter of the first word in the definition should be lower case unless the first word is a proper noun or an acronym/initialism

## Issue(s)

[AI-1322](https://www.notion.so/oaknationalacademy/Keyword-def-lowercase-21726cc4e1b180d69e19c1aee9f22931?source=copy_link)