### PR TITLE
chore: make 'topic' nullable [AI-1337]

### DIFF
--- a/packages/aila/src/core/prompt/builders/AilaLessonPromptBuilder.ts
+++ b/packages/aila/src/core/prompt/builders/AilaLessonPromptBuilder.ts
@@ -116,7 +116,7 @@ export class AilaLessonPromptBuilder extends AilaPromptBuilder {
       relevantLessonPlans = await fetchRagContent({
         title: title ?? "unknown",
         subject,
-        topic,
+        topic: topic ?? undefined,
         keyStage,
         id: chatId,
         k:

--- a/packages/aila/src/features/persistence/AilaPersistence.ts
+++ b/packages/aila/src/features/persistence/AilaPersistence.ts
@@ -134,7 +134,7 @@ export abstract class AilaPersistence {
 export type ChatPersistencePayload = AilaPersistedChat & {
   subject: string;
   keyStage: string;
-  topic: string;
+  topic: string | null;
   options: AilaOptionsWithDefaultFallbackValues;
 };
 

--- a/packages/aila/src/features/rag/AilaRag.ts
+++ b/packages/aila/src/features/rag/AilaRag.ts
@@ -55,7 +55,7 @@ export class AilaRag implements AilaRagFeature {
               title,
               keyStage,
               subject,
-              topic,
+              topic: topic ?? undefined,
               k:
                 numberOfRecordsInRag ??
                 this._aila?.options.numberOfRecordsInRag ??

--- a/packages/aila/src/lib/agents/agents.ts
+++ b/packages/aila/src/lib/agents/agents.ts
@@ -76,7 +76,7 @@ export type PromptAgentDefinition<
   prompt: string;
   schemaForLLM: SchemaForLLM;
   schemaStrict: SchemaStrict;
-  extractRagData: (exampleLessonPlan: CompletedLessonPlan) => string;
+  extractRagData: (exampleLessonPlan: CompletedLessonPlan) => string | null;
 };
 export type AgentDefinition =
   | PromptAgentDefinition

--- a/packages/aila/src/lib/agents/promptAgentHandler.ts
+++ b/packages/aila/src/lib/agents/promptAgentHandler.ts
@@ -54,7 +54,6 @@ export async function promptAgentHandler<
 
   const instructions = agent.prompt;
   const input = `### Examples from similar lessons
-
 ${examplesFromSimilarLessons(ragData, targetKey, agent.extractRagData)}
  
     ### Document

--- a/packages/aila/src/lib/agents/prompts/shared/examplesFromSimilarLessons.test.ts
+++ b/packages/aila/src/lib/agents/prompts/shared/examplesFromSimilarLessons.test.ts
@@ -1,0 +1,218 @@
+import { examplesFromSimilarLessons } from "./examplesFromSimilarLessons";
+
+interface MockLesson {
+  id: string;
+  title: string;
+  content?: string;
+  description?: string;
+}
+
+describe("examplesFromSimilarLessons", () => {
+  const mockLessons: MockLesson[] = [
+    {
+      id: "1",
+      title: "Lesson 1",
+      content: "This is lesson 1 content",
+      description: "A basic lesson",
+    },
+    {
+      id: "2",
+      title: "Lesson 2",
+      content: "This is lesson 2 content",
+      description: "Another lesson",
+    },
+    {
+      id: "3",
+      title: "Lesson 3",
+      // No content field
+      description: "Lesson without content",
+    },
+  ];
+
+  const extractContent = (lesson: MockLesson): string | null => {
+    return lesson.content ?? null;
+  };
+
+  const extractDescription = (lesson: MockLesson): string | null => {
+    return lesson.description ?? null;
+  };
+
+  it("should format examples correctly with valid data", () => {
+    const result = examplesFromSimilarLessons(
+      mockLessons,
+      "content",
+      extractContent,
+    );
+
+    expect(result).toBe(
+      `<example-content-0>\nThis is lesson 1 content\n</example-content-0>\n\n<example-content-1>\nThis is lesson 2 content\n</example-content-1>`,
+    );
+  });
+
+  it("should use the correct targetKey in the example tags", () => {
+    const result = examplesFromSimilarLessons(
+      mockLessons.slice(0, 1),
+      "quiz",
+      extractContent,
+    );
+
+    expect(result).toBe(
+      `<example-quiz-0>\nThis is lesson 1 content\n</example-quiz-0>`,
+    );
+  });
+
+  it("should filter out lessons where extractRagDataAsText returns null", () => {
+    const result = examplesFromSimilarLessons(
+      mockLessons,
+      "content",
+      extractContent,
+    );
+
+    // Should only include lessons 1 and 2, not lesson 3 (which has no content)
+    expect(result).toContain("This is lesson 1 content");
+    expect(result).toContain("This is lesson 2 content");
+    expect(result).not.toContain("Lesson without content");
+  });
+
+  it("should return 'No relevant examples found.' when no lessons have extractable data", () => {
+    const lessonsWithoutContent = [
+      { id: "1", title: "Lesson 1", description: "A lesson" },
+      { id: "2", title: "Lesson 2", description: "Another lesson" },
+    ];
+
+    const result = examplesFromSimilarLessons(
+      lessonsWithoutContent,
+      "content",
+      extractContent,
+    );
+
+    expect(result).toBe("No relevant examples found.");
+  });
+
+  it("should return 'No relevant examples found.' when lessons array is empty", () => {
+    const result = examplesFromSimilarLessons([], "content", extractContent);
+
+    expect(result).toBe("No relevant examples found.");
+  });
+
+  it("should handle different extraction functions", () => {
+    const result = examplesFromSimilarLessons(
+      mockLessons,
+      "description",
+      extractDescription,
+    );
+
+    expect(result).toContain("A basic lesson");
+    expect(result).toContain("Another lesson");
+    expect(result).toContain("Lesson without content");
+    expect(result).toContain("<example-description-0>");
+    expect(result).toContain("<example-description-1>");
+    expect(result).toContain("<example-description-2>");
+  });
+
+  it("should handle lessons with empty string content", () => {
+    const lessonsWithEmptyContent = [
+      { id: "1", title: "Lesson 1", content: "" },
+      { id: "2", title: "Lesson 2", content: "Valid content" },
+    ];
+
+    const extractContentOrEmpty = (lesson: MockLesson): string | null => {
+      return lesson.content === "" ? null : lesson.content ?? null;
+    };
+
+    const result = examplesFromSimilarLessons(
+      lessonsWithEmptyContent,
+      "content",
+      extractContentOrEmpty,
+    );
+
+    expect(result).toBe(
+      `<example-content-0>\nValid content\n</example-content-0>`,
+    );
+  });
+
+  it("should maintain correct indexing when filtering", () => {
+    const mixedLessons = [
+      { id: "1", title: "Lesson 1" }, // No content
+      { id: "2", title: "Lesson 2", content: "Content 2" },
+      { id: "3", title: "Lesson 3" }, // No content
+      { id: "4", title: "Lesson 4", content: "Content 4" },
+    ];
+
+    const result = examplesFromSimilarLessons(
+      mixedLessons,
+      "test",
+      extractContent,
+    );
+
+    expect(result).toBe(
+      `<example-test-0>\nContent 2\n</example-test-0>\n\n<example-test-1>\nContent 4\n</example-test-1>`,
+    );
+  });
+
+  it("should handle special characters in content", () => {
+    const lessonsWithSpecialChars = [
+      {
+        id: "1",
+        title: "Lesson 1",
+        content: "Content with <tags>, quotes \"test\", and & symbols",
+      },
+    ];
+
+    const result = examplesFromSimilarLessons(
+      lessonsWithSpecialChars,
+      "special",
+      extractContent,
+    );
+
+    expect(result).toBe(
+      `<example-special-0>\nContent with <tags>, quotes "test", and & symbols\n</example-special-0>`,
+    );
+  });
+
+  it("should work with different generic types", () => {
+    interface DifferentLesson {
+      name: string;
+      data: string;
+    }
+
+    const differentLessons: DifferentLesson[] = [
+      { name: "Test", data: "Some data" },
+      { name: "Another", data: "More data" },
+    ];
+
+    const extractData = (lesson: DifferentLesson): string | null => {
+      return lesson.data;
+    };
+
+    const result = examplesFromSimilarLessons(
+      differentLessons,
+      "data",
+      extractData,
+    );
+
+    expect(result).toBe(
+      `<example-data-0>\nSome data\n</example-data-0>\n\n<example-data-1>\nMore data\n</example-data-1>`,
+    );
+  });
+
+  it("should handle multiline content correctly", () => {
+    const lessonsWithMultilineContent = [
+      {
+        id: "1",
+        title: "Lesson 1",
+        content: "Line 1\nLine 2\nLine 3",
+      },
+    ];
+
+    const result = examplesFromSimilarLessons(
+      lessonsWithMultilineContent,
+      "multiline",
+      extractContent,
+    );
+
+    expect(result).toBe(
+      `<example-multiline-0>\nLine 1\nLine 2\nLine 3\n</example-multiline-0>`,
+    );
+  });
+});

--- a/packages/aila/src/lib/agents/prompts/shared/examplesFromSimilarLessons.test.ts
+++ b/packages/aila/src/lib/agents/prompts/shared/examplesFromSimilarLessons.test.ts
@@ -117,7 +117,7 @@ describe("examplesFromSimilarLessons", () => {
     ];
 
     const extractContentOrEmpty = (lesson: MockLesson): string | null => {
-      return lesson.content === "" ? null : lesson.content ?? null;
+      return lesson.content === "" ? null : (lesson.content ?? null);
     };
 
     const result = examplesFromSimilarLessons(
@@ -155,7 +155,7 @@ describe("examplesFromSimilarLessons", () => {
       {
         id: "1",
         title: "Lesson 1",
-        content: "Content with <tags>, quotes \"test\", and & symbols",
+        content: 'Content with <tags>, quotes "test", and & symbols',
       },
     ];
 

--- a/packages/aila/src/lib/agents/prompts/shared/examplesFromSimilarLessons.ts
+++ b/packages/aila/src/lib/agents/prompts/shared/examplesFromSimilarLessons.ts
@@ -1,11 +1,18 @@
 export const examplesFromSimilarLessons = <T>(
   lessons: T[],
   targetKey: string,
-  extractRagDataAsText: (lesson: T) => string,
-) =>
-  lessons
+  extractRagDataAsText: (lesson: T) => string | null,
+) => {
+  const examples = lessons.filter(extractRagDataAsText);
+
+  if (!examples.length) {
+    return `No relevant examples found.`;
+  }
+
+  return examples
     .map(
       (lesson, i) =>
         `<example-${targetKey}-${i}>\n${extractRagDataAsText(lesson)}\n</example-${targetKey}-${i}>`,
     )
     .join("\n\n");
+};

--- a/packages/aila/src/lib/agents/prompts/shared/examplesFromSimilarLessons.ts
+++ b/packages/aila/src/lib/agents/prompts/shared/examplesFromSimilarLessons.ts
@@ -1,3 +1,8 @@
+export const decorateExample =
+  <T>(extractFn: (lesson: T) => string | null) =>
+  (lesson: T, i: number, targetKey: string) =>
+    `<example-${targetKey}-${i}>\n${extractFn(lesson)}\n</example-${targetKey}-${i}>`;
+
 export const examplesFromSimilarLessons = <T>(
   lessons: T[],
   targetKey: string,
@@ -9,10 +14,9 @@ export const examplesFromSimilarLessons = <T>(
     return `No relevant examples found.`;
   }
 
+  const decorateFn = decorateExample(extractRagDataAsText);
+
   return examples
-    .map(
-      (lesson, i) =>
-        `<example-${targetKey}-${i}>\n${extractRagDataAsText(lesson)}\n</example-${targetKey}-${i}>`,
-    )
+    .map((lesson, i) => decorateFn(lesson, i, targetKey))
     .join("\n\n");
 };

--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -391,7 +391,7 @@ export const CompletedLessonPlanSchema = z.object({
   title: LessonTitleSchema,
   keyStage: KeyStageSchema,
   subject: SubjectSchema,
-  topic: TopicSchema,
+  topic: TopicSchema.nullable(),
   learningOutcome: LearningOutcomeSchema,
   learningCycles: LearningCyclesSchema,
   priorKnowledge: PriorKnowledgeSchema,

--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -398,13 +398,13 @@ export const CompletedLessonPlanSchema = z.object({
   keyLearningPoints: KeyLearningPointsSchema,
   misconceptions: MisconceptionsSchema,
   keywords: KeywordsSchema,
-  basedOn: BasedOnSchema.optional(),
+  basedOn: BasedOnSchema.nullish(),
   starterQuiz: QuizSchema.describe(LESSON_PLAN_DESCRIPTIONS.starterQuiz),
   cycle1: CycleSchema.describe("The first learning cycle"),
   cycle2: CycleSchema.describe("The second learning cycle"),
   cycle3: CycleSchema.describe("The third learning cycle"),
   exitQuiz: QuizSchema.describe(LESSON_PLAN_DESCRIPTIONS.exitQuiz),
-  additionalMaterials: AdditionalMaterialsSchema,
+  additionalMaterials: AdditionalMaterialsSchema.nullable(),
 });
 
 export type CompletedLessonPlan = z.infer<typeof CompletedLessonPlanSchema>;

--- a/packages/exports/src/schema/input.schema.ts
+++ b/packages/exports/src/schema/input.schema.ts
@@ -130,7 +130,7 @@ export const exportableQuizAppStateSchema = z.object({
   status: quizAppStatusSchema,
   keyStage: z.string(),
   subject: z.string(),
-  topic: z.string().optional(),
+  topic: z.string().nullish(),
   questions: z.array(exportableQuizQuestionSchema),
 });
 


### PR DESCRIPTION
## Description

- the latest ingested lesson plans have **topic** as `null`, as agreed with HB, since there currently isn't a clear and consistent way we're handling 'topic'
- same goes for **basedOn** and **additionalMaterials**
- this PR changes the schema to allow 'topic' to be null, which will then mean we can see the latest ingested lesson plans in the new RAG schema
- it also refactors the 'examplesFromSimilarLessons` function and adds a test for it

## Issue(s)

AI-1337

## How to test

- **Non-agentic Aila should work as per usual**
- **Test for agentic Aila:**
1. Create a maths lesson plan, e.g. "circles for ks3"
2. Once confirming title, ks, subject,, you should see a list of lessons offered to base your lesson on
3. That is all