### PR TITLE
feat: [AI-1374] implement quiz v2 multiple choice components

### DIFF
--- a/apps/nextjs/src/app/aila/[id]/share/index.tsx
+++ b/apps/nextjs/src/app/aila/[id]/share/index.tsx
@@ -9,8 +9,8 @@ import { OakSmallPrimaryButton } from "@oaknational/oak-components";
 import * as Sentry from "@sentry/react";
 import Link from "next/link";
 
-import LessonPlanMapToMarkDown from "@/components/AppComponents/Chat/chat-lessonPlanMapToMarkDown";
 import { GuidanceRequired } from "@/components/AppComponents/Chat/guidance-required";
+import StaticLessonPlanRenderer from "@/components/AppComponents/static-lesson-plan-renderer";
 import { Icon } from "@/components/Icon";
 import { Logo } from "@/components/Logo";
 import { OakMathJaxContext } from "@/components/MathJax";
@@ -101,7 +101,7 @@ export default function ShareChat({
           className="mb-14 border-b pb-14"
         >
           <OakMathJaxContext>
-            <LessonPlanMapToMarkDown lessonPlan={lessonPlan} />
+            <StaticLessonPlanRenderer lessonPlan={lessonPlan} />
           </OakMathJaxContext>
         </div>
       </div>

--- a/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/drop-down-section-content.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/drop-down-section/drop-down-section-content.tsx
@@ -2,38 +2,28 @@ import type {
   LessonPlanKey,
   LessonPlanSectionWhileStreaming,
 } from "@oakai/aila/src/protocol/schema";
-import { sectionToMarkdown } from "@oakai/aila/src/protocol/sectionToMarkdown";
 
 import { OakFlex } from "@oaknational/oak-components";
-import { MathJax } from "better-react-mathjax";
 
-import { lessonSectionTitlesAndMiniDescriptions } from "@/data/lessonSectionTitlesAndMiniDescriptions";
-
-import { MemoizedReactMarkdownWithStyles } from "../markdown";
+import { SectionContent } from "../../SectionContent";
 import AddAdditionalMaterialsButton from "./add-additional-materials-button";
 import FlagButton from "./flag-button";
 import ModifyButton from "./modify-button";
 import { sectionTitle } from "./sectionTitle";
 
-export type LessonPlanSectionContentProps = Readonly<{
+export type DropDownSectionContentProps = Readonly<{
   sectionKey: LessonPlanKey;
   value: LessonPlanSectionWhileStreaming;
 }>;
 
-export const LessonPlanSectionContent = ({
+export const DropDownSectionContent = ({
   sectionKey,
   value,
-}: LessonPlanSectionContentProps) => {
+}: DropDownSectionContentProps) => {
   return (
     <OakFlex $flexDirection="column">
-      <MathJax hideUntilTypeset="every" dynamic>
-        <MemoizedReactMarkdownWithStyles
-          lessonPlanSectionDescription={
-            lessonSectionTitlesAndMiniDescriptions[sectionKey]?.description
-          }
-          markdown={`${sectionToMarkdown(sectionKey, value)}`}
-        />
-      </MathJax>
+      <SectionContent sectionKey={sectionKey} value={value} />
+
       <OakFlex
         $gap="all-spacing-3"
         $mt="space-between-s"

--- a/apps/nextjs/src/components/AppComponents/Chat/lesson-plan-section/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/lesson-plan-section/index.tsx
@@ -14,7 +14,7 @@ import {
 } from "@/stores/lessonPlanStore/selectors";
 
 import Skeleton from "../../common/Skeleton";
-import { LessonPlanSectionContent } from "../drop-down-section/lesson-plan-section-content";
+import { DropDownSectionContent } from "../drop-down-section/drop-down-section-content";
 import { sectionTitle } from "../drop-down-section/sectionTitle";
 
 export type LessonPlanSectionProps = Readonly<{
@@ -84,7 +84,7 @@ export const LessonPlanSection = ({
       {isOpen && (
         <div className="mt-12 w-full">
           {status === "loaded" && section ? (
-            <LessonPlanSectionContent sectionKey={sectionKey} value={section} />
+            <DropDownSectionContent sectionKey={sectionKey} value={section} />
           ) : (
             <Skeleton loaded={false} numberOfRows={1}>
               <p>Loading</p>

--- a/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
@@ -3,7 +3,6 @@ import React, { memo, useMemo } from "react";
 import type { Components, Options } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 
-import * as Tooltip from "@radix-ui/react-tooltip";
 import { Box, Flex } from "@radix-ui/themes";
 import remarkGfm from "remark-gfm";
 
@@ -25,10 +24,7 @@ export type ReactMarkdownWithStylesProps = Readonly<{
 }>;
 
 // This could do with further refactoring to make it more readable
-const createComponents = (
-  className?: string,
-  lessonPlanSectionDescription?: string,
-): Partial<Components> => ({
+const createComponents = (className?: string): Partial<Components> => ({
   li: ({ children }) => (
     <li className={cn("marker:text-black", className)}>{children}</li>
   ),
@@ -36,33 +32,7 @@ const createComponents = (
     <p className={cn("mb-7 last:mb-0", className)}>{children}</p>
   ),
   h1: ({ children }) => (
-    <Flex align="center" gap="3" className="mt-20">
-      <Box>
-        <h2 className="mb-0 mt-0 text-xl font-bold">{children}</h2>
-      </Box>
-      {!!lessonPlanSectionDescription && (
-        <Tooltip.Provider delayDuration={0}>
-          <Tooltip.Root>
-            <Tooltip.Trigger asChild>
-              <Box className="mb-0 mt-0">
-                <button className="my-0 flex h-[24px] w-[24px] items-center justify-center overflow-hidden rounded-full bg-black p-4">
-                  <span className="p-3 text-xs text-white">i</span>
-                </button>
-              </Box>
-            </Tooltip.Trigger>
-            <Tooltip.Portal>
-              <Tooltip.Content
-                className="max-w-[300px] rounded-lg bg-black p-7 text-center text-sm text-white"
-                sideOffset={5}
-              >
-                {lessonPlanSectionDescription}
-                <Tooltip.Arrow className="TooltipArrow" />
-              </Tooltip.Content>
-            </Tooltip.Portal>
-          </Tooltip.Root>
-        </Tooltip.Provider>
-      )}
-    </Flex>
+    <h2 className="mb-0 mt-20 text-xl font-bold">{children}</h2>
   ),
   code: (props) => {
     const {
@@ -119,12 +89,11 @@ const createComponents = (
 
 export const MemoizedReactMarkdownWithStyles = ({
   markdown,
-  lessonPlanSectionDescription,
   className,
 }: ReactMarkdownWithStylesProps) => {
   const components: Partial<Components> = useMemo(() => {
-    return createComponents(className, lessonPlanSectionDescription);
-  }, [className, lessonPlanSectionDescription]);
+    return createComponents(className);
+  }, [className]);
   return (
     <MemoizedReactMarkdown
       className="prose break-words dark:prose-invert prose-p:leading-relaxed prose-pre:p-0"

--- a/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
@@ -3,7 +3,6 @@ import React, { memo, useMemo } from "react";
 import type { Components, Options } from "react-markdown";
 import ReactMarkdown from "react-markdown";
 
-import { Box, Flex } from "@radix-ui/themes";
 import remarkGfm from "remark-gfm";
 
 import { cn } from "@/lib/utils";

--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/MultipleChoiceQuestion.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/MultipleChoiceQuestion.tsx
@@ -17,12 +17,13 @@ type AnswerCheckboxProps = {
 
 const AnswerCheckbox = ({ isChecked }: AnswerCheckboxProps) => {
   return (
-    <OakBox
+    <OakFlex
       $mr="space-between-xs"
       $width="all-spacing-7"
       $height="all-spacing-7"
       $ba="border-solid-m"
       $borderColor="black"
+      $flexShrink="0"
     >
       {isChecked && (
         <OakIcon
@@ -33,7 +34,7 @@ const AnswerCheckbox = ({ isChecked }: AnswerCheckboxProps) => {
           $transform="scale(1.15)"
         />
       )}
-    </OakBox>
+    </OakFlex>
   );
 };
 
@@ -67,9 +68,12 @@ export const MultipleChoiceQuestion = ({
 
       <OakBox>
         {answers.map((answer, index) => (
-          <OakFlex key={index} $alignItems="center" $mb="space-between-xs">
+          <OakFlex key={index} $alignItems="flex-start" $mb="space-between-xs">
             <AnswerCheckbox isChecked={answer.isCorrect} />
-            <OakBox $font={answer.isCorrect ? "body-2-bold" : "body-2"}>
+            <OakBox
+              $font={answer.isCorrect ? "body-2-bold" : "body-2"}
+              className="pt-[2px]"
+            >
               <MemoizedReactMarkdownWithStyles
                 markdown={`${String.fromCharCode(97 + index)}) ${answer.text}`}
                 className="[&>p]:mb-0 [&>p]:inline"

--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/MultipleChoiceQuestion.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/MultipleChoiceQuestion.tsx
@@ -1,12 +1,40 @@
 import type { QuizV2QuestionMultipleChoice } from "@oakai/aila/src/protocol/schema";
 
-import { OakBox, OakFlex, OakIcon, OakP } from "@oaknational/oak-components";
+import { OakBox, OakFlex, OakIcon } from "@oaknational/oak-components";
+
+import { MemoizedReactMarkdownWithStyles } from "@/components/AppComponents/Chat/markdown";
 
 import { shuffleMultipleChoiceAnswers } from "./shuffle";
 
 type MultipleChoiceQuestionProps = {
   question: QuizV2QuestionMultipleChoice;
   questionNumber: number;
+};
+
+type AnswerCheckboxProps = {
+  isChecked: boolean;
+};
+
+const AnswerCheckbox = ({ isChecked }: AnswerCheckboxProps) => {
+  return (
+    <OakBox
+      $mr="space-between-xs"
+      $width="all-spacing-7"
+      $height="all-spacing-7"
+      $ba="border-solid-m"
+      $borderColor="black"
+    >
+      {isChecked && (
+        <OakIcon
+          iconName="tick"
+          $width="100%"
+          $height="100%"
+          $color="text-inverted"
+          $transform="scale(1.15)"
+        />
+      )}
+    </OakBox>
+  );
 };
 
 export const MultipleChoiceQuestion = ({
@@ -18,50 +46,35 @@ export const MultipleChoiceQuestion = ({
     question.distractors,
   );
 
-  const ensureEndsWithPeriod = (text: string) => {
-    const endsWithPunctuation = /[.!?]$/.test(text);
-    return endsWithPunctuation ? text : `${text}.`;
-  };
-
-  // NOTE: Tick instruction suppressed until design requirement is confirmed
-  // const correctAnswerCount = question.answers.length;
-  // const tickInstruction = `Tick ${correctAnswerCount} correct answer${correctAnswerCount !== 1 ? "s" : ""}.`;
-  const tickInstruction = "";
-  const fullQuestionText = `${questionNumber}. ${ensureEndsWithPeriod(question.question)} ${tickInstruction}`;
-
   return (
     <OakBox $mb="space-between-l">
-      <OakP $mb="space-between-s">{fullQuestionText}</OakP>
+      <OakFlex $mb="space-between-s">
+        <OakBox className="leading-[26px]">{questionNumber}.&nbsp;</OakBox>
+        <MemoizedReactMarkdownWithStyles
+          markdown={question.question}
+          className="[&>p]:mb-0"
+        />
+      </OakFlex>
 
       {question.hint && (
-        <OakP $mb="space-between-s" $color="text-subdued">
-          {question.hint}
-        </OakP>
+        <OakBox $mb="space-between-s" $color="text-subdued">
+          <MemoizedReactMarkdownWithStyles
+            markdown={question.hint}
+            className="[&>p]:mb-0"
+          />
+        </OakBox>
       )}
 
       <OakBox>
         {answers.map((answer, index) => (
           <OakFlex key={index} $alignItems="center" $mb="space-between-xs">
-            <OakBox
-              $mr="space-between-xs"
-              $width="all-spacing-7"
-              $height="all-spacing-7"
-              $ba="border-solid-m"
-              $borderColor="black"
-            >
-              {answer.isCorrect && (
-                <OakIcon
-                  iconName="tick"
-                  $width="100%"
-                  $height="100%"
-                  $color="text-inverted"
-                  $transform="scale(1.15)"
-                />
-              )}
+            <AnswerCheckbox isChecked={answer.isCorrect} />
+            <OakBox $font={answer.isCorrect ? "body-2-bold" : "body-2"}>
+              <MemoizedReactMarkdownWithStyles
+                markdown={`${String.fromCharCode(97 + index)}) ${answer.text}`}
+                className="[&>p]:mb-0 [&>p]:inline"
+              />
             </OakBox>
-            <OakP $font={answer.isCorrect ? "body-2-bold" : "body-2"}>
-              {String.fromCharCode(97 + index)}) {answer.text}
-            </OakP>
           </OakFlex>
         ))}
       </OakBox>

--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/MultipleChoiceQuestion.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/MultipleChoiceQuestion.tsx
@@ -1,0 +1,70 @@
+import type { QuizV2QuestionMultipleChoice } from "@oakai/aila/src/protocol/schema";
+
+import { OakBox, OakFlex, OakIcon, OakP } from "@oaknational/oak-components";
+
+import { shuffleMultipleChoiceAnswers } from "./shuffle";
+
+type MultipleChoiceQuestionProps = {
+  question: QuizV2QuestionMultipleChoice;
+  questionNumber: number;
+};
+
+export const MultipleChoiceQuestion = ({
+  question,
+  questionNumber,
+}: MultipleChoiceQuestionProps) => {
+  const answers = shuffleMultipleChoiceAnswers(
+    question.answers,
+    question.distractors,
+  );
+
+  const ensureEndsWithPeriod = (text: string) => {
+    const endsWithPunctuation = /[.!?]$/.test(text);
+    return endsWithPunctuation ? text : `${text}.`;
+  };
+
+  // NOTE: Tick instruction suppressed until design requirement is confirmed
+  // const correctAnswerCount = question.answers.length;
+  // const tickInstruction = `Tick ${correctAnswerCount} correct answer${correctAnswerCount !== 1 ? "s" : ""}.`;
+  const tickInstruction = "";
+  const fullQuestionText = `${questionNumber}. ${ensureEndsWithPeriod(question.question)} ${tickInstruction}`;
+
+  return (
+    <OakBox $mb="space-between-l">
+      <OakP $mb="space-between-s">{fullQuestionText}</OakP>
+
+      {question.hint && (
+        <OakP $mb="space-between-s" $color="text-subdued">
+          {question.hint}
+        </OakP>
+      )}
+
+      <OakBox>
+        {answers.map((answer, index) => (
+          <OakFlex key={index} $alignItems="center" $mb="space-between-xs">
+            <OakBox
+              $mr="space-between-xs"
+              $width="all-spacing-7"
+              $height="all-spacing-7"
+              $ba="border-solid-m"
+              $borderColor="black"
+            >
+              {answer.isCorrect && (
+                <OakIcon
+                  iconName="tick"
+                  $width="100%"
+                  $height="100%"
+                  $color="text-inverted"
+                  $transform="scale(1.15)"
+                />
+              )}
+            </OakBox>
+            <OakP $font={answer.isCorrect ? "body-2-bold" : "body-2"}>
+              {String.fromCharCode(97 + index)}) {answer.text}
+            </OakP>
+          </OakFlex>
+        ))}
+      </OakBox>
+    </OakBox>
+  );
+};

--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/index.tsx
@@ -1,0 +1,99 @@
+import type {
+  QuizV1,
+  QuizV2QuestionMultipleChoice,
+} from "@oakai/aila/src/protocol/schema";
+import { convertQuizV1ToV2 } from "@oakai/aila/src/protocol/schemas/quiz/conversion/quizV1ToV2";
+
+import { OakBox, OakFlex, OakIcon, OakP } from "@oaknational/oak-components";
+
+import { shuffleMultipleChoiceAnswers } from "./shuffle";
+
+export type QuizSectionProps = {
+  quiz: QuizV1;
+};
+
+type MultipleChoiceQuestionProps = {
+  question: QuizV2QuestionMultipleChoice;
+};
+
+const MultipleChoiceQuestion = ({
+  question,
+  questionNumber,
+}: MultipleChoiceQuestionProps & { questionNumber: number }) => {
+  const answers = shuffleMultipleChoiceAnswers(
+    question.answers,
+    question.distractors,
+  );
+
+  const answerLabels = ["a", "b", "c", "d", "e", "f"];
+  const correctAnswerCount = question.answers.length;
+
+  const ensureEndsWithPeriod = (text: string) => {
+    const endsWithPunctuation = /[.!?]$/.test(text);
+    return endsWithPunctuation ? text : `${text}.`;
+  };
+
+  const tickInstruction = `Tick ${correctAnswerCount} correct answer${correctAnswerCount !== 1 ? "s" : ""}.`;
+  const fullQuestionText = `${questionNumber}. ${ensureEndsWithPeriod(question.questionStem)} ${tickInstruction}`;
+
+  return (
+    <OakBox $mb="space-between-l">
+      <OakP $mb="space-between-s">{fullQuestionText}</OakP>
+
+      {question.hint && (
+        <OakP $mb="space-between-s" $color="text-subdued">
+          {question.hint}
+        </OakP>
+      )}
+
+      <OakBox>
+        {answers.map((answer, index) => (
+          <OakFlex key={index} $alignItems="center" $mb="space-between-xs">
+            <OakBox
+              $mr="space-between-xs"
+              $width="all-spacing-7"
+              $height="all-spacing-7"
+              $ba="border-solid-m"
+              $borderColor="black"
+            >
+              {answer.isCorrect && (
+                <OakIcon
+                  iconName="tick"
+                  $width="100%"
+                  $height="100%"
+                  $color="text-inverted"
+                  $transform="scale(1.15)"
+                />
+              )}
+            </OakBox>
+            <OakP $font={answer.isCorrect ? "body-2-bold" : "body-2"}>
+              {answerLabels[index] || index + 1}) {answer.text}
+            </OakP>
+          </OakFlex>
+        ))}
+      </OakBox>
+
+    </OakBox>
+  );
+};
+
+export const QuizSection = ({ quiz }: QuizSectionProps) => {
+  const quizV2 = convertQuizV1ToV2(quiz);
+  const questions = quizV2.questions;
+  return (
+    <>
+      {questions.map((question, index) => {
+        if (question.questionType === "multiple-choice") {
+          return (
+            <MultipleChoiceQuestion
+              key={index}
+              question={question}
+              questionNumber={index + 1}
+            />
+          );
+        }
+        return null;
+      })}
+    </>
+  );
+};

--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/index.tsx
@@ -25,7 +25,6 @@ const MultipleChoiceQuestion = ({
     question.distractors,
   );
 
-  const answerLabels = ["a", "b", "c", "d", "e", "f"];
   const correctAnswerCount = question.answers.length;
 
   const ensureEndsWithPeriod = (text: string) => {
@@ -67,7 +66,7 @@ const MultipleChoiceQuestion = ({
               )}
             </OakBox>
             <OakP $font={answer.isCorrect ? "body-2-bold" : "body-2"}>
-              {answerLabels[index] || index + 1}) {answer.text}
+              {String.fromCharCode(97 + index)}) {answer.text}
             </OakP>
           </OakFlex>
         ))}

--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/index.tsx
@@ -33,7 +33,7 @@ const MultipleChoiceQuestion = ({
   };
 
   const tickInstruction = `Tick ${correctAnswerCount} correct answer${correctAnswerCount !== 1 ? "s" : ""}.`;
-  const fullQuestionText = `${questionNumber}. ${ensureEndsWithPeriod(question.questionStem)} ${tickInstruction}`;
+  const fullQuestionText = `${questionNumber}. ${ensureEndsWithPeriod(question.question)} ${tickInstruction}`;
 
   return (
     <OakBox $mb="space-between-l">
@@ -71,7 +71,6 @@ const MultipleChoiceQuestion = ({
           </OakFlex>
         ))}
       </OakBox>
-
     </OakBox>
   );
 };

--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/index.tsx
@@ -1,86 +1,32 @@
-import type {
-  QuizV1,
-  QuizV2QuestionMultipleChoice,
-} from "@oakai/aila/src/protocol/schema";
+import { useMemo } from "react";
+
+import type { LessonPlanSectionWhileStreaming } from "@oakai/aila/src/protocol/schema";
+import { QuizV1Schema } from "@oakai/aila/src/protocol/schema";
 import { convertQuizV1ToV2 } from "@oakai/aila/src/protocol/schemas/quiz/conversion/quizV1ToV2";
 
-import { OakBox, OakFlex, OakIcon, OakP } from "@oaknational/oak-components";
-
-import { shuffleMultipleChoiceAnswers } from "./shuffle";
+import { MultipleChoiceQuestion } from "./MultipleChoiceQuestion";
 
 export type QuizSectionProps = {
-  quiz: QuizV1;
+  // When we have agentic generation, we will know that sections are valid when streamed
+  // Until then, it's a loose type
+  quizSection: LessonPlanSectionWhileStreaming;
 };
 
-type MultipleChoiceQuestionProps = {
-  question: QuizV2QuestionMultipleChoice;
-};
+export const QuizSection = ({ quizSection }: QuizSectionProps) => {
+  const quiz = useMemo(() => {
+    return QuizV1Schema.safeParse(quizSection).data;
+  }, [quizSection]);
 
-const MultipleChoiceQuestion = ({
-  question,
-  questionNumber,
-}: MultipleChoiceQuestionProps & { questionNumber: number }) => {
-  const answers = shuffleMultipleChoiceAnswers(
-    question.answers,
-    question.distractors,
-  );
+  if (!quiz) {
+    // Shouldn't happen, but just to be safe
+    return "Invalid quiz";
+  }
 
-  const correctAnswerCount = question.answers.length;
-
-  const ensureEndsWithPeriod = (text: string) => {
-    const endsWithPunctuation = /[.!?]$/.test(text);
-    return endsWithPunctuation ? text : `${text}.`;
-  };
-
-  const tickInstruction = `Tick ${correctAnswerCount} correct answer${correctAnswerCount !== 1 ? "s" : ""}.`;
-  const fullQuestionText = `${questionNumber}. ${ensureEndsWithPeriod(question.question)} ${tickInstruction}`;
-
-  return (
-    <OakBox $mb="space-between-l">
-      <OakP $mb="space-between-s">{fullQuestionText}</OakP>
-
-      {question.hint && (
-        <OakP $mb="space-between-s" $color="text-subdued">
-          {question.hint}
-        </OakP>
-      )}
-
-      <OakBox>
-        {answers.map((answer, index) => (
-          <OakFlex key={index} $alignItems="center" $mb="space-between-xs">
-            <OakBox
-              $mr="space-between-xs"
-              $width="all-spacing-7"
-              $height="all-spacing-7"
-              $ba="border-solid-m"
-              $borderColor="black"
-            >
-              {answer.isCorrect && (
-                <OakIcon
-                  iconName="tick"
-                  $width="100%"
-                  $height="100%"
-                  $color="text-inverted"
-                  $transform="scale(1.15)"
-                />
-              )}
-            </OakBox>
-            <OakP $font={answer.isCorrect ? "body-2-bold" : "body-2"}>
-              {String.fromCharCode(97 + index)}) {answer.text}
-            </OakP>
-          </OakFlex>
-        ))}
-      </OakBox>
-    </OakBox>
-  );
-};
-
-export const QuizSection = ({ quiz }: QuizSectionProps) => {
   const quizV2 = convertQuizV1ToV2(quiz);
-  const questions = quizV2.questions;
+
   return (
     <>
-      {questions.map((question, index) => {
+      {quizV2.questions.map((question, index) => {
         if (question.questionType === "multiple-choice") {
           return (
             <MultipleChoiceQuestion

--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/shuffle.ts
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/shuffle.ts
@@ -1,0 +1,43 @@
+function simpleHash(str: string): number {
+  let hash = 0;
+  if (str.length === 0) return hash;
+  for (let i = 0; i < str.length; i++) {
+    const char = str.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash = hash & hash; // Convert to 32-bit integer
+  }
+  return Math.abs(hash);
+}
+
+export interface ShuffledChoice {
+  text: string;
+  isCorrect: boolean;
+}
+
+/**
+ * Shuffle multiple choice answers and distractors deterministically
+ */
+export function shuffleMultipleChoiceAnswers(
+  answers: string[],
+  distractors: string[],
+): ShuffledChoice[] {
+  const allChoices = [
+    ...answers.map((answer) => ({
+      text: answer,
+      isCorrect: true,
+      sortKey: simpleHash(answer),
+    })),
+    ...distractors.map((distractor) => ({
+      text: distractor,
+      isCorrect: false,
+      sortKey: simpleHash(distractor),
+    })),
+  ];
+
+  return allChoices
+    .sort((a, b) => a.sortKey - b.sortKey)
+    .map((choice) => ({
+      text: choice.text,
+      isCorrect: choice.isCorrect,
+    }));
+}

--- a/apps/nextjs/src/components/AppComponents/SectionContent/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/index.stories.tsx
@@ -1,0 +1,106 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { chromaticParams } from "@/storybook/chromatic";
+import { MathJaxDecorator } from "@/storybook/decorators/MathJaxDecorator";
+
+import { SectionContent } from "./index";
+
+const meta = {
+  title: "Components/SectionContent",
+  component: SectionContent,
+  tags: ["autodocs"],
+  decorators: [MathJaxDecorator],
+  parameters: {
+    ...chromaticParams(["desktop"]),
+  },
+  args: {
+    sectionKey: "learningOutcome",
+    value: "Students will learn about the water cycle and its importance.",
+  },
+} satisfies Meta<typeof SectionContent>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Markdown: Story = {
+  args: {
+    sectionKey: "learningOutcome",
+    value: `# Learning Outcomes
+
+Students will be able to:
+- **Identify** the stages of the water cycle
+- *Explain* how evaporation and condensation work
+- Create a diagram showing the water cycle
+
+## Key Concepts
+1. Evaporation
+2. Condensation
+3. Precipitation
+4. Collection`,
+  },
+};
+
+export const WithMath: Story = {
+  args: {
+    sectionKey: "learningOutcome",
+    value: `# Mathematical Concepts
+
+Students will understand:
+- The formula for area: $A = \\pi r^2$
+- Basic algebra: $ax + b = c$
+- Complex equations: 
+  $$\\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$$`,
+  },
+};
+
+export const StartQuiz: Story = {
+  args: {
+    sectionKey: "starterQuiz",
+    value: [
+      {
+        question: "What is the capital of France?",
+        answers: ["Paris"],
+        distractors: ["London", "Berlin", "Madrid"],
+      },
+      {
+        question: "Which of the following is a prime number?",
+        answers: ["7"],
+        distractors: ["4", "6", "8"],
+      },
+    ],
+  },
+};
+
+export const StartQuizWithMath: Story = {
+  args: {
+    sectionKey: "starterQuiz",
+    value: [
+      {
+        question: "What is the value of $$x$$ in the equation $$2x + 5 = 13$$?",
+        answers: ["4"],
+        distractors: ["3", "5", "6"],
+      },
+      {
+        question:
+          "Calculate the area of a circle with radius $$r = 3$$cm using $$A = \\pi r^2$$",
+        answers: ["$$9\\pi$$ cm²"],
+        distractors: ["$$6\\pi$$ cm²", "$$12\\pi$$ cm²", "$$18\\pi$$ cm²"],
+      },
+    ],
+  },
+};
+
+export const QuizWithHints: Story = {
+  args: {
+    sectionKey: "starterQuiz",
+    value: [
+      {
+        question: "What is the largest planet in our solar system?",
+        answers: ["Jupiter"],
+        distractors: ["Earth", "Saturn", "Neptune"],
+      },
+    ],
+  },
+};

--- a/apps/nextjs/src/components/AppComponents/SectionContent/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/index.stories.tsx
@@ -1,5 +1,6 @@
-import type { Meta, StoryObj } from "@storybook/react";
 import type { QuizV1Question } from "@oakai/aila/src/protocol/schema";
+
+import type { Meta, StoryObj } from "@storybook/react";
 
 import { chromaticParams } from "@/storybook/chromatic";
 import { MathJaxDecorator } from "@/storybook/decorators/MathJaxDecorator";
@@ -111,17 +112,20 @@ export const QuizWithImages: Story = {
     sectionKey: "starterQuiz",
     value: [
       {
-        question: "40 is a multiple of 8. Which multiples of 8 are adjacent to 40?\n\n![Number squares showing 40](https://oaknationalacademy-res.cloudinary.com/image/upload/v1706266807/a3g7nwse0lqdvrggp1vt.png)",
+        question:
+          "40 is a multiple of 8. Which multiples of 8 are adjacent to 40?\n\n![Number squares showing 40](https://oaknationalacademy-res.cloudinary.com/image/upload/v1706266807/a3g7nwse0lqdvrggp1vt.png)",
         answers: ["32", "48"],
         distractors: ["34", "50", "47"],
       },
       {
-        question: "Which mixed operation equation can be used to calculate the missing multiple of 8?\n\n![Number line with missing value](https://oaknationalacademy-res.cloudinary.com/image/upload/v1706266808/pggweqwl9chfutuul4pm.png)",
+        question:
+          "Which mixed operation equation can be used to calculate the missing multiple of 8?\n\n![Number line with missing value](https://oaknationalacademy-res.cloudinary.com/image/upload/v1706266808/pggweqwl9chfutuul4pm.png)",
         answers: ["5 × 8 − 8", "3 × 8 + 8"],
         distractors: ["4 groups of 8", "8 x 4"],
       },
       {
-        question: "Here is part of the 8 times table grid. What could Izzy do to find 13 × 8 quickly?\n\n![8 times table grid](https://oaknationalacademy-res.cloudinary.com/image/upload/v1706266809/pm6upn12cjexhp4xcccg.png)",
+        question:
+          "Here is part of the 8 times table grid. What could Izzy do to find 13 × 8 quickly?\n\n![8 times table grid](https://oaknationalacademy-res.cloudinary.com/image/upload/v1706266809/pm6upn12cjexhp4xcccg.png)",
         answers: ["12 x 8 + 8", "Increase 96 by 8"],
         distractors: ["Count in eights from zero"],
       },
@@ -130,7 +134,9 @@ export const QuizWithImages: Story = {
         // and currently renders poorly. The images appear inline with text and need
         // proper layout/styling for a better visual presentation.
         question: "Which diagram shows 3 groups of 8?",
-        answers: ["![3 groups of 8 dots](https://oaknationalacademy-res.cloudinary.com/image/upload/v1706266807/a3g7nwse0lqdvrggp1vt.png)"],
+        answers: [
+          "![3 groups of 8 dots](https://oaknationalacademy-res.cloudinary.com/image/upload/v1706266807/a3g7nwse0lqdvrggp1vt.png)",
+        ],
         distractors: [
           "![2 groups of 8 dots](https://oaknationalacademy-res.cloudinary.com/image/upload/v1706266808/pggweqwl9chfutuul4pm.png)",
           "![4 groups of 8 dots](https://oaknationalacademy-res.cloudinary.com/image/upload/v1706266809/pm6upn12cjexhp4xcccg.png)",

--- a/apps/nextjs/src/components/AppComponents/SectionContent/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/index.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import type { QuizV1Question } from "@oakai/aila/src/protocol/schema";
 
 import { chromaticParams } from "@/storybook/chromatic";
 import { MathJaxDecorator } from "@/storybook/decorators/MathJaxDecorator";
@@ -42,7 +43,7 @@ Students will be able to:
   },
 };
 
-export const WithMath: Story = {
+export const WithMaths: Story = {
   args: {
     sectionKey: "learningOutcome",
     value: `# Mathematical Concepts
@@ -50,12 +51,12 @@ export const WithMath: Story = {
 Students will understand:
 - The formula for area: $A = \\pi r^2$
 - Basic algebra: $ax + b = c$
-- Complex equations: 
+- Complex equations:
   $$\\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$$`,
   },
 };
 
-export const StartQuiz: Story = {
+export const Quiz: Story = {
   args: {
     sectionKey: "starterQuiz",
     value: [
@@ -69,11 +70,11 @@ export const StartQuiz: Story = {
         answers: ["7"],
         distractors: ["4", "6", "8"],
       },
-    ],
+    ] satisfies QuizV1Question[],
   },
 };
 
-export const StartQuizWithMath: Story = {
+export const QuizWithMaths: Story = {
   args: {
     sectionKey: "starterQuiz",
     value: [
@@ -88,11 +89,11 @@ export const StartQuizWithMath: Story = {
         answers: ["$$9\\pi$$ cm²"],
         distractors: ["$$6\\pi$$ cm²", "$$12\\pi$$ cm²", "$$18\\pi$$ cm²"],
       },
-    ],
+    ] satisfies QuizV1Question[],
   },
 };
 
-export const QuizWithHints: Story = {
+export const WithHints: Story = {
   args: {
     sectionKey: "starterQuiz",
     value: [
@@ -101,6 +102,40 @@ export const QuizWithHints: Story = {
         answers: ["Jupiter"],
         distractors: ["Earth", "Saturn", "Neptune"],
       },
-    ],
+    ] satisfies QuizV1Question[],
+  },
+};
+
+export const QuizWithImages: Story = {
+  args: {
+    sectionKey: "starterQuiz",
+    value: [
+      {
+        question: "40 is a multiple of 8. Which multiples of 8 are adjacent to 40?\n\n![Number squares showing 40](https://oaknationalacademy-res.cloudinary.com/image/upload/v1706266807/a3g7nwse0lqdvrggp1vt.png)",
+        answers: ["32", "48"],
+        distractors: ["34", "50", "47"],
+      },
+      {
+        question: "Which mixed operation equation can be used to calculate the missing multiple of 8?\n\n![Number line with missing value](https://oaknationalacademy-res.cloudinary.com/image/upload/v1706266808/pggweqwl9chfutuul4pm.png)",
+        answers: ["5 × 8 − 8", "3 × 8 + 8"],
+        distractors: ["4 groups of 8", "8 x 4"],
+      },
+      {
+        question: "Here is part of the 8 times table grid. What could Izzy do to find 13 × 8 quickly?\n\n![8 times table grid](https://oaknationalacademy-res.cloudinary.com/image/upload/v1706266809/pm6upn12cjexhp4xcccg.png)",
+        answers: ["12 x 8 + 8", "Increase 96 by 8"],
+        distractors: ["Count in eights from zero"],
+      },
+      {
+        // TODO: This use case (images in answer choices) is not fully implemented yet
+        // and currently renders poorly. The images appear inline with text and need
+        // proper layout/styling for a better visual presentation.
+        question: "Which diagram shows 3 groups of 8?",
+        answers: ["![3 groups of 8 dots](https://oaknationalacademy-res.cloudinary.com/image/upload/v1706266807/a3g7nwse0lqdvrggp1vt.png)"],
+        distractors: [
+          "![2 groups of 8 dots](https://oaknationalacademy-res.cloudinary.com/image/upload/v1706266808/pggweqwl9chfutuul4pm.png)",
+          "![4 groups of 8 dots](https://oaknationalacademy-res.cloudinary.com/image/upload/v1706266809/pm6upn12cjexhp4xcccg.png)",
+        ],
+      },
+    ] satisfies QuizV1Question[],
   },
 };

--- a/apps/nextjs/src/components/AppComponents/SectionContent/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/index.stories.tsx
@@ -94,19 +94,6 @@ export const QuizWithMaths: Story = {
   },
 };
 
-export const WithHints: Story = {
-  args: {
-    sectionKey: "starterQuiz",
-    value: [
-      {
-        question: "What is the largest planet in our solar system?",
-        answers: ["Jupiter"],
-        distractors: ["Earth", "Saturn", "Neptune"],
-      },
-    ] satisfies QuizV1Question[],
-  },
-};
-
 export const QuizWithImages: Story = {
   args: {
     sectionKey: "starterQuiz",

--- a/apps/nextjs/src/components/AppComponents/SectionContent/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/index.tsx
@@ -25,7 +25,6 @@ export const SectionContent = ({ sectionKey, value }: SectionContentProps) => {
         </MathJax>
       );
     }
-    // Invalid quiz data, show error or empty
     return <div>Quiz data invalid or loading...</div>;
   }
   return (

--- a/apps/nextjs/src/components/AppComponents/SectionContent/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/index.tsx
@@ -1,0 +1,38 @@
+import type {
+  LessonPlanKey,
+  LessonPlanSectionWhileStreaming,
+} from "@oakai/aila/src/protocol/schema";
+import { QuizV1Schema } from "@oakai/aila/src/protocol/schema";
+import { sectionToMarkdown } from "@oakai/aila/src/protocol/sectionToMarkdown";
+
+import { MathJax } from "better-react-mathjax";
+
+import { MemoizedReactMarkdownWithStyles } from "../Chat/markdown";
+import { QuizSection } from "./QuizSection";
+
+export type SectionContentProps = {
+  sectionKey: LessonPlanKey;
+  value: LessonPlanSectionWhileStreaming;
+};
+
+export const SectionContent = ({ sectionKey, value }: SectionContentProps) => {
+  if (sectionKey === "starterQuiz" || sectionKey === "exitQuiz") {
+    const quizResult = QuizV1Schema.safeParse(value);
+    if (quizResult.success) {
+      return (
+        <MathJax hideUntilTypeset="every" dynamic>
+          <QuizSection quiz={quizResult.data} />
+        </MathJax>
+      );
+    }
+    // Invalid quiz data, show error or empty
+    return <div>Quiz data invalid or loading...</div>;
+  }
+  return (
+    <MathJax hideUntilTypeset="every" dynamic>
+      <MemoizedReactMarkdownWithStyles
+        markdown={sectionToMarkdown(sectionKey, value) ?? ""}
+      />
+    </MathJax>
+  );
+};

--- a/apps/nextjs/src/components/AppComponents/SectionContent/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/index.tsx
@@ -2,7 +2,6 @@ import type {
   LessonPlanKey,
   LessonPlanSectionWhileStreaming,
 } from "@oakai/aila/src/protocol/schema";
-import { QuizV1Schema } from "@oakai/aila/src/protocol/schema";
 import { sectionToMarkdown } from "@oakai/aila/src/protocol/sectionToMarkdown";
 
 import { MathJax } from "better-react-mathjax";
@@ -17,15 +16,11 @@ export type SectionContentProps = {
 
 export const SectionContent = ({ sectionKey, value }: SectionContentProps) => {
   if (sectionKey === "starterQuiz" || sectionKey === "exitQuiz") {
-    const quizResult = QuizV1Schema.safeParse(value);
-    if (quizResult.success) {
-      return (
-        <MathJax hideUntilTypeset="every" dynamic>
-          <QuizSection quiz={quizResult.data} />
-        </MathJax>
-      );
-    }
-    return <div>Quiz data invalid or loading...</div>;
+    return (
+      <MathJax hideUntilTypeset="every" dynamic>
+        <QuizSection quizSection={value} />
+      </MathJax>
+    );
   }
   return (
     <MathJax hideUntilTypeset="every" dynamic>

--- a/apps/nextjs/src/components/AppComponents/static-lesson-plan-renderer.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/static-lesson-plan-renderer.stories.tsx
@@ -1,0 +1,53 @@
+import type { Meta, StoryObj } from "@storybook/react";
+
+import { chromaticParams } from "@/storybook/chromatic";
+import { MathJaxDecorator } from "@/storybook/decorators/MathJaxDecorator";
+
+import StaticLessonPlanRenderer from "./static-lesson-plan-renderer";
+
+const meta = {
+  title: "Components/StaticLessonPlanRenderer",
+  component: StaticLessonPlanRenderer,
+  tags: ["autodocs"],
+  decorators: [MathJaxDecorator],
+  parameters: {
+    ...chromaticParams(["desktop"]),
+  },
+  args: {
+    lessonPlan: {
+      title: "About Frogs",
+      keyStage: "Key Stage 2",
+      subject: "Science",
+      topic: "Amphibians",
+      learningOutcome:
+        "Students will understand the characteristics of amphibians",
+      starterQuiz: [
+        {
+          question: "What do you know about frogs?",
+          answers: ["They are amphibians"],
+          distractors: ["They are reptiles", "They are fish"],
+        },
+      ],
+      keyLearningPoints: [
+        "Frogs are amphibians",
+        "They live in water and on land",
+      ],
+    },
+  },
+} satisfies Meta<typeof StaticLessonPlanRenderer>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const WithTooltips: Story = {
+  parameters: {
+    docs: {
+      description: {
+        story:
+          "Shows section titles with info tooltips - the key feature of the static renderer.",
+      },
+    },
+  },
+};

--- a/apps/nextjs/src/components/AppComponents/static-lesson-plan-renderer.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/static-lesson-plan-renderer.stories.tsx
@@ -53,17 +53,17 @@ export const WithTooltips: Story = {
   },
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
-    
+
     // Wait for the component to render
     await new Promise((resolve) => setTimeout(resolve, 100));
-    
+
     // Find all info buttons (they contain "i" text)
-    const infoButtons = canvas.getAllByText('i');
-    
+    const infoButtons = canvas.getAllByText("i");
+
     if (infoButtons.length > 0) {
       // Hover over the first info button to show tooltip
       await userEvent.hover(infoButtons[0]!);
-      
+
       // Keep the tooltip visible for Chromatic snapshot
       await new Promise((resolve) => setTimeout(resolve, 500));
     }

--- a/apps/nextjs/src/components/AppComponents/static-lesson-plan-renderer.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/static-lesson-plan-renderer.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from "@storybook/react";
+import { userEvent, within } from "@storybook/test";
 
 import { chromaticParams } from "@/storybook/chromatic";
 import { MathJaxDecorator } from "@/storybook/decorators/MathJaxDecorator";
@@ -49,5 +50,22 @@ export const WithTooltips: Story = {
           "Shows section titles with info tooltips - the key feature of the static renderer.",
       },
     },
+  },
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    
+    // Wait for the component to render
+    await new Promise((resolve) => setTimeout(resolve, 100));
+    
+    // Find all info buttons (they contain "i" text)
+    const infoButtons = canvas.getAllByText('i');
+    
+    if (infoButtons.length > 0) {
+      // Hover over the first info button to show tooltip
+      await userEvent.hover(infoButtons[0]!);
+      
+      // Keep the tooltip visible for Chromatic snapshot
+      await new Promise((resolve) => setTimeout(resolve, 500));
+    }
   },
 };

--- a/apps/nextjs/src/components/AppComponents/static-lesson-plan-renderer.tsx
+++ b/apps/nextjs/src/components/AppComponents/static-lesson-plan-renderer.tsx
@@ -117,7 +117,7 @@ export const StaticSection = ({
 
   return (
     <div ref={sectionRef}>
-      <Flex align="center" gap="3" className="mt-20">
+      <Flex align="center" gap="3" className="mb-11 mt-20">
         <Box>
           <h2 className="mb-0 mt-0 text-xl font-bold">{title}</h2>
         </Box>

--- a/apps/nextjs/src/components/AppComponents/static-lesson-plan-renderer.tsx
+++ b/apps/nextjs/src/components/AppComponents/static-lesson-plan-renderer.tsx
@@ -2,17 +2,18 @@ import { useRef } from "react";
 
 import type {
   LessonPlanKey,
+  LessonPlanSectionWhileStreaming,
   LooseLessonPlan,
 } from "@oakai/aila/src/protocol/schema";
-import { sectionToMarkdown } from "@oakai/aila/src/protocol/sectionToMarkdown";
 
-import { MathJax } from "better-react-mathjax";
+import * as Tooltip from "@radix-ui/react-tooltip";
+import { Box, Flex } from "@radix-ui/themes";
 
 import { lessonSectionTitlesAndMiniDescriptions } from "@/data/lessonSectionTitlesAndMiniDescriptions";
 
-import { notEmpty } from "./chat-lessonPlanDisplay";
-import { sectionTitle } from "./drop-down-section/sectionTitle";
-import { MemoizedReactMarkdownWithStyles } from "./markdown";
+import { notEmpty } from "./Chat/chat-lessonPlanDisplay";
+import { sectionTitle } from "./Chat/drop-down-section/sectionTitle";
+import { SectionContent } from "./SectionContent";
 
 const excludedKeys = [
   "title",
@@ -25,7 +26,7 @@ const excludedKeys = [
 type ExcludedKeys = (typeof excludedKeys)[number];
 type ValidLessonPlanKey = Exclude<LessonPlanKey, ExcludedKeys>;
 
-const LessonPlanMapToMarkDown = ({
+const StaticLessonPlanRenderer = ({
   lessonPlan,
   sectionRefs,
 }: {
@@ -82,7 +83,7 @@ const LessonPlanMapToMarkDown = ({
     })
     .map(({ key, value }) => {
       return (
-        <ChatSection
+        <StaticSection
           key={key}
           sectionRefs={sectionRefs}
           objectKey={key}
@@ -92,33 +93,57 @@ const LessonPlanMapToMarkDown = ({
     });
 };
 
-export default LessonPlanMapToMarkDown;
+export default StaticLessonPlanRenderer;
 
-export interface ChatSectionProps {
+export interface StaticSectionProps {
   sectionRefs?: Record<string, React.MutableRefObject<HTMLDivElement | null>>;
   objectKey: LessonPlanKey;
-  value: unknown;
+  value: LessonPlanSectionWhileStreaming;
 }
 
-const ChatSection = ({
+// Rendered in static contexts like the share page
+export const StaticSection = ({
   sectionRefs,
   objectKey,
   value,
-}: Readonly<ChatSectionProps>) => {
+}: Readonly<StaticSectionProps>) => {
   const sectionRef = useRef<HTMLDivElement | null>(null);
   if (sectionRefs) sectionRefs[objectKey] = sectionRef;
 
+  const title = sectionTitle(objectKey);
+  const sectionDescription = sectionTitle(
+    lessonSectionTitlesAndMiniDescriptions[objectKey].description,
+  );
+
   return (
     <div ref={sectionRef}>
-      <MathJax hideUntilTypeset="every" dynamic>
-        <MemoizedReactMarkdownWithStyles
-          lessonPlanSectionDescription={
-            lessonSectionTitlesAndMiniDescriptions[objectKey]?.description
-          }
-          markdown={`# ${sectionTitle(objectKey)}
-${sectionToMarkdown(objectKey, value)}`}
-        />
-      </MathJax>
+      <Flex align="center" gap="3" className="mt-20">
+        <Box>
+          <h2 className="mb-0 mt-0 text-xl font-bold">{title}</h2>
+        </Box>
+        <Tooltip.Provider delayDuration={0}>
+          <Tooltip.Root>
+            <Tooltip.Trigger asChild>
+              <Box className="mb-0 mt-0">
+                <button className="my-0 flex h-[24px] w-[24px] items-center justify-center overflow-hidden rounded-full bg-black p-4">
+                  <span className="p-3 text-xs text-white">i</span>
+                </button>
+              </Box>
+            </Tooltip.Trigger>
+            <Tooltip.Portal>
+              <Tooltip.Content
+                className="max-w-[300px] rounded-lg bg-black p-7 text-center text-sm text-white"
+                sideOffset={5}
+              >
+                {sectionDescription}
+                <Tooltip.Arrow className="TooltipArrow" />
+              </Tooltip.Content>
+            </Tooltip.Portal>
+          </Tooltip.Root>
+        </Tooltip.Provider>
+      </Flex>
+
+      <SectionContent sectionKey={objectKey} value={value} />
     </div>
   );
 };

--- a/apps/nextjs/src/stores/chatStore/hooks/useChatStoreAiSdkSync.ts
+++ b/apps/nextjs/src/stores/chatStore/hooks/useChatStoreAiSdkSync.ts
@@ -22,6 +22,7 @@ export const useChatStoreAiSdkSync = (
   const { setMessages, setAiSdkActions } = useChatActions();
 
   useEffect(() => {
+    console.log("useChatStoreAiSdkSync", messages, isLoading);
     setMessages(messages, isLoading);
   }, [messages, isLoading, setMessages]);
 

--- a/apps/nextjs/src/stores/chatStore/hooks/useChatStoreAiSdkSync.ts
+++ b/apps/nextjs/src/stores/chatStore/hooks/useChatStoreAiSdkSync.ts
@@ -22,7 +22,6 @@ export const useChatStoreAiSdkSync = (
   const { setMessages, setAiSdkActions } = useChatActions();
 
   useEffect(() => {
-    console.log("useChatStoreAiSdkSync", messages, isLoading);
     setMessages(messages, isLoading);
   }, [messages, isLoading, setMessages]);
 

--- a/packages/aila/src/protocol/schemas/quiz/conversion/quizV1ToV2.test.ts
+++ b/packages/aila/src/protocol/schemas/quiz/conversion/quizV1ToV2.test.ts
@@ -20,10 +20,9 @@ describe("V1 to V2 Quiz Conversion", () => {
 
       expect(result).toEqual({
         questionType: "multiple-choice",
-        questionStem: "What is 2 + 2?",
+        question: "What is 2 + 2?",
         answers: ["4"],
         distractors: ["3", "5"],
-        feedback: undefined,
         hint: undefined,
       });
     });
@@ -63,10 +62,9 @@ describe("V1 to V2 Quiz Conversion", () => {
         questions: [
           {
             questionType: "multiple-choice" as const,
-            questionStem: "Q1",
+            question: "Q1",
             answers: ["A"],
             distractors: ["B"],
-            feedback: undefined,
             hint: undefined,
           },
         ],

--- a/packages/aila/src/protocol/schemas/quiz/conversion/quizV1ToV2.ts
+++ b/packages/aila/src/protocol/schemas/quiz/conversion/quizV1ToV2.ts
@@ -4,7 +4,12 @@
  * This module provides utilities to convert V1 quiz format (multiple choice only)
  * to V2 format (discriminated union supporting multiple quiz types).
  */
-import type { QuizV1, QuizV1Question, QuizV2, QuizV2Question } from "..";
+import type {
+  QuizV1,
+  QuizV1Question,
+  QuizV2,
+  QuizV2Question,
+} from "..";
 
 /**
  * Convert a V1 quiz question (MC only) to V2 format
@@ -17,7 +22,6 @@ export function convertQuizV1QuestionToV2(
     questionStem: questionV1.question,
     answers: questionV1.answers,
     distractors: questionV1.distractors,
-    feedback: undefined,
     hint: undefined,
   };
 }

--- a/packages/aila/src/protocol/schemas/quiz/conversion/quizV1ToV2.ts
+++ b/packages/aila/src/protocol/schemas/quiz/conversion/quizV1ToV2.ts
@@ -4,12 +4,7 @@
  * This module provides utilities to convert V1 quiz format (multiple choice only)
  * to V2 format (discriminated union supporting multiple quiz types).
  */
-import type {
-  QuizV1,
-  QuizV1Question,
-  QuizV2,
-  QuizV2Question,
-} from "..";
+import type { QuizV1, QuizV1Question, QuizV2, QuizV2Question } from "..";
 
 /**
  * Convert a V1 quiz question (MC only) to V2 format
@@ -19,7 +14,7 @@ export function convertQuizV1QuestionToV2(
 ): QuizV2Question {
   return {
     questionType: "multiple-choice",
-    questionStem: questionV1.question,
+    question: questionV1.question,
     answers: questionV1.answers,
     distractors: questionV1.distractors,
     hint: undefined,

--- a/packages/aila/src/protocol/schemas/quiz/quizV2.ts
+++ b/packages/aila/src/protocol/schemas/quiz/quizV2.ts
@@ -3,7 +3,7 @@ import { z } from "zod";
 // ********** QUIZ V2 (discriminated union for multiple quiz types) **********
 
 export const QUIZ_V2_DESCRIPTIONS = {
-  questionStem: "The question stem as markdown text",
+  question: "The question as markdown text",
   questionType: "The type of quiz question",
   answers: "The answers specific to this question type",
   hint: "Optional hint to help students",
@@ -11,8 +11,7 @@ export const QUIZ_V2_DESCRIPTIONS = {
 
 // Base question schema with common fields
 export const QuizV2QuestionBaseSchema = z.object({
-  // TODO: rename to question
-  questionStem: z.string().describe(QUIZ_V2_DESCRIPTIONS.questionStem),
+  question: z.string().describe(QUIZ_V2_DESCRIPTIONS.question),
   hint: z.string().optional().describe(QUIZ_V2_DESCRIPTIONS.hint),
 });
 

--- a/packages/aila/src/protocol/schemas/quiz/quizV2.ts
+++ b/packages/aila/src/protocol/schemas/quiz/quizV2.ts
@@ -6,14 +6,13 @@ export const QUIZ_V2_DESCRIPTIONS = {
   questionStem: "The question stem as markdown text",
   questionType: "The type of quiz question",
   answers: "The answers specific to this question type",
-  feedback: "Feedback to show after the question is answered",
   hint: "Optional hint to help students",
 } as const;
 
 // Base question schema with common fields
 export const QuizV2QuestionBaseSchema = z.object({
+  // TODO: rename to question
   questionStem: z.string().describe(QUIZ_V2_DESCRIPTIONS.questionStem),
-  feedback: z.string().optional().describe(QUIZ_V2_DESCRIPTIONS.feedback),
   hint: z.string().optional().describe(QUIZ_V2_DESCRIPTIONS.hint),
 });
 


### PR DESCRIPTION
## Summary
Implement quiz V2 rendering components to display existing V1 quiz data. Both the chat interface and share page use the same rendering components but with different title displays - chat uses collapsible sections while share page shows static titles with tooltips.

## Changes
- Add `SectionContent` component that validates V1 quiz data and converts to V2 for rendering
- Create `QuizSection` component with Oak styling (checkboxes, answer labels, dynamic instructions)
- Refactor shared rendering: `ChatSection` → `StaticSection` and move out of Chat folder  
- Add storybook stories for testing components
- Remove unused `feedback` field from QuizV2 schema

## Test plan
- [ ] Check quiz rendering in Storybook
- [ ] Verify math delimiters work (`$$..$$`)
- [ ] Test quiz display in both chat and share page contexts