### PR TITLE
feat: add convertRawQuizToV2 function for quiz format conversion

### DIFF
--- a/packages/aila/src/protocol/schemas/quiz/conversion/__snapshots__/rawQuizIngest.test.ts.snap
+++ b/packages/aila/src/protocol/schemas/quiz/conversion/__snapshots__/rawQuizIngest.test.ts.snap
@@ -2,6 +2,16 @@
 
 exports[`convertRawQuizToV2 should convert raw quiz to V2 format 1`] = `
 {
+  "imageAttributions": [
+    {
+      "attribution": "Photo by John Doe on Unsplash",
+      "imageUrl": "https://example.com/dog.jpg",
+    },
+    {
+      "attribution": "Image © Example Inc",
+      "imageUrl": "https://example.com/cat.jpg",
+    },
+  ],
   "questions": [
     {
       "answers": [
@@ -11,7 +21,7 @@ exports[`convertRawQuizToV2 should convert raw quiz to V2 format 1`] = `
         "London",
         "Berlin",
       ],
-      "imageAttributions": [],
+      "hint": "Think about the Eiffel Tower",
       "question": "What is the capital of France?",
       "questionType": "multiple-choice",
     },
@@ -21,7 +31,7 @@ exports[`convertRawQuizToV2 should convert raw quiz to V2 format 1`] = `
         "blue",
         "yellow",
       ],
-      "imageAttributions": [],
+      "hint": "These colors cannot be created by mixing other colors",
       "question": "Name a primary color",
       "questionType": "short-answer",
     },
@@ -32,21 +42,12 @@ exports[`convertRawQuizToV2 should convert raw quiz to V2 format 1`] = `
       "distractors": [
         "Cat ![](https://example.com/cat.jpg)",
       ],
-      "imageAttributions": [
-        {
-          "attribution": "Photo by John Doe on Unsplash",
-          "imageUrl": "https://example.com/dog.jpg",
-        },
-        {
-          "attribution": "Image © Example Inc",
-          "imageUrl": "https://example.com/cat.jpg",
-        },
-      ],
-      "question": "Which animal is shown in the image? ![](https://example.com/dog.jpg)",
+      "hint": "It barks",
+      "question": "Which animal is shown in the image? ![A friendly golden retriever sitting in a park](https://example.com/dog.jpg)",
       "questionType": "multiple-choice",
     },
     {
-      "imageAttributions": [],
+      "hint": "Think about European geography",
       "pairs": [
         {
           "left": "France",
@@ -61,7 +62,7 @@ exports[`convertRawQuizToV2 should convert raw quiz to V2 format 1`] = `
       "questionType": "match",
     },
     {
-      "imageAttributions": [],
+      "hint": "Start with the smallest",
       "items": [
         "1",
         "3",

--- a/packages/aila/src/protocol/schemas/quiz/conversion/__snapshots__/rawQuizIngest.test.ts.snap
+++ b/packages/aila/src/protocol/schemas/quiz/conversion/__snapshots__/rawQuizIngest.test.ts.snap
@@ -1,0 +1,76 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`convertRawQuizToV2 should convert raw quiz to V2 format 1`] = `
+{
+  "questions": [
+    {
+      "answers": [
+        "Paris",
+      ],
+      "distractors": [
+        "London",
+        "Berlin",
+      ],
+      "imageAttributions": [],
+      "question": "What is the capital of France?",
+      "questionType": "multiple-choice",
+    },
+    {
+      "answers": [
+        "red",
+        "blue",
+        "yellow",
+      ],
+      "imageAttributions": [],
+      "question": "Name a primary color",
+      "questionType": "short-answer",
+    },
+    {
+      "answers": [
+        "Dog",
+      ],
+      "distractors": [
+        "Cat ![](https://example.com/cat.jpg)",
+      ],
+      "imageAttributions": [
+        {
+          "attribution": "Photo by John Doe on Unsplash",
+          "imageUrl": "https://example.com/dog.jpg",
+        },
+        {
+          "attribution": "Image © Example Inc",
+          "imageUrl": "https://example.com/cat.jpg",
+        },
+      ],
+      "question": "Which animal is shown in the image? ![](https://example.com/dog.jpg)",
+      "questionType": "multiple-choice",
+    },
+    {
+      "imageAttributions": [],
+      "pairs": [
+        {
+          "left": "France",
+          "right": "Paris",
+        },
+        {
+          "left": "Germany",
+          "right": "Berlin",
+        },
+      ],
+      "question": "Match the countries to their capitals",
+      "questionType": "match",
+    },
+    {
+      "imageAttributions": [],
+      "items": [
+        "1",
+        "3",
+        "5",
+      ],
+      "question": "Put these numbers in ascending order",
+      "questionType": "order",
+    },
+  ],
+  "version": "v2",
+}
+`;

--- a/packages/aila/src/protocol/schemas/quiz/conversion/rawQuizIngest.test.ts
+++ b/packages/aila/src/protocol/schemas/quiz/conversion/rawQuizIngest.test.ts
@@ -161,4 +161,22 @@ describe("convertRawQuizToV2", () => {
       "![A golden retriever sitting in a park](https://example.com/dog.jpg)",
     );
   });
+
+  it("should throw error for unknown question type", () => {
+    const unknownTypeQuiz = [
+      {
+        question_id: 1,
+        question_uid: "test-uid-1",
+        question_type: "unknown-type" as unknown as "multiple-choice",
+        question_stem: [{ text: "Question", type: "text" }],
+        answers: {},
+        feedback: "",
+        hint: "",
+        active: true,
+      },
+    ] as RawQuiz;
+    expect(() => convertRawQuizToV2(unknownTypeQuiz)).toThrow(
+      "Unknown question type: unknown-type",
+    );
+  });
 });

--- a/packages/aila/src/protocol/schemas/quiz/conversion/rawQuizIngest.test.ts
+++ b/packages/aila/src/protocol/schemas/quiz/conversion/rawQuizIngest.test.ts
@@ -1,0 +1,123 @@
+import { describe, expect, it } from "@jest/globals";
+
+import { rawQuizFixture } from "../fixtures/rawQuizFixture";
+import type { RawQuiz } from "../rawQuiz";
+import { convertRawQuizToV2 } from "./rawQuizIngest";
+
+describe("convertRawQuizToV2", () => {
+  it("should convert raw quiz to V2 format", () => {
+    const result = convertRawQuizToV2(rawQuizFixture);
+    expect(result).toMatchSnapshot();
+  });
+
+  it("should handle empty quiz", () => {
+    const result = convertRawQuizToV2([]);
+    expect(result).toEqual({
+      version: "v2",
+      questions: [],
+    });
+  });
+
+  it("should handle null quiz", () => {
+    const result = convertRawQuizToV2(null);
+    expect(result).toEqual({
+      version: "v2",
+      questions: [],
+    });
+  });
+
+  it("should filter out explanatory-text questions", () => {
+    const explanatoryOnlyQuiz: RawQuiz = [
+      {
+        question_id: 1,
+        question_uid: "test-uid-1",
+        question_type: "explanatory-text",
+        question_stem: [{ text: "Just text", type: "text" }],
+        answers: { "explanatory-text": null },
+        feedback: "",
+        hint: "",
+        active: true,
+      },
+    ];
+    const result = convertRawQuizToV2(explanatoryOnlyQuiz);
+    expect(result.questions).toHaveLength(0);
+  });
+
+  it("should extract image attributions correctly", () => {
+    const quizWithImages: RawQuiz = [
+      {
+        question_id: 1,
+        question_uid: "test-uid-1",
+        question_type: "multiple-choice",
+        question_stem: [
+          {
+            image_object: {
+              secure_url: "https://example.com/image1.jpg",
+              metadata: {
+                attribution: "Photo by Photographer",
+              },
+            },
+            type: "image",
+          },
+        ],
+        answers: {
+          "multiple-choice": [
+            {
+              answer: [{ text: "A", type: "text" }],
+              answer_is_correct: true,
+            },
+          ],
+        },
+        feedback: "",
+        hint: "",
+        active: true,
+      },
+    ];
+    const result = convertRawQuizToV2(quizWithImages);
+    expect(result.questions[0]?.question).toContain(
+      "![](https://example.com/image1.jpg)",
+    );
+    expect(result.questions[0]?.imageAttributions).toEqual([
+      {
+        imageUrl: "https://example.com/image1.jpg",
+        attribution: "Photo by Photographer",
+      },
+    ]);
+  });
+
+  it("should convert images to markdown syntax", () => {
+    const quizWithImages: RawQuiz = [
+      {
+        question_id: 1,
+        question_uid: "test-uid-1",
+        question_type: "multiple-choice",
+        question_stem: [
+          { text: "Look at", type: "text" },
+          {
+            image_object: {
+              secure_url: "https://example.com/image.jpg",
+              metadata: {},
+            },
+            type: "image",
+          },
+          { text: "What is it?", type: "text" },
+        ],
+        answers: {
+          "multiple-choice": [
+            {
+              answer: [{ text: "A", type: "text" }],
+              answer_is_correct: true,
+            },
+          ],
+        },
+        feedback: "",
+        hint: "",
+        active: true,
+      },
+    ];
+    const result = convertRawQuizToV2(quizWithImages);
+    expect(result.questions[0]?.question).toBe(
+      "Look at ![](https://example.com/image.jpg) What is it?",
+    );
+  });
+});

--- a/packages/aila/src/protocol/schemas/quiz/conversion/rawQuizIngest.test.ts
+++ b/packages/aila/src/protocol/schemas/quiz/conversion/rawQuizIngest.test.ts
@@ -15,6 +15,7 @@ describe("convertRawQuizToV2", () => {
     expect(result).toEqual({
       version: "v2",
       questions: [],
+      imageAttributions: [],
     });
   });
 
@@ -23,6 +24,7 @@ describe("convertRawQuizToV2", () => {
     expect(result).toEqual({
       version: "v2",
       questions: [],
+      imageAttributions: [],
     });
   });
 
@@ -77,7 +79,7 @@ describe("convertRawQuizToV2", () => {
     expect(result.questions[0]?.question).toContain(
       "![](https://example.com/image1.jpg)",
     );
-    expect(result.questions[0]?.imageAttributions).toEqual([
+    expect(result.imageAttributions).toEqual([
       {
         imageUrl: "https://example.com/image1.jpg",
         attribution: "Photo by Photographer",
@@ -118,6 +120,45 @@ describe("convertRawQuizToV2", () => {
     const result = convertRawQuizToV2(quizWithImages);
     expect(result.questions[0]?.question).toBe(
       "Look at ![](https://example.com/image.jpg) What is it?",
+    );
+  });
+
+  it("should extract alt text from images when available", () => {
+    const quizWithAltText: RawQuiz = [
+      {
+        question_id: 1,
+        question_uid: "test-uid-1",
+        question_type: "multiple-choice",
+        question_stem: [
+          {
+            image_object: {
+              secure_url: "https://example.com/dog.jpg",
+              metadata: {},
+              context: {
+                custom: {
+                  alt: "A golden retriever sitting in a park",
+                },
+              },
+            },
+            type: "image",
+          },
+        ],
+        answers: {
+          "multiple-choice": [
+            {
+              answer: [{ text: "Dog", type: "text" }],
+              answer_is_correct: true,
+            },
+          ],
+        },
+        feedback: "",
+        hint: "",
+        active: true,
+      },
+    ];
+    const result = convertRawQuizToV2(quizWithAltText);
+    expect(result.questions[0]?.question).toBe(
+      "![A golden retriever sitting in a park](https://example.com/dog.jpg)",
     );
   });
 });

--- a/packages/aila/src/protocol/schemas/quiz/conversion/rawQuizIngest.ts
+++ b/packages/aila/src/protocol/schemas/quiz/conversion/rawQuizIngest.ts
@@ -1,17 +1,22 @@
 import type { QuizV2, QuizV2Question } from "../quizV2";
-import type { ImageItem, ImageOrTextItem, RawQuiz, TextItem } from "../rawQuiz";
+import type {
+  RawQuiz,
+  StemImageObject,
+  StemObject,
+  StemTextObject,
+} from "../rawQuiz";
 
 /**
  * Check if an item is a text item
  */
-function isTextItem(item: ImageOrTextItem): item is TextItem {
+function isTextItem(item: StemObject): item is StemTextObject {
   return item.type === "text";
 }
 
 /**
  * Check if an item is an image item
  */
-function isImageItem(item: ImageOrTextItem): item is ImageItem {
+function isImageItem(item: StemObject): item is StemImageObject {
   return item.type === "image";
 }
 
@@ -20,7 +25,7 @@ function isImageItem(item: ImageOrTextItem): item is ImageItem {
  * Returns both the markdown content and attribution metadata
  */
 function extractMarkdownFromContent(
-  contentItems: Array<TextItem | ImageItem | undefined>,
+  contentItems: Array<StemObject | undefined>,
 ): {
   markdown: string;
   attributions: Array<{ imageUrl: string; attribution: string }>;
@@ -28,12 +33,15 @@ function extractMarkdownFromContent(
   const attributions: Array<{ imageUrl: string; attribution: string }> = [];
 
   const markdownParts = contentItems
-    .filter((item): item is TextItem | ImageItem => item !== undefined)
+    .filter((item): item is StemObject => item !== undefined)
     .map((item) => {
       if (isTextItem(item)) {
         return item.text || "";
       } else if (isImageItem(item)) {
         const imageUrl = item.image_object.secure_url;
+
+        // Extract alt text from context if available
+        const altText = item.image_object.context?.custom?.alt ?? "";
 
         // Extract attribution if available
         if (
@@ -47,8 +55,8 @@ function extractMarkdownFromContent(
           }
         }
 
-        // Return markdown image syntax
-        return `![](${imageUrl})`;
+        // Return markdown image syntax with alt text
+        return `![${altText}](${imageUrl})`;
       }
       return "";
     });
@@ -67,8 +75,13 @@ export function convertRawQuizToV2(rawQuiz: RawQuiz): QuizV2 {
     return {
       version: "v2",
       questions: [],
+      imageAttributions: [],
     };
   }
+
+  // Collect all image attributions from all questions
+  const allImageAttributions: Array<{ imageUrl: string; attribution: string }> =
+    [];
 
   const questions = rawQuiz
     .filter((rawQuestion) => rawQuestion.question_type !== "explanatory-text")
@@ -80,13 +93,17 @@ export function convertRawQuizToV2(rawQuiz: RawQuiz): QuizV2 {
           question: "Invalid question",
           answers: ["N/A"],
           distractors: ["N/A"],
-          imageAttributions: [],
+          hint: null,
         };
       }
 
       // Extract question stem as markdown with inlined images
       const { markdown: questionStem, attributions } =
-        extractMarkdownFromContent(rawQuestion.question_stem);
+        extractMarkdownFromContent(
+          rawQuestion.question_stem as Array<StemObject | undefined>,
+        );
+
+      const hint = rawQuestion.hint ?? null;
 
       // Handle different question types based on Oak's schema
       switch (rawQuestion.question_type) {
@@ -108,18 +125,18 @@ export function convertRawQuizToV2(rawQuiz: RawQuiz): QuizV2 {
           );
 
           // Collect all attributions from question and answers
-          const allAttributions = [
+          allImageAttributions.push(
             ...attributions,
             ...correctAnswerResults.flatMap((result) => result.attributions),
             ...distractorResults.flatMap((result) => result.attributions),
-          ];
+          );
 
           return {
             questionType: "multiple-choice" as const,
             question: questionStem,
             answers: correctAnswers,
             distractors,
-            imageAttributions: allAttributions,
+            hint,
           };
         }
 
@@ -130,16 +147,16 @@ export function convertRawQuizToV2(rawQuiz: RawQuiz): QuizV2 {
           );
           const answers = answerResults.map((result) => result.markdown);
 
-          const allAttributions = [
+          allImageAttributions.push(
             ...attributions,
             ...answerResults.flatMap((result) => result.attributions),
-          ];
+          );
 
           return {
             questionType: "short-answer" as const,
             question: questionStem,
             answers,
-            imageAttributions: allAttributions,
+            hint,
           };
         }
 
@@ -153,7 +170,7 @@ export function convertRawQuizToV2(rawQuiz: RawQuiz): QuizV2 {
               matchItem.correct_choice || [],
             );
 
-            attributions.push(
+            allImageAttributions.push(
               ...leftResult.attributions,
               ...rightResult.attributions,
             );
@@ -164,11 +181,13 @@ export function convertRawQuizToV2(rawQuiz: RawQuiz): QuizV2 {
             };
           });
 
+          allImageAttributions.push(...attributions);
+
           return {
             questionType: "match" as const,
             question: questionStem,
             pairs,
-            imageAttributions: attributions,
+            hint,
           };
         }
 
@@ -179,27 +198,29 @@ export function convertRawQuizToV2(rawQuiz: RawQuiz): QuizV2 {
           );
           const items = itemResults.map((result) => result.markdown);
 
-          const allAttributions = [
+          allImageAttributions.push(
             ...attributions,
             ...itemResults.flatMap((result) => result.attributions),
-          ];
+          );
 
           return {
             questionType: "order" as const,
             question: questionStem,
             items,
-            imageAttributions: allAttributions,
+            hint,
           };
         }
 
         default:
           // Fallback for unknown question types
+          allImageAttributions.push(...attributions);
+
           return {
             questionType: "multiple-choice" as const,
             question: questionStem,
             answers: ["N/A"],
             distractors: ["N/A"],
-            imageAttributions: attributions,
+            hint,
           };
       }
     });
@@ -207,5 +228,6 @@ export function convertRawQuizToV2(rawQuiz: RawQuiz): QuizV2 {
   return {
     version: "v2",
     questions,
+    imageAttributions: allImageAttributions,
   };
 }

--- a/packages/aila/src/protocol/schemas/quiz/conversion/rawQuizIngest.ts
+++ b/packages/aila/src/protocol/schemas/quiz/conversion/rawQuizIngest.ts
@@ -1,135 +1,211 @@
-import type {
-  imageItemSchema,
-  quizQuestionSchema,
-  textItemSchema,
-} from "@oaknational/oak-curriculum-schema";
-import {
-  matchSchema,
-  multipleChoiceSchema,
-  orderSchema,
-  shortAnswerSchema,
-} from "@oaknational/oak-curriculum-schema";
-import { z } from "zod";
+import type { QuizV2, QuizV2Question } from "../quizV2";
+import type { ImageItem, ImageOrTextItem, RawQuiz, TextItem } from "../rawQuiz";
 
-type SnakeToCamelCase<S extends string> =
-  S extends `${infer T}_${infer U}${infer Rest}`
-    ? `${T}${Uppercase<U>}${SnakeToCamelCase<Rest>}`
-    : S;
-export type ConvertKeysToCamelCase<T> =
-  T extends Array<infer U>
-    ? Array<ConvertKeysToCamelCase<U>>
-    : T extends object
-      ? {
-          [K in keyof T as SnakeToCamelCase<
-            K & string
-          >]: ConvertKeysToCamelCase<T[K]>;
-        }
-      : T;
-export function convertKey(key: string): string {
-  return key.replace(/(_\w)/g, (_, [, m]) => (m as string)?.toUpperCase());
+/**
+ * Check if an item is a text item
+ */
+function isTextItem(item: ImageOrTextItem): item is TextItem {
+  return item.type === "text";
 }
-export type QuizQuestion = ConvertKeysToCamelCase<
-  z.infer<typeof quizQuestionSchema>
->;
 
-export type QuizQuestionAnswers = NonNullable<
-  ConvertKeysToCamelCase<z.infer<typeof quizQuestionSchema>["answers"]>
->;
+/**
+ * Check if an item is an image item
+ */
+function isImageItem(item: ImageOrTextItem): item is ImageItem {
+  return item.type === "image";
+}
 
-export type MCAnswer = ConvertKeysToCamelCase<
-  z.infer<typeof multipleChoiceSchema>
->;
-export type ShortAnswer = ConvertKeysToCamelCase<
-  z.infer<typeof shortAnswerSchema>
->;
-export type OrderAnswer = ConvertKeysToCamelCase<z.infer<typeof orderSchema>>;
-export type MatchAnswer = ConvertKeysToCamelCase<z.infer<typeof matchSchema>>;
+/**
+ * Extract markdown content from Oak's content items array, inlining images
+ * Returns both the markdown content and attribution metadata
+ */
+function extractMarkdownFromContent(
+  contentItems: Array<TextItem | ImageItem | undefined>,
+): {
+  markdown: string;
+  attributions: Array<{ imageUrl: string; attribution: string }>;
+} {
+  const attributions: Array<{ imageUrl: string; attribution: string }> = [];
 
-export type ImageItem = ConvertKeysToCamelCase<z.infer<typeof imageItemSchema>>;
-export type TextItem = ConvertKeysToCamelCase<z.infer<typeof textItemSchema>>;
-export type ImageOrTextItem = ImageItem | TextItem;
+  const markdownParts = contentItems
+    .filter((item): item is TextItem | ImageItem => item !== undefined)
+    .map((item) => {
+      if (isTextItem(item)) {
+        return item.text || "";
+      } else if (isImageItem(item)) {
+        const imageUrl = item.image_object.secure_url;
 
-const stemTextObjectSchema = z.object({
-  text: z.string(),
-  type: z.literal("text"),
-});
+        // Extract attribution if available
+        if (
+          item.image_object.metadata &&
+          typeof item.image_object.metadata === "object" &&
+          !Array.isArray(item.image_object.metadata)
+        ) {
+          const attribution = item.image_object.metadata.attribution;
+          if (attribution) {
+            attributions.push({ imageUrl, attribution });
+          }
+        }
 
-export type StemTextObject = z.infer<typeof stemTextObjectSchema>;
+        // Return markdown image syntax
+        return `![](${imageUrl})`;
+      }
+      return "";
+    });
 
-const stemImageObjectSchema = z.object({
-  imageObject: z.object({
-    format: z.enum(["png", "jpg", "jpeg", "webp", "gif", "svg"]).optional(),
-    secureUrl: z.string().url(),
-    url: z.string().url().optional(),
-    height: z.number().optional(),
-    width: z.number().optional(),
-    metadata: z.union([
-      z.array(z.any()),
-      z.object({
-        attribution: z.string().optional(),
-        usageRestriction: z.string().optional(),
-      }),
-    ]),
-    publicId: z.string().optional(),
-    version: z.number().optional(),
-  }),
-  type: z.literal("image"),
-});
+  return {
+    markdown: markdownParts.join(" ").trim(),
+    attributions,
+  };
+}
 
-export type StemImageObject = z.infer<typeof stemImageObjectSchema>;
-
-export type StemObject = StemTextObject | StemImageObject;
-
-const answersSchema = z.object({
-  "multiple-choice": z.array(multipleChoiceSchema).nullable().optional(),
-  match: z.array(matchSchema).nullable().optional(),
-  order: z.array(orderSchema).nullable().optional(),
-  "short-answer": z.array(shortAnswerSchema).nullable().optional(),
-  "explanatory-text": z.null().optional(),
-});
-
-export const rawQuizQuestionSchema = z.object({
-  questionId: z.number(),
-  questionUid: z.string(),
-  questionType: z.enum([
-    "multiple-choice",
-    "match",
-    "order",
-    "short-answer",
-    "explanatory-text",
-  ]),
-  questionStem: z
-    .array(z.union([stemTextObjectSchema, stemImageObjectSchema]))
-    .min(1),
-  answers: answersSchema.nullable().optional(),
-  feedback: z.string(),
-  hint: z.string(),
-  active: z.boolean(),
-});
-
-export const rawQuizSchema = z
-  .array(rawQuizQuestionSchema)
-  .nullable()
-  .optional();
-
-export type RawQuiz = ConvertKeysToCamelCase<z.infer<typeof rawQuizSchema>>;
-export type QuizProps = {
-  questions: NonNullable<RawQuiz>;
-  imageAttribution: { attribution: string; questionNumber: string }[];
-  isMathJaxLesson: boolean;
-};
-
-export function keysToCamelCase<T>(obj: T): ConvertKeysToCamelCase<T> {
-  if (Array.isArray(obj)) {
-    return obj.map((item) =>
-      keysToCamelCase(item as unknown[]),
-    ) as ConvertKeysToCamelCase<T>;
-  } else if (obj && typeof obj === "object") {
-    return Object.entries(obj).reduce((acc, [key, value]) => {
-      const newKey = convertKey(key);
-      acc[newKey as keyof typeof acc] = keysToCamelCase(value);
-      return acc;
-    }, {} as ConvertKeysToCamelCase<T>);
+/**
+ * Convert raw quiz from Oak curriculum format to Quiz V2 format
+ */
+export function convertRawQuizToV2(rawQuiz: RawQuiz): QuizV2 {
+  if (!rawQuiz || !Array.isArray(rawQuiz)) {
+    return {
+      version: "v2",
+      questions: [],
+    };
   }
-  return obj as ConvertKeysToCamelCase<T>;
+
+  const questions = rawQuiz
+    .filter((rawQuestion) => rawQuestion.question_type !== "explanatory-text")
+    .map((rawQuestion): QuizV2Question => {
+      if (!rawQuestion) {
+        // Fallback for invalid questions
+        return {
+          questionType: "multiple-choice" as const,
+          question: "Invalid question",
+          answers: ["N/A"],
+          distractors: ["N/A"],
+          imageAttributions: [],
+        };
+      }
+
+      // Extract question stem as markdown with inlined images
+      const { markdown: questionStem, attributions } =
+        extractMarkdownFromContent(rawQuestion.question_stem);
+
+      // Handle different question types based on Oak's schema
+      switch (rawQuestion.question_type) {
+        case "multiple-choice": {
+          const mcAnswers = rawQuestion.answers?.["multiple-choice"] ?? [];
+
+          const correctAnswerResults = mcAnswers
+            .filter((answer) => answer.answer_is_correct)
+            .map((answer) => extractMarkdownFromContent(answer.answer || []));
+          const correctAnswers = correctAnswerResults.map(
+            (result) => result.markdown,
+          );
+
+          const distractorResults = mcAnswers
+            .filter((answer) => !answer.answer_is_correct)
+            .map((answer) => extractMarkdownFromContent(answer.answer || []));
+          const distractors = distractorResults.map(
+            (result) => result.markdown,
+          );
+
+          // Collect all attributions from question and answers
+          const allAttributions = [
+            ...attributions,
+            ...correctAnswerResults.flatMap((result) => result.attributions),
+            ...distractorResults.flatMap((result) => result.attributions),
+          ];
+
+          return {
+            questionType: "multiple-choice" as const,
+            question: questionStem,
+            answers: correctAnswers,
+            distractors,
+            imageAttributions: allAttributions,
+          };
+        }
+
+        case "short-answer": {
+          const saAnswers = rawQuestion.answers?.["short-answer"] ?? [];
+          const answerResults = saAnswers.map((answer) =>
+            extractMarkdownFromContent(answer.answer || []),
+          );
+          const answers = answerResults.map((result) => result.markdown);
+
+          const allAttributions = [
+            ...attributions,
+            ...answerResults.flatMap((result) => result.attributions),
+          ];
+
+          return {
+            questionType: "short-answer" as const,
+            question: questionStem,
+            answers,
+            imageAttributions: allAttributions,
+          };
+        }
+
+        case "match": {
+          const matchAnswers = rawQuestion.answers?.match ?? [];
+          const pairs = matchAnswers.map((matchItem) => {
+            const leftResult = extractMarkdownFromContent(
+              matchItem.match_option ?? [],
+            );
+            const rightResult = extractMarkdownFromContent(
+              matchItem.correct_choice || [],
+            );
+
+            attributions.push(
+              ...leftResult.attributions,
+              ...rightResult.attributions,
+            );
+
+            return {
+              left: leftResult.markdown,
+              right: rightResult.markdown,
+            };
+          });
+
+          return {
+            questionType: "match" as const,
+            question: questionStem,
+            pairs,
+            imageAttributions: attributions,
+          };
+        }
+
+        case "order": {
+          const orderAnswers = rawQuestion.answers?.order ?? [];
+          const itemResults = orderAnswers.map((orderItem) =>
+            extractMarkdownFromContent(orderItem.answer || []),
+          );
+          const items = itemResults.map((result) => result.markdown);
+
+          const allAttributions = [
+            ...attributions,
+            ...itemResults.flatMap((result) => result.attributions),
+          ];
+
+          return {
+            questionType: "order" as const,
+            question: questionStem,
+            items,
+            imageAttributions: allAttributions,
+          };
+        }
+
+        default:
+          // Fallback for unknown question types
+          return {
+            questionType: "multiple-choice" as const,
+            question: questionStem,
+            answers: ["N/A"],
+            distractors: ["N/A"],
+            imageAttributions: attributions,
+          };
+      }
+    });
+
+  return {
+    version: "v2",
+    questions,
+  };
 }

--- a/packages/aila/src/protocol/schemas/quiz/fixtures/rawQuizFixture.ts
+++ b/packages/aila/src/protocol/schemas/quiz/fixtures/rawQuizFixture.ts
@@ -72,6 +72,11 @@ export const rawQuizFixture: RawQuiz = [
             attribution: "Photo by John Doe on Unsplash",
             usageRestriction: "Free to use",
           },
+          context: {
+            custom: {
+              alt: "A friendly golden retriever sitting in a park",
+            },
+          },
         },
         type: "image",
       },

--- a/packages/aila/src/protocol/schemas/quiz/fixtures/rawQuizFixture.ts
+++ b/packages/aila/src/protocol/schemas/quiz/fixtures/rawQuizFixture.ts
@@ -1,0 +1,173 @@
+import type { RawQuiz } from "../rawQuiz";
+
+export const rawQuizFixture: RawQuiz = [
+  {
+    question_id: 1,
+    question_uid: "test-uid-1",
+    question_type: "multiple-choice",
+    question_stem: [
+      {
+        text: "What is the capital of France?",
+        type: "text",
+      },
+    ],
+    answers: {
+      "multiple-choice": [
+        {
+          answer: [{ text: "Paris", type: "text" }],
+          answer_is_correct: true,
+        },
+        {
+          answer: [{ text: "London", type: "text" }],
+          answer_is_correct: false,
+        },
+        {
+          answer: [{ text: "Berlin", type: "text" }],
+          answer_is_correct: false,
+        },
+      ],
+    },
+    feedback: "Paris is the capital of France",
+    hint: "Think about the Eiffel Tower",
+    active: true,
+  },
+  {
+    question_id: 2,
+    question_uid: "test-uid-2",
+    question_type: "short-answer",
+    question_stem: [
+      {
+        text: "Name a primary color",
+        type: "text",
+      },
+    ],
+    answers: {
+      "short-answer": [
+        { answer: [{ text: "red", type: "text" }], answer_is_default: true },
+        { answer: [{ text: "blue", type: "text" }], answer_is_default: false },
+        {
+          answer: [{ text: "yellow", type: "text" }],
+          answer_is_default: false,
+        },
+      ],
+    },
+    feedback: "Primary colors are red, blue, and yellow",
+    hint: "These colors cannot be created by mixing other colors",
+    active: true,
+  },
+  {
+    question_id: 3,
+    question_uid: "test-uid-3",
+    question_type: "multiple-choice",
+    question_stem: [
+      {
+        text: "Which animal is shown in the image?",
+        type: "text",
+      },
+      {
+        image_object: {
+          secure_url: "https://example.com/dog.jpg",
+          url: "https://example.com/dog.jpg",
+          metadata: {
+            attribution: "Photo by John Doe on Unsplash",
+            usageRestriction: "Free to use",
+          },
+        },
+        type: "image",
+      },
+    ],
+    answers: {
+      "multiple-choice": [
+        {
+          answer: [{ text: "Dog", type: "text" }],
+          answer_is_correct: true,
+        },
+        {
+          answer: [
+            {
+              text: "Cat",
+              type: "text",
+            },
+            {
+              image_object: {
+                secure_url: "https://example.com/cat.jpg",
+                metadata: {
+                  attribution: "Image © Example Inc",
+                },
+              },
+              type: "image",
+            },
+          ],
+          answer_is_correct: false,
+        },
+      ],
+    },
+    feedback: "This is a dog",
+    hint: "It barks",
+    active: true,
+  },
+  {
+    question_id: 4,
+    question_uid: "test-uid-4",
+    question_type: "match",
+    question_stem: [
+      {
+        text: "Match the countries to their capitals",
+        type: "text",
+      },
+    ],
+    answers: {
+      match: [
+        {
+          match_option: [{ text: "France", type: "text" }],
+          correct_choice: [{ text: "Paris", type: "text" }],
+        },
+        {
+          match_option: [{ text: "Germany", type: "text" }],
+          correct_choice: [{ text: "Berlin", type: "text" }],
+        },
+      ],
+    },
+    feedback: "Well done!",
+    hint: "Think about European geography",
+    active: true,
+  },
+  {
+    question_id: 5,
+    question_uid: "test-uid-5",
+    question_type: "order",
+    question_stem: [
+      {
+        text: "Put these numbers in ascending order",
+        type: "text",
+      },
+    ],
+    answers: {
+      order: [
+        { answer: [{ text: "1", type: "text" }], correct_order: 1 },
+        { answer: [{ text: "3", type: "text" }], correct_order: 2 },
+        { answer: [{ text: "5", type: "text" }], correct_order: 3 },
+      ],
+    },
+    feedback: "Correct order!",
+    hint: "Start with the smallest",
+    active: true,
+  },
+  {
+    question_id: 6,
+    question_uid: "test-uid-6",
+    question_type: "explanatory-text",
+    question_stem: [
+      {
+        text: "This is just explanatory text",
+        type: "text",
+      },
+    ],
+    answers: {
+      "explanatory-text": null,
+    },
+    feedback: "",
+    hint: "",
+    active: true,
+  },
+];

--- a/packages/aila/src/protocol/schemas/quiz/rawQuiz.ts
+++ b/packages/aila/src/protocol/schemas/quiz/rawQuiz.ts
@@ -48,6 +48,15 @@ const stemImageObjectSchema = z.object({
         usageRestriction: z.string().optional(),
       }),
     ]),
+    context: z
+      .object({
+        custom: z
+          .object({
+            alt: z.string().optional(),
+          })
+          .optional(),
+      })
+      .optional(),
     public_id: z.string().optional(),
     version: z.number().optional(),
   }),


### PR DESCRIPTION
## Summary
- Add `convertRawQuizToV2` function to convert Oak's raw quiz format to Quiz V2 structure
- Extract markdown content from complex stem arrays with text and image items
- Preserve image attribution metadata throughout conversion
- **NEW**: Support alt text extraction from images when available
- **NEW**: Extract hints from raw quiz questions

## Implementation Details
- Works directly with snake_case data from Oak curriculum (no camelCase conversion needed)
- Converts images to markdown syntax with alt text: `\![alt text](secure_url)`
- Extracts attribution from `image_object.metadata.attribution`
- Extracts hints from `rawQuestion.hint` field
- Supports all quiz types: multiple-choice, short-answer, match, order
- Returns clean V2 structure with markdown strings and image attributions at quiz level

## Example
**Input (Oak raw format):**
```typescript
{
  question_stem: [
    { text: "What is", type: "text" },
    { 
      image_object: { 
        secure_url: "https://...",
        metadata: { attribution: "© Oak National" },
        context: { custom: { alt: "A golden retriever" } }
      },
      type: "image" 
    }
  ],
  hint: "Think about man's best friend"
}
```

**Output (V2 format):**
```typescript
{
  version: "v2",
  questions: [{
    question: "What is \![A golden retriever](https://...)",
    hint: "Think about man's best friend",
    // ... other fields
  }],
  imageAttributions: [
    { imageUrl: "https://...", attribution: "© Oak National" }
  ]
}
```

## Changes in this PR
1. Added alt text support for images using `context?.custom?.alt`
2. Extract hints from raw quiz questions using nullish coalescing
3. Moved `imageAttributions` to quiz level (not question level) per V2 schema
4. Updated TypeScript types to use `StemObject` types for proper context access
5. Added comprehensive tests for all functionality

## Notes
- The test_quiz_page continues to use camelCase types as requested
- This conversion function is ready for future migration to V2 format