### PR TITLE
fix: remove handwriting wobble effect from quiz answer boxes

### DIFF
--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/AnswerBox.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/AnswerBox.tsx
@@ -9,27 +9,9 @@ type AnswerBoxProps = {
    * Use <AnswerBox.Check /> for correct answers.
    */
   children?: ReactNode;
-  wobbleOffset?: number;
 };
 
-// Generate transform for handwritten feel based on variant
-const getWobbleTransform = (variant: number | undefined) => {
-  if (variant === undefined) {
-    return undefined;
-  }
-
-  const rotations = [-1.5, 1.5, -1.5, 2.5, 0, -3, 1];
-  const xOffsets = [0.25, -0.25, 0, 0.25, -0.25, 0, 0.25];
-  const yOffsets = [-0.25, 0, 0.25, -0.25, 0.25, 0, -0.25];
-
-  const rotation = rotations[variant % rotations.length];
-  const xOffset = xOffsets[variant % xOffsets.length];
-  const yOffset = yOffsets[variant % yOffsets.length];
-
-  return `rotate(${rotation}deg) translate(${xOffset}px, ${yOffset}px)`;
-};
-
-const AnswerBoxBase = ({ children, wobbleOffset }: AnswerBoxProps) => {
+const AnswerBoxBase = ({ children }: AnswerBoxProps) => {
   return (
     <OakFlex
       $mr="space-between-xs"
@@ -47,7 +29,6 @@ const AnswerBoxBase = ({ children, wobbleOffset }: AnswerBoxProps) => {
     >
       <span
         style={{
-          transform: getWobbleTransform(wobbleOffset),
           display: "block",
           width: "100%",
           height: "100%",

--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/MatchQuestion.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/MatchQuestion.tsx
@@ -88,7 +88,7 @@ export const MatchQuestion = ({
               role="listitem"
               aria-label={`Matches with ${item.label}: ${item.text}`}
             >
-              <AnswerBox wobbleOffset={index}>{item.label}</AnswerBox>
+              <AnswerBox>{item.label}</AnswerBox>
               <OakBox>
                 <MemoizedReactMarkdownWithStyles
                   markdown={item.text}

--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/MultipleChoiceQuestion.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/MultipleChoiceQuestion.tsx
@@ -55,9 +55,7 @@ export const MultipleChoiceQuestion = ({
                 answer.isCorrect ? ", correct answer" : ""
               }`}
             >
-              <AnswerBox wobbleOffset={index}>
-                {answer.isCorrect && <AnswerBox.Check />}
-              </AnswerBox>
+              <AnswerBox>{answer.isCorrect && <AnswerBox.Check />}</AnswerBox>
               <OakBox
                 $font={answer.isCorrect ? "body-2-bold" : "body-2"}
                 className="pt-[2px]"

--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/OrderQuestion.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/OrderQuestion.tsx
@@ -53,7 +53,7 @@ export const OrderQuestion = ({
             role="listitem"
             aria-label={`Item in position ${item.correctIndex}: ${item.text}`}
           >
-            <AnswerBox wobbleOffset={index}>{item.correctIndex}</AnswerBox>
+            <AnswerBox>{item.correctIndex}</AnswerBox>
             <OakBox $font="body-2">
               <MemoizedReactMarkdownWithStyles
                 markdown={item.text}


### PR DESCRIPTION
## Summary
- Removed the handwriting wobble effect from quiz answer boxes for a cleaner, more professional appearance
- The wobble effect was created using CSS transforms with slight rotations and translations

## Changes
- Removed `getWobbleTransform` function from AnswerBox component
- Removed `wobbleOffset` prop from AnswerBoxProps interface
- Removed transform styling from answer boxes
- Updated all quiz question components to stop passing the wobbleOffset prop:
  - MultipleChoiceQuestion
  - MatchQuestion
  - OrderQuestion

## Test plan
- [x] TypeScript checks pass
- [x] Prettier formatting checks pass
- [x] Lint checks pass (no new errors)
- [ ] Visual inspection of quiz answer boxes to confirm they appear straight and aligned
- [ ] Test all three quiz question types to ensure functionality remains intact