### PR TITLE
fix: rag lesson schema - cycle3 optional and all without length

### DIFF
--- a/packages/additional-materials/src/documents/additionalMaterials/promptHelpers.ts
+++ b/packages/additional-materials/src/documents/additionalMaterials/promptHelpers.ts
@@ -5,7 +5,10 @@ export const getLessonTranscript = (transcript: string) => {
   return transcript;
 };
 
-const renderCycle = (cycle: LooseLessonPlan["cycle1"], label: string) => {
+const renderCycle = (
+  cycle: LooseLessonPlan["cycle1"] | null,
+  label: string,
+) => {
   if (!cycle) return "";
 
   const {

--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -371,7 +371,7 @@ export const CompletedLessonPlanSchema = z.object({
   starterQuiz: QuizV2Schema.describe(LESSON_PLAN_DESCRIPTIONS.starterQuiz),
   cycle1: CycleSchema.describe("The first learning cycle"),
   cycle2: CycleSchema.describe("The second learning cycle"),
-  cycle3: CycleSchema.describe("The third learning cycle"),
+  cycle3: CycleSchema.nullable().describe("The third learning cycle"),
   exitQuiz: QuizV2Schema.describe(LESSON_PLAN_DESCRIPTIONS.exitQuiz),
   additionalMaterials: AdditionalMaterialsSchema.nullable(),
 });
@@ -521,7 +521,9 @@ export const CompletedLessonPlanSchemaWithoutLength = z.object({
   ),
   cycle1: CycleSchemaWithoutLength.describe("The first learning cycle"),
   cycle2: CycleSchemaWithoutLength.describe("The second learning cycle"),
-  cycle3: CycleSchemaWithoutLength.describe("The third learning cycle"),
+  cycle3: CycleSchemaWithoutLength.nullable().describe(
+    "The third learning cycle",
+  ),
   exitQuiz: QuizV2SchemaWithoutLength.describe(
     LESSON_PLAN_DESCRIPTIONS.exitQuiz,
   ),

--- a/packages/rag/lib/search/parseResult.ts
+++ b/packages/rag/lib/search/parseResult.ts
@@ -1,13 +1,13 @@
 import { z } from "zod";
 
-import { CompletedLessonPlanSchema } from "../../../aila/src/protocol/schema";
+import { CompletedLessonPlanSchemaWithoutLength } from "../../../aila/src/protocol/schema";
 import type { DeepPartial, RagLessonPlanResult } from "../../types";
 
 const databaseResponseSchema = z.object({
   ragLessonPlanId: z.string(),
   oakLessonId: z.number().nullable(),
   oakLessonSlug: z.string(),
-  lessonPlan: CompletedLessonPlanSchema,
+  lessonPlan: CompletedLessonPlanSchemaWithoutLength,
   matchedKey: z.string(),
   matchedValue: z.string(),
   distance: z.number(),


### PR DESCRIPTION
## Description

- Ingested lesson plans will now have cycle3 as optional and broadly speaking won't have length constraints
- This PR updates the RAG search function to reflect that
- It also generally makes Cycle 3 nullable, which I actually thought it should have been already (we have Slides templates for lessons with 1 or 2 cycles) 

_**Note:** it's this last point that is the most substantial change (potential to affect application beyond the maths/agentic capability)_ 

## Issue(s)

https://www.notion.so/oaknationalacademy/Fix-new-RAG-zod-schema-24126cc4e1b180738046ed321a0dbbc9?source=copy_link

