### PR TITLE
feat: implement LaTeX image dimensions and URL handling

### DIFF
--- a/packages/exports/src/dataHelpers/prepQuizForDocs.ts
+++ b/packages/exports/src/dataHelpers/prepQuizForDocs.ts
@@ -1,11 +1,12 @@
 import type { Quiz } from "../schema/input.schema";
 import { filterToMcQuestions, processQuizAnswers } from "../utils";
+import { latexToImageReplacements } from "../gSuite/docs/latexToImageReplacements";
 
-function processQuizAnswersForQuiz(
+async function processQuizAnswersForQuiz(
   answers: string[] | undefined,
   distractors: string[] | undefined,
 ) {
-  return processQuizAnswers(
+  const processedAnswers = processQuizAnswers(
     {
       sortAlpha: true,
       includeTicks: false,
@@ -14,9 +15,24 @@ function processQuizAnswersForQuiz(
     answers,
     distractors,
   );
+  
+  // Process each answer for LaTeX replacements
+  const latexProcessedAnswers = await Promise.all(
+    processedAnswers.map(async (answer) => {
+      if (!answer) return answer;
+      const { modifiedText } = await latexToImageReplacements(answer);
+      return modifiedText;
+    })
+  );
+  
+  return latexProcessedAnswers;
 }
-function processQuizQuestionText(question: string | undefined, index: number) {
-  return question ? `${index + 1}. ${question}` : " ";
+async function processQuizQuestionText(question: string | undefined, index: number) {
+  if (!question) return " ";
+  
+  const numberedQuestion = `${index + 1}. ${question}`;
+  const { modifiedText } = await latexToImageReplacements(numberedQuestion);
+  return modifiedText;
 }
 
 export async function prepQuizForDocs({
@@ -35,101 +51,55 @@ export async function prepQuizForDocs({
   // Other question types (short-answer, match, order) are ignored
   const mcQuestions = filterToMcQuestions(quiz.questions);
 
-  return Promise.resolve({
+  // Process all questions and answers in parallel for efficiency
+  const [
+    q1, q1_answers,
+    q2, q2_answers,
+    q3, q3_answers,
+    q4, q4_answers,
+    q5, q5_answers,
+    q6, q6_answers,
+  ] = await Promise.all([
+    processQuizQuestionText(mcQuestions[0]?.question, 0),
+    processQuizAnswersForQuiz(mcQuestions[0]?.answers, mcQuestions[0]?.distractors),
+    processQuizQuestionText(mcQuestions[1]?.question, 1),
+    processQuizAnswersForQuiz(mcQuestions[1]?.answers, mcQuestions[1]?.distractors),
+    processQuizQuestionText(mcQuestions[2]?.question, 2),
+    processQuizAnswersForQuiz(mcQuestions[2]?.answers, mcQuestions[2]?.distractors),
+    processQuizQuestionText(mcQuestions[3]?.question, 3),
+    processQuizAnswersForQuiz(mcQuestions[3]?.answers, mcQuestions[3]?.distractors),
+    processQuizQuestionText(mcQuestions[4]?.question, 4),
+    processQuizAnswersForQuiz(mcQuestions[4]?.answers, mcQuestions[4]?.distractors),
+    processQuizQuestionText(mcQuestions[5]?.question, 5),
+    processQuizAnswersForQuiz(mcQuestions[5]?.answers, mcQuestions[5]?.distractors),
+  ]);
+
+  return {
     lesson_title: title,
     quiz_type: quizTypeText,
-    question_1: processQuizQuestionText(mcQuestions[0]?.question, 0),
-    question_1_answer_a: processQuizAnswersForQuiz(
-      mcQuestions[0]?.answers,
-      mcQuestions[0]?.distractors,
-    )[0],
-    question_1_answer_b: processQuizAnswersForQuiz(
-      mcQuestions[0]?.answers,
-      mcQuestions[0]?.distractors,
-    )[1],
-    question_1_answer_c: processQuizAnswersForQuiz(
-      mcQuestions[0]?.answers,
-      mcQuestions[0]?.distractors,
-    )[2],
-    question_2: processQuizQuestionText(mcQuestions[1]?.question, 1),
-    question_2_answer_a:
-      processQuizAnswersForQuiz(
-        mcQuestions[1]?.answers,
-        mcQuestions[1]?.distractors,
-      )[0] ?? " ",
-    question_2_answer_b:
-      processQuizAnswersForQuiz(
-        mcQuestions[1]?.answers,
-        mcQuestions[1]?.distractors,
-      )[1] ?? " ",
-    question_2_answer_c:
-      processQuizAnswersForQuiz(
-        mcQuestions[1]?.answers,
-        mcQuestions[1]?.distractors,
-      )[2] ?? " ",
-    question_3: processQuizQuestionText(mcQuestions[2]?.question, 2),
-    question_3_answer_a:
-      processQuizAnswersForQuiz(
-        mcQuestions[2]?.answers,
-        mcQuestions[2]?.distractors,
-      )[0] ?? " ",
-    question_3_answer_b:
-      processQuizAnswersForQuiz(
-        mcQuestions[2]?.answers,
-        mcQuestions[2]?.distractors,
-      )[1] ?? " ",
-    question_3_answer_c:
-      processQuizAnswersForQuiz(
-        mcQuestions[2]?.answers,
-        mcQuestions[2]?.distractors,
-      )[2] ?? " ",
-    question_4: processQuizQuestionText(mcQuestions[3]?.question, 3),
-    question_4_answer_a:
-      processQuizAnswersForQuiz(
-        mcQuestions[3]?.answers,
-        mcQuestions[3]?.distractors,
-      )[0] ?? " ",
-    question_4_answer_b:
-      processQuizAnswersForQuiz(
-        mcQuestions[3]?.answers,
-        mcQuestions[3]?.distractors,
-      )[1] ?? " ",
-    question_4_answer_c:
-      processQuizAnswersForQuiz(
-        mcQuestions[3]?.answers,
-        mcQuestions[3]?.distractors,
-      )[2] ?? " ",
-    question_5: processQuizQuestionText(mcQuestions[4]?.question, 4),
-    question_5_answer_a:
-      processQuizAnswersForQuiz(
-        mcQuestions[4]?.answers,
-        mcQuestions[4]?.distractors,
-      )[0] ?? " ",
-    question_5_answer_b:
-      processQuizAnswersForQuiz(
-        mcQuestions[4]?.answers,
-        mcQuestions[4]?.distractors,
-      )[1] ?? " ",
-    question_5_answer_c:
-      processQuizAnswersForQuiz(
-        mcQuestions[4]?.answers,
-        mcQuestions[4]?.distractors,
-      )[2] ?? " ",
-    question_6: processQuizQuestionText(mcQuestions[5]?.question, 5),
-    question_6_answer_a:
-      processQuizAnswersForQuiz(
-        mcQuestions[5]?.answers,
-        mcQuestions[5]?.distractors,
-      )[0] ?? " ",
-    question_6_answer_b:
-      processQuizAnswersForQuiz(
-        mcQuestions[5]?.answers,
-        mcQuestions[5]?.distractors,
-      )[1] ?? " ",
-    question_6_answer_c:
-      processQuizAnswersForQuiz(
-        mcQuestions[5]?.answers,
-        mcQuestions[5]?.distractors,
-      )[2] ?? " ",
-  });
+    question_1: q1,
+    question_1_answer_a: q1_answers[0] ?? " ",
+    question_1_answer_b: q1_answers[1] ?? " ",
+    question_1_answer_c: q1_answers[2] ?? " ",
+    question_2: q2,
+    question_2_answer_a: q2_answers[0] ?? " ",
+    question_2_answer_b: q2_answers[1] ?? " ",
+    question_2_answer_c: q2_answers[2] ?? " ",
+    question_3: q3,
+    question_3_answer_a: q3_answers[0] ?? " ",
+    question_3_answer_b: q3_answers[1] ?? " ",
+    question_3_answer_c: q3_answers[2] ?? " ",
+    question_4: q4,
+    question_4_answer_a: q4_answers[0] ?? " ",
+    question_4_answer_b: q4_answers[1] ?? " ",
+    question_4_answer_c: q4_answers[2] ?? " ",
+    question_5: q5,
+    question_5_answer_a: q5_answers[0] ?? " ",
+    question_5_answer_b: q5_answers[1] ?? " ",
+    question_5_answer_c: q5_answers[2] ?? " ",
+    question_6: q6,
+    question_6_answer_a: q6_answers[0] ?? " ",
+    question_6_answer_b: q6_answers[1] ?? " ",
+    question_6_answer_c: q6_answers[2] ?? " ",
+  };
 }

--- a/packages/exports/src/gSuite/docs/imageReplacements.ts
+++ b/packages/exports/src/gSuite/docs/imageReplacements.ts
@@ -36,6 +36,20 @@ export function imageReplacements(
       },
     });
 
+    function getDimensions(imageUrl: string) {
+      //1px =  0.75pt
+      const scale = 2;
+      // Extract dimensions from URLs like "latex/abc123-100x100.png"
+      const dimensions = imageUrl.match(/-(\d+)x(\d+)\.png$/);
+      if (dimensions?.[1] && dimensions?.[2]) {
+        const width = parseInt(dimensions[1], 10) / scale;
+        const height = parseInt(dimensions[2], 10) / scale;
+        return { width, height };
+      }
+      return { width: 150, height: 150 };
+    }
+    const dimensions = getDimensions(image.url);
+
     // Request to insert the inline image at the adjusted startIndex
     requests.push({
       insertInlineImage: {
@@ -45,11 +59,11 @@ export function imageReplacements(
         },
         objectSize: {
           height: {
-            magnitude: 150,
+            magnitude: dimensions.height,
             unit: "PT",
           },
           width: {
-            magnitude: 150,
+            magnitude: dimensions.width,
             unit: "PT",
           },
         },

--- a/packages/exports/src/gSuite/docs/latexToImageReplacements.ts
+++ b/packages/exports/src/gSuite/docs/latexToImageReplacements.ts
@@ -34,10 +34,8 @@ export async function latexToImageReplacements(
 
   // First pass: Prepare all images for upload
   const imagePromises = patterns.map(async (pattern) => {
-    const filename = generateLatexImageFilename(pattern.hash);
-
     // Check if image already exists
-    const existingUrl = await getExistingImageUrl(filename);
+    const existingUrl = await getExistingImageUrl(pattern.hash);
     if (existingUrl) {
       log.info(
         `Using existing LaTeX image: ${pattern.latex.substring(0, 30)}...`,
@@ -47,8 +45,13 @@ export async function latexToImageReplacements(
 
     // Generate and upload new image
     const svg = latexToSvg(pattern.latex, pattern.type === "display");
-    const pngBuffer = svgToPng(svg);
-    const url = await uploadImageToGCS(pngBuffer, filename);
+    const pngResult = svgToPng(svg);
+    const url = await uploadImageToGCS(
+      pngResult.buffer,
+      pattern.hash,
+      pngResult.width,
+      pngResult.height,
+    );
     log.info(`Uploaded new LaTeX image: ${pattern.latex.substring(0, 30)}...`);
     return url;
   });

--- a/packages/exports/src/images/fixtures/generateFixtures.ts
+++ b/packages/exports/src/images/fixtures/generateFixtures.ts
@@ -27,8 +27,8 @@ fixtures.forEach(({ name, latex, display }) => {
     console.log(`✅ Generated ${name}.svg`);
 
     // Generate PNG
-    const pngBuffer = svgToPng(svg, { width: 600 });
-    writeFileSync(join(fixturesDir, `${name}.png`), pngBuffer);
+    const pngResult = svgToPng(svg);
+    writeFileSync(join(fixturesDir, `${name}.png`), pngResult.buffer);
     console.log(`✅ Generated ${name}.png`);
   } catch (error) {
     console.error(`❌ Failed to generate ${name}:`, error);

--- a/packages/exports/src/images/svgToPng.test.ts
+++ b/packages/exports/src/images/svgToPng.test.ts
@@ -52,10 +52,10 @@ describe("svgToPng", () => {
     );
     const expectedPng = readFileSync("src/images/fixtures/simple-equation.png");
 
-    const result = svgToPng(svg, { width: 600 });
+    const result = svgToPng(svg);
 
-    expect(result).toBeInstanceOf(Buffer);
-    comparePngWithFixture(result, expectedPng, "simple-equation");
+    expect(result.buffer).toBeInstanceOf(Buffer);
+    comparePngWithFixture(result.buffer, expectedPng, "simple-equation");
   });
 
   it("converts quadratic formula SVG to PNG", () => {
@@ -67,10 +67,10 @@ describe("svgToPng", () => {
       "src/images/fixtures/quadratic-formula.png",
     );
 
-    const result = svgToPng(svg, { width: 600 });
+    const result = svgToPng(svg);
 
-    expect(result).toBeInstanceOf(Buffer);
-    comparePngWithFixture(result, expectedPng, "quadratic-formula");
+    expect(result.buffer).toBeInstanceOf(Buffer);
+    comparePngWithFixture(result.buffer, expectedPng, "quadratic-formula");
   });
 
   it("converts display mode fraction SVG to PNG", () => {
@@ -82,22 +82,10 @@ describe("svgToPng", () => {
       "src/images/fixtures/fraction-display.png",
     );
 
-    const result = svgToPng(svg, { width: 600 });
+    const result = svgToPng(svg);
 
-    expect(result).toBeInstanceOf(Buffer);
-    comparePngWithFixture(result, expectedPng, "fraction-display");
+    expect(result.buffer).toBeInstanceOf(Buffer);
+    comparePngWithFixture(result.buffer, expectedPng, "fraction-display");
   });
 
-  it("respects width option", () => {
-    const svg = readFileSync(
-      "src/images/fixtures/simple-equation.svg",
-      "utf-8",
-    );
-
-    const smallPng = svgToPng(svg, { width: 300 });
-    const largePng = svgToPng(svg, { width: 600 });
-
-    // Different widths should produce different size buffers
-    expect(smallPng.length).toBeLessThan(largePng.length);
-  });
 });

--- a/packages/exports/src/images/svgToPng.ts
+++ b/packages/exports/src/images/svgToPng.ts
@@ -6,19 +6,14 @@ const log = aiLogger("exports");
 
 export function svgToPng(
   svgString: string,
-  options: {
-    width?: number;
-    height?: number;
-  } = {},
-): Buffer {
+): { buffer: Buffer; width: number; height: number } {
   try {
+    log.info(`Converting SVG to PNG`);
     const resvg = new Resvg(svgString, {
-      fitTo: options.width
-        ? {
-            mode: "width",
-            value: options.width,
-          }
-        : undefined,
+      fitTo: {
+        mode: "zoom",
+        value: 3,
+      },
       background: "rgba(255, 255, 255, 0)",
       font: {
         loadSystemFonts: true,
@@ -29,7 +24,11 @@ export function svgToPng(
     const pngBuffer = pngData.asPng();
 
     log.info(`Converted SVG to PNG (${pngBuffer.length} bytes)`);
-    return pngBuffer;
+    return {
+      buffer: pngBuffer,
+      width: pngData.width,
+      height: pngData.height,
+    };
   } catch (error) {
     throw new Error("SVG to PNG conversion failed", { cause: error });
   }


### PR DESCRIPTION
## Summary
Improves LaTeX image handling by extracting accurate dimensions from rendered PNGs and updating the filename format to include dimensions.

## Changes
- Extract dimensions from resvg's rendered PNG output instead of parsing SVG ex units
- Update GCS filename format to include dimensions: `latex/{hash}-{width}x{height}.png`
- Simplify `latexToSvg` to return only the SVG string (dimensions come from PNG)
- Remove width option from `svgToPng` - always render at natural size with 3x zoom
- Fix `getDimensions` regex parsing with optional chaining for type safety
- Clean up alt text generation by removing resolution info

## Why these changes?
- **Accurate dimensions**: SVG ex units are font-relative and hard to convert. Getting dimensions from the rendered PNG is more reliable.
- **Filename format**: Including dimensions in the filename allows the Google Docs API to size images correctly without additional metadata.
- **Simpler API**: Removing unnecessary options makes the code cleaner and easier to use.

## Testing
- [x] Type checking passes
- [x] Updated tests to match new API
- [x] Manual testing confirms dimensions are correctly extracted

## Related
- Builds on #757 (GCS infrastructure) and #756 (LaTeX rendering)