### PR TITLE
fix: update legal page links to point to thenational.academy

### DIFF
--- a/apps/nextjs/src/app/faqs/index.tsx
+++ b/apps/nextjs/src/app/faqs/index.tsx
@@ -456,7 +456,10 @@ export const FAQPageContent = () => {
               of the website using speech recognition software; listen to most
               of the website using a screen reader (including the most recent
               versions of JAWS, NVDA, and VoiceOver). View our{" "}
-              <OakLink href="https://labs.thenational.academy/legal/accessibility-statement">
+              <OakLink
+                href="https://www.thenational.academy/legal/accessibility-statement"
+                target="_blank"
+              >
                 full accessibility statement
               </OakLink>
               .

--- a/apps/nextjs/src/app/legal/account-locked/account-locked.tsx
+++ b/apps/nextjs/src/app/legal/account-locked/account-locked.tsx
@@ -13,7 +13,10 @@ export const AccountLocked = () => {
 
       <FullPageWarning.Content>
         Your activity may be in violation of our{" "}
-        <Link href="https://www.thenational.academy/legal/terms-and-conditions">
+        <Link
+          href="https://www.thenational.academy/legal/terms-and-conditions"
+          target="_blank"
+        >
           terms and conditions
         </Link>{" "}
         so your account has been locked. If this is an error, please contact us

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-panel-disclaimer.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-panel-disclaimer.tsx
@@ -7,7 +7,7 @@ const ChatPanelDisclaimer = ({
     <p className={`my-12 text-${size}`}>
       Aila can make mistakes. Check your lesson before use. See our{" "}
       <a
-        href="https://labs.thenational.academy/legal/terms"
+        href="https://www.thenational.academy/legal/terms-and-conditions"
         className="text-blue underline"
         target="_blank"
       >

--- a/apps/nextjs/src/components/ContextProviders/CookieConsentProvider.tsx
+++ b/apps/nextjs/src/components/ContextProviders/CookieConsentProvider.tsx
@@ -51,7 +51,7 @@ const CookieConsentUIProvider = ({ children }: PropsWithChildren) => {
     >
       {children}
       <OakCookieConsent
-        policyURL={"/legal/cookies"}
+        policyURL={"https://www.thenational.academy/legal/cookie-policy"}
         isFixed={true}
         zIndex={99999}
       />

--- a/apps/nextjs/src/components/Onboarding/AcceptTermsForm.tsx
+++ b/apps/nextjs/src/components/Onboarding/AcceptTermsForm.tsx
@@ -89,7 +89,11 @@ export const AcceptTermsForm = () => {
               Keep me updated with latest Oak AI experiments, resources and
               other helpful content by email. You can unsubscribe at any time.
               See our{" "}
-              <OakLink element={Link} href="/legal/privacy">
+              <OakLink
+                element={Link}
+                href="https://www.thenational.academy/legal/privacy-policy"
+                target="_blank"
+              >
                 privacy policy
               </OakLink>
               .

--- a/apps/nextjs/src/components/Onboarding/TermsContent.tsx
+++ b/apps/nextjs/src/components/Onboarding/TermsContent.tsx
@@ -37,7 +37,12 @@ const TermsContent = () => {
       <OakP $mb="space-between-s">
         This service is intended to be used by teachers and educators. To use
         this website, you must register for an account. Please see our{" "}
-        <OakLink element={Link} className="text-blue" href="/legal/privacy">
+        <OakLink
+          element={Link}
+          className="text-blue"
+          href="https://www.thenational.academy/legal/privacy-policy"
+          target="_blank"
+        >
           Privacy Policy
         </OakLink>{" "}
         for details of how we handle your personal data.
@@ -134,7 +139,12 @@ const TermsContent = () => {
             we work with in order to make them more accurate and better at
             providing content which is helpful to you. We store inputs you
             provide only for this purpose (see our{" "}
-            <OakLink element={Link} className="text-blue" href="/legal/privacy">
+            <OakLink
+              element={Link}
+              className="text-blue"
+              href="https://www.thenational.academy/legal/privacy-policy"
+              target="_blank"
+            >
               Privacy Policy
             </OakLink>{" "}
             for further details);
@@ -276,6 +286,7 @@ const TermsContent = () => {
           element={Link}
           className="text-blue"
           href="https://www.thenational.academy/legal/security-disclosure-policy"
+          target="_blank"
         >
           Security Disclosure Policy
         </OakLink>

--- a/apps/nextjs/src/data/menus.tsx
+++ b/apps/nextjs/src/data/menus.tsx
@@ -53,8 +53,9 @@ export const legalMenuItems: MenuItem[] = [
   },
   {
     title: "Cookie policy",
-    href: "/legal/cookies",
+    href: "https://www.thenational.academy/legal/cookie-policy",
     id: "cookies",
+    target: "_blank",
   },
   {
     title: "Manage cookie settings",
@@ -69,8 +70,9 @@ export const legalMenuItems: MenuItem[] = [
   },
   {
     title: "Accessibility statement",
-    href: "/legal/accessibility-statement",
+    href: "https://www.thenational.academy/legal/accessibility-statement",
     id: "accessibility-statement",
+    target: "_blank",
   },
   {
     title: "Safeguarding statement",


### PR DESCRIPTION
## Summary
- Fixed incorrect legal page links that were pointing to outdated Sanity-powered pages on the labs subdomain
- All legal links now correctly point to the official pages on `www.thenational.academy`
- Added `target="_blank"` to all legal links for consistent UX (preserves user context)

## Problem
Users reported that the privacy policy link was going to the wrong place. Investigation revealed that:
- Some links were pointing to `/legal/*` paths (served from Sanity CMS with outdated content)
- Some links were pointing to `labs.thenational.academy/legal/*` 
- The correct legal pages are hosted at `www.thenational.academy/legal/*`

## Changes
Updated links in 7 files:
- ✅ Privacy policy → `https://www.thenational.academy/legal/privacy-policy`
- ✅ Cookie policy → `https://www.thenational.academy/legal/cookie-policy`
- ✅ Terms & conditions → `https://www.thenational.academy/legal/terms-and-conditions`
- ✅ Accessibility statement → `https://www.thenational.academy/legal/accessibility-statement`
- ✅ Security disclosure → `https://www.thenational.academy/legal/security-disclosure-policy`

## Test plan
- [x] All links return HTTP 200 status
- [x] All links contain appropriate content for their topic
- [x] Links open in new tabs to preserve user context
- [x] Type checks pass
- [x] Linting passes (only existing warnings)

## Follow-up
A separate PR will remove the old `/legal/[slug]/` route handler and Sanity CMS integration since legal pages are now served from thenational.academy (keeping `/legal/account-locked` which is still needed).