### PR TITLE
fix: short answer placeholder patterns

### DIFF
--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/ShortAnswerQuestion.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/ShortAnswerQuestion.stories.tsx
@@ -28,6 +28,18 @@ export const InlineAnswer: Story = {
   },
 };
 
+export const InlineAnswerWithSpaces: Story = {
+  args: {
+    question: {
+      questionType: "short-answer",
+      question: "The capital of France is {{ }}.",
+      answers: ["Paris"],
+      hint: null,
+    },
+    questionNumber: 2,
+  },
+};
+
 export const SeparateAnswer: Story = {
   args: {
     question: {

--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/ShortAnswerQuestion.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/ShortAnswerQuestion.tsx
@@ -17,7 +17,8 @@ type ShortAnswerQuestionProps = {
 // Create custom components for inline answer rendering
 const getInlineAnswerComponents = (answer: string): Partial<Components> => ({
   em: ({ children }) => {
-    const isInlineAnswer = children?.toString() === "{{}}";
+    const content = children?.toString();
+    const isInlineAnswer = content === "{{ }}" || content === "{{}}";
     if (isInlineAnswer) {
       return (
         <OakSpan
@@ -43,12 +44,13 @@ export const ShortAnswerQuestion = ({
   question,
   questionNumber,
 }: ShortAnswerQuestionProps) => {
-  const hasInlineAnswer = question.question.includes("{{}}");
+  const hasInlineAnswer =
+    question.question.includes("{{}}") || question.question.includes("{{ }}");
   const answer = question.answers?.[0] ?? "";
 
   const questionText = addInstruction(
-    // Wrap {{}} in italics. We can intercept with a custom em component
-    question.question.replace("{{}}", "_{{}}_ "),
+    // Wrap {{}} and {{ }} in italics. We can intercept with a custom em component
+    question.question.replace(/\{\{ ?\}\}/g, "_{{}}_"),
     "Fill in the blank.",
   );
 


### PR DESCRIPTION
Support both `{{}}` and `{{ }}` patterns in short answer questions.

Adds Storybook example for `{{ }}` pattern.