### PR TITLE
fix: resolve RAG parse errors blocking lesson retrieval

### DIFF
--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -509,7 +509,7 @@ export const CompletedLessonPlanSchemaWithoutLength = z.object({
   title: LessonTitleSchema,
   keyStage: KeyStageSchema,
   subject: SubjectSchema,
-  topic: TopicSchema,
+  topic: TopicSchema.nullable(),
   learningOutcome: LearningOutcomeSchema,
   learningCycles: LearningCyclesSchema,
   priorKnowledge: PriorKnowledgeSchema,

--- a/packages/rag/lib/search/search.ts
+++ b/packages/rag/lib/search/search.ts
@@ -50,6 +50,11 @@ export async function vectorSearch({
   log.info(`Parse errors: ${parseErrors.length}`);
   log.info(`Invalid results: ${queryResponse.length - results.length}`);
   log.info(`Valid results: ${results.length}`);
+  
+  // Log first 3 parse errors for debugging
+  parseErrors.slice(0, 3).forEach((error, index) => {
+    log.error(`Parse error ${index + 1}:`, error);
+  });
 
   const endAt = new Date();
   log.info(

--- a/packages/rag/lib/search/search.ts
+++ b/packages/rag/lib/search/search.ts
@@ -58,7 +58,9 @@ export async function vectorSearch({
 
   // Throw if we have at least 3 rows but all failed to parse
   if (queryResponse.length >= 3 && results.length === 0) {
-    throw new Error(`All RAG results failed to parse. Found ${queryResponse.length} results but all ${parseErrors.length} failed validation. Check logs above for details.`);
+    throw new Error(
+      `All RAG results failed to parse. Found ${queryResponse.length} results but all ${parseErrors.length} failed validation. Check logs above for details.`,
+    );
   }
 
   const endAt = new Date();

--- a/packages/rag/lib/search/search.ts
+++ b/packages/rag/lib/search/search.ts
@@ -50,7 +50,7 @@ export async function vectorSearch({
   log.info(`Parse errors: ${parseErrors.length}`);
   log.info(`Invalid results: ${queryResponse.length - results.length}`);
   log.info(`Valid results: ${results.length}`);
-  
+
   // Log first 3 parse errors for debugging
   parseErrors.slice(0, 3).forEach((error, index) => {
     log.error(`Parse error ${index + 1}:`, error);

--- a/packages/rag/lib/search/search.ts
+++ b/packages/rag/lib/search/search.ts
@@ -56,6 +56,11 @@ export async function vectorSearch({
     log.error(`Parse error ${index + 1}:`, error);
   });
 
+  // Throw if we have at least 3 rows but all failed to parse
+  if (queryResponse.length >= 3 && results.length === 0) {
+    throw new Error(`All RAG results failed to parse. Found ${queryResponse.length} results but all ${parseErrors.length} failed validation. Check logs above for details.`);
+  }
+
   const endAt = new Date();
   log.info(
     `Fetched ${results.length} lesson plans in ${endAt.getTime() - startAt.getTime()}ms`,

--- a/packages/rag/types.ts
+++ b/packages/rag/types.ts
@@ -11,8 +11,10 @@ export type RagLessonPlanResult = {
 };
 
 export type RagLogger = {
-  info: (...args: string[]) => void;
-  error: (...args: string[]) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  info: (...args: any[]) => void;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  error: (...args: any[]) => void;
 };
 
 export type DeepPartial<T> = T extends object


### PR DESCRIPTION
Fixes RAG lesson plan parsing failures that were returning 0 results.

The main issue: We were parding RAG data with CompletedLessonPlanSchemaWithoutLength, where `topic` was required.

- Make topic field nullable to handle legacy data
- Add detailed error logging to identify validation issues
- Throw early when all results fail parsing
- Update RagLogger type to support object logging