### PR TITLE
feat: extend blank placeholder processing to all quiz question types

### DIFF
--- a/packages/exports/src/gSuite/docs/quiz/table-generators/questions/matchingPairs.ts
+++ b/packages/exports/src/gSuite/docs/quiz/table-generators/questions/matchingPairs.ts
@@ -3,7 +3,10 @@
  */
 import invariant from "tiny-invariant";
 
-import { addInstruction } from "../../../../../quiz-utils/formatting";
+import {
+  addInstruction,
+  processBlankPlaceholders,
+} from "../../../../../quiz-utils/formatting";
 import { shuffleMatchItems } from "../../../../../quiz-utils/shuffle";
 import { CHECKBOX_PLACEHOLDER, COLUMN_WIDTHS } from "../constants";
 import { createTableElement, createTextElement } from "../elements";
@@ -24,7 +27,8 @@ export function generateMatchingPairsTable(
 
   // Question text element with properly formatted instruction
   const instruction = "Write the matching letter in each box.";
-  const formattedQuestion = addInstruction(question, instruction);
+  const questionWithBlanks = processBlankPlaceholders(question);
+  const formattedQuestion = addInstruction(questionWithBlanks, instruction);
   elements.push(
     createTextElement(insertIndex, `${questionNumber}. ${formattedQuestion}`),
   );

--- a/packages/exports/src/gSuite/docs/quiz/table-generators/questions/multipleChoice.ts
+++ b/packages/exports/src/gSuite/docs/quiz/table-generators/questions/multipleChoice.ts
@@ -1,7 +1,10 @@
 /**
  * Multiple choice question generator
  */
-import { addInstruction } from "../../../../../quiz-utils/formatting";
+import {
+  addInstruction,
+  processBlankPlaceholders,
+} from "../../../../../quiz-utils/formatting";
 import { shuffleMultipleChoiceAnswers } from "../../../../../quiz-utils/shuffle";
 import { CHECKBOX_PLACEHOLDER, COLUMN_WIDTHS } from "../constants";
 import { createTableElement, createTextElement } from "../elements";
@@ -31,7 +34,8 @@ export function generateMultipleChoiceTable(
       : "Tick 1 correct answer.";
 
   // Question text element with properly formatted instruction
-  const formattedQuestion = addInstruction(question, instruction);
+  const questionWithBlanks = processBlankPlaceholders(question);
+  const formattedQuestion = addInstruction(questionWithBlanks, instruction);
   elements.push(
     createTextElement(insertIndex, `${questionNumber}. ${formattedQuestion}`),
   );

--- a/packages/exports/src/gSuite/docs/quiz/table-generators/questions/ordering.ts
+++ b/packages/exports/src/gSuite/docs/quiz/table-generators/questions/ordering.ts
@@ -1,7 +1,10 @@
 /**
  * Ordering question generator
  */
-import { addInstruction } from "../../../../../quiz-utils/formatting";
+import {
+  addInstruction,
+  processBlankPlaceholders,
+} from "../../../../../quiz-utils/formatting";
 import { shuffleOrderItems } from "../../../../../quiz-utils/shuffle";
 import { COLUMN_WIDTHS } from "../constants";
 import { createTableElement, createTextElement } from "../elements";
@@ -24,7 +27,8 @@ export function generateOrderingTable(
 
   // Question text element with properly formatted instruction
   const instruction = "Write the correct number in each box.";
-  const formattedQuestion = addInstruction(question, instruction);
+  const questionWithBlanks = processBlankPlaceholders(question);
+  const formattedQuestion = addInstruction(questionWithBlanks, instruction);
   elements.push(
     createTextElement(insertIndex, `${questionNumber}. ${formattedQuestion}`),
   );

--- a/packages/exports/src/gSuite/docs/quiz/table-generators/questions/shortAnswer.ts
+++ b/packages/exports/src/gSuite/docs/quiz/table-generators/questions/shortAnswer.ts
@@ -1,23 +1,13 @@
 /**
  * Short answer question generator
  */
-import { addInstruction } from "../../../../../quiz-utils/formatting";
+import {
+  addInstruction,
+  hasBlankPlaceholders,
+  processBlankPlaceholders,
+} from "../../../../../quiz-utils/formatting";
 import { createTextElement } from "../elements";
 import type { QuizElement } from "../types";
-
-// Blank patterns that we support
-// NOTE: Don't use /g flags as they are stateful when tested multiple times
-const BLANK_PATTERNS = {
-  CURLY_BRACES: /\{\{ ?\}\}/,
-  UNDERSCORES: /_{3,}/,
-} as const;
-
-export const hasBlankSpaces = (text: string): boolean => {
-  return (
-    BLANK_PATTERNS.CURLY_BRACES.test(text) ||
-    BLANK_PATTERNS.UNDERSCORES.test(text)
-  );
-};
 
 /**
  * Generate elements for a short answer question (no table needed)
@@ -28,28 +18,26 @@ export function generateShortAnswerQuestion(
   question: string,
   questionNumber: number,
 ): QuizElement[] {
-  const answerLine = "▁".repeat(10);
+  const blankLine = "▁".repeat(10);
   const instruction = "Fill in the blank.";
-  const isInline = hasBlankSpaces(question);
+  const questionWithBlanks = processBlankPlaceholders(question);
+  const formattedQuestion = addInstruction(questionWithBlanks, instruction);
 
-  if (isInline) {
-    const textWithLine = question
-      .replace(BLANK_PATTERNS.CURLY_BRACES, answerLine)
-      .replace(BLANK_PATTERNS.UNDERSCORES, answerLine);
-    const formattedQuestion = addInstruction(textWithLine, instruction);
+  // If question already contains inline blanks, don't add a separate answer line
+  if (hasBlankPlaceholders(question)) {
     return [
       createTextElement(
         insertIndex,
         `${questionNumber}. ${formattedQuestion}\n`,
       ),
     ];
-  } else {
-    const formattedQuestion = addInstruction(question, instruction);
-    return [
-      createTextElement(
-        insertIndex,
-        `${questionNumber}. ${formattedQuestion}\n\n${answerLine}\n`,
-      ),
-    ];
   }
+
+  // If no inline blanks, add a separate blank line for the answer
+  return [
+    createTextElement(
+      insertIndex,
+      `${questionNumber}. ${formattedQuestion}\n\n${blankLine}\n`,
+    ),
+  ];
 }

--- a/packages/exports/src/quiz-utils/formatting.test.ts
+++ b/packages/exports/src/quiz-utils/formatting.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Tests for blank placeholder processing
+ */
+import { hasBlankPlaceholders, processBlankPlaceholders } from "./formatting";
+
+describe("hasBlankPlaceholders", () => {
+  it("should detect curly braces patterns", () => {
+    expect(hasBlankPlaceholders("What is {{}}?")).toBe(true);
+    expect(hasBlankPlaceholders("What is {{ }}?")).toBe(true);
+  });
+
+  it("should detect underscore patterns", () => {
+    expect(hasBlankPlaceholders("What is ___?")).toBe(true);
+    expect(hasBlankPlaceholders("What is ______?")).toBe(true);
+  });
+
+  it("should not detect short underscore patterns", () => {
+    expect(hasBlankPlaceholders("What is __?")).toBe(false);
+    expect(hasBlankPlaceholders("What is _?")).toBe(false);
+  });
+
+  it("should not detect regular text", () => {
+    expect(hasBlankPlaceholders("What is the answer?")).toBe(false);
+    expect(hasBlankPlaceholders("No blanks here")).toBe(false);
+  });
+});
+
+describe("processBlankPlaceholders", () => {
+  it("should replace curly braces with underlined characters", () => {
+    const result = processBlankPlaceholders("What is {{}}?");
+    expect(result).toBe("What is ▁▁▁▁▁▁▁▁▁▁?");
+  });
+
+  it("should replace curly braces with spaces", () => {
+    const result = processBlankPlaceholders("What is {{ }}?");
+    expect(result).toBe("What is ▁▁▁▁▁▁▁▁▁▁?");
+  });
+
+  it("should replace underscores with underlined characters", () => {
+    const result = processBlankPlaceholders("What is ___?");
+    expect(result).toBe("What is ▁▁▁▁▁▁▁▁▁▁?");
+  });
+
+  it("should replace long underscores with underlined characters", () => {
+    const result = processBlankPlaceholders("What is ______?");
+    expect(result).toBe("What is ▁▁▁▁▁▁▁▁▁▁?");
+  });
+
+  it("should handle multiple blanks in one text", () => {
+    const result = processBlankPlaceholders("{{}} + ___ = 10");
+    expect(result).toBe("▁▁▁▁▁▁▁▁▁▁ + ▁▁▁▁▁▁▁▁▁▁ = 10");
+  });
+
+  it("should not modify text without blanks", () => {
+    const result = processBlankPlaceholders("What is the answer?");
+    expect(result).toBe("What is the answer?");
+  });
+
+  it("should not replace short underscores", () => {
+    const result = processBlankPlaceholders("What is __?");
+    expect(result).toBe("What is __?");
+  });
+});

--- a/packages/exports/src/quiz-utils/formatting.ts
+++ b/packages/exports/src/quiz-utils/formatting.ts
@@ -3,6 +3,16 @@
  * Ensures consistency between web display and exported documents
  */
 
+// Blank patterns that we support
+// NOTE: Don't use /g flags as they are stateful when tested multiple times
+const BLANK_PATTERNS = {
+  CURLY_BRACES: /\{\{ ?\}\}/,
+  UNDERSCORES: /_{3,}/,
+} as const;
+
+// Length of the blank line placeholder (repeated underline characters)
+const BLANK_LINE_LENGTH = 10;
+
 /**
  * Ensures text ends with proper punctuation
  * Preserves markdown images at the end
@@ -28,4 +38,26 @@ export function ensureEndsWithPeriod(text: string): string {
  */
 export function addInstruction(question: string, instruction: string): string {
   return `${ensureEndsWithPeriod(question)} ${instruction}`;
+}
+
+/**
+ * Checks if text contains blank placeholders
+ */
+export function hasBlankPlaceholders(text: string): boolean {
+  return (
+    BLANK_PATTERNS.CURLY_BRACES.test(text) ||
+    BLANK_PATTERNS.UNDERSCORES.test(text)
+  );
+}
+
+/**
+ * Processes blank placeholders in text, converting them to underlined spaces
+ * Uses U+2581 LOWER ONE EIGHTH BLOCK character repeated multiple times
+ */
+export function processBlankPlaceholders(text: string): string {
+  const blankLine = "▁".repeat(BLANK_LINE_LENGTH); // U+2581 LOWER ONE EIGHTH BLOCK
+
+  return text
+    .replace(BLANK_PATTERNS.CURLY_BRACES, blankLine)
+    .replace(BLANK_PATTERNS.UNDERSCORES, blankLine);
 }


### PR DESCRIPTION
- Move blank processing from shortAnswer.ts to shared formatting utility
- Apply {{}} and ___ conversion to question text in all quiz types
- Ensures consistent blank rendering across multiple choice, match, order, and short answer exports
- Improves code reuse and maintainability with shared processing logic

## Description

- List of changes

## Issue(s)

Fixes #

## How to test

1. Go to {deployment_url}
2. Click on \_\_\_\_\_\_
3. You should see \_\_\_\_\_\_

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
