### PR TITLE
feat: set a max width and height for quiz images

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
@@ -86,6 +86,17 @@ const createComponents = (className?: string): Partial<Components> => ({
       </a>
     );
   },
+  img: ({ src, alt, title }) => {
+    // Apply fixed max dimensions to all images
+    return (
+      <img
+        src={src}
+        alt={alt}
+        title={title}
+        className="h-auto max-h-[200px] w-auto max-w-[250px] object-contain"
+      />
+    );
+  },
 });
 
 export const MemoizedReactMarkdownWithStyles = ({

--- a/packages/exports/src/gSuite/docs/replacements/imageReplacements.ts
+++ b/packages/exports/src/gSuite/docs/replacements/imageReplacements.ts
@@ -2,7 +2,11 @@ import { aiLogger } from "@oakai/logger";
 
 import type { docs_v1 } from "@googleapis/docs";
 
-import { getGoogleDocsDimensions } from "../../../images/constants";
+import {
+  QUESTION_IMAGE_MAX_HEIGHT,
+  QUESTION_IMAGE_MAX_WIDTH,
+  calculateLatexImageDimensions,
+} from "../../../images/constants";
 import { GCS_LATEX_BUCKET_NAME } from "../../../images/gcsCredentials";
 
 const log = aiLogger("exports");
@@ -15,7 +19,7 @@ function getDimensions(imageUrl: string) {
     const scaledWidth = parseInt(dimensions[1], 10);
     const scaledHeight = parseInt(dimensions[2], 10);
 
-    return getGoogleDocsDimensions(scaledWidth, scaledHeight);
+    return calculateLatexImageDimensions(scaledWidth, scaledHeight);
   }
 
   throw new Error(`Unable to extract dimensions from image URL: ${imageUrl}`);
@@ -67,6 +71,16 @@ const insertStemImage = (
         uri: image.url,
         location: {
           index: startIndex, // Insert at the same startIndex where the Markdown was removed
+        },
+        objectSize: {
+          height: {
+            magnitude: QUESTION_IMAGE_MAX_HEIGHT,
+            unit: "PT",
+          },
+          width: {
+            magnitude: QUESTION_IMAGE_MAX_WIDTH,
+            unit: "PT",
+          },
         },
       },
     },

--- a/packages/exports/src/images/constants.ts
+++ b/packages/exports/src/images/constants.ts
@@ -17,6 +17,12 @@ export const DPI_SCALE_FACTOR = 3.0;
 export const LATEX_VISUAL_SCALE = 1.3;
 
 /**
+ * Max dimensions for images in question text (points)
+ */
+export const QUESTION_IMAGE_MAX_WIDTH = 250;
+export const QUESTION_IMAGE_MAX_HEIGHT = 200;
+
+/**
  * Whether to render LaTeX expressions in bold
  */
 export const LATEX_USE_BOLD = false;
@@ -33,15 +39,15 @@ export function pxToPt(pixels: number): number {
 }
 
 /**
- * Get Google Docs dimensions from scaled pixel values.
+ * Calculate Google Docs dimensions from DPI-scaled pixel values.
  * Takes pixel dimensions that were scaled up during PNG generation
  * and converts them to the correct point dimensions for Google Docs.
  *
- * @param scaledWidth - Width in pixels (after scaling)
- * @param scaledHeight - Height in pixels (after scaling)
+ * @param scaledWidth - Width in pixels (after DPI scaling)
+ * @param scaledHeight - Height in pixels (after DPI scaling)
  * @returns Object with width and height in points for Google Docs
  */
-export function getGoogleDocsDimensions(
+export function calculateLatexImageDimensions(
   scaledWidth: number,
   scaledHeight: number,
 ): { width: number; height: number } {


### PR DESCRIPTION
## Description

At the moment, quiz images are displayed at their original resolution. The problem is that content creators are told to create assets in as high a resolution as they can so that they look sharp in different places and screens. This makes them too large in our exports

Solution:

- Set a max width and height for images in quizzes

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
