### PR TITLE
fix: disable blockquote rendering in quiz answers

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
@@ -35,6 +35,8 @@ const createComponents = (className?: string): Partial<Components> => ({
   h1: ({ children }) => (
     <h2 className="mb-0 mt-20 text-xl font-bold">{children}</h2>
   ),
+  // Disable blockquote rendering to prevent answers like "> 90 degrees" from being styled as quotes
+  blockquote: ({ children }) => <>{children}</>,
   code: (props) => {
     const {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/MultipleChoiceQuestion.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/MultipleChoiceQuestion.stories.tsx
@@ -75,3 +75,16 @@ export const WithUnfilledBlanks: Story = {
     questionNumber: 4,
   },
 };
+
+export const WithBlockquoteText: Story = {
+  args: {
+    question: {
+      questionType: "multiple-choice",
+      question: "What angle is greater than a right angle?",
+      answers: ["> 90 degrees"],
+      distractors: ["< 90 degrees", "= 90 degrees", "≤ 45 degrees"],
+      hint: null,
+    },
+    questionNumber: 5,
+  },
+};


### PR DESCRIPTION
## Summary
- Disables blockquote rendering in markdown to prevent quiz answers starting with ">" from being styled as quotes
- Adds Storybook story demonstrating the fix with "> 90 degrees" example

## Test plan
- [ ] Check Storybook story renders "> 90 degrees" as plain text
- [ ] Verify existing quiz functionality unchanged