### PR TITLE
fix: fix radio button dot after oak-components update

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -57,7 +57,7 @@
     "@oakai/exports": "*",
     "@oakai/logger": "*",
     "@oakai/prettier-config": "*",
-    "@oaknational/oak-components": "^1.142.0",
+    "@oaknational/oak-components": "^1.142.2",
     "@oaknational/oak-consent-client": "^2.1.0",
     "@oaknational/oak-curriculum-schema": "^1.59.1",
     "@portabletext/react": "^3.1.0",

--- a/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StepLayouts/StepOne.tsx
+++ b/apps/nextjs/src/components/AppComponents/AdditionalMaterials/StepLayouts/StepOne.tsx
@@ -72,7 +72,6 @@ const StepOne = ({
               {resourceTypes.map((resourceType) => (
                 <OakLabel key={resourceType.id}>
                   <OakRadioButton
-                    $borderStyle={"none"}
                     id={resourceType.id}
                     value={resourceType.id}
                     radioInnerSize="all-spacing-5"

--- a/apps/nextjs/src/components/DialogControl/ContentOptions/AdditionalMaterialsStartAgain.tsx
+++ b/apps/nextjs/src/components/DialogControl/ContentOptions/AdditionalMaterialsStartAgain.tsx
@@ -105,6 +105,7 @@ const AdditionalMaterialsStartAgain = ({
               value="new-lesson"
               radioInnerSize="all-spacing-5"
               radioOuterSize="all-spacing-6"
+              $borderStyle={"none"}
               label={
                 <OakFlex
                   $flexDirection="column"

--- a/apps/nextjs/src/components/DialogControl/ContentOptions/AdditionalMaterialsStartAgain.tsx
+++ b/apps/nextjs/src/components/DialogControl/ContentOptions/AdditionalMaterialsStartAgain.tsx
@@ -82,7 +82,6 @@ const AdditionalMaterialsStartAgain = ({
           >
             <OakRadioButton
               id="current-lesson"
-              $borderStyle={"none"}
               value="current-lesson"
               radioInnerSize="all-spacing-5"
               radioOuterSize="all-spacing-6"
@@ -105,7 +104,6 @@ const AdditionalMaterialsStartAgain = ({
               value="new-lesson"
               radioInnerSize="all-spacing-5"
               radioOuterSize="all-spacing-6"
-              $borderStyle={"none"}
               label={
                 <OakFlex
                   $flexDirection="column"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,8 +144,8 @@ importers:
         specifier: '*'
         version: link:../../packages/prettier-config
       '@oaknational/oak-components':
-        specifier: ^1.142.0
-        version: 1.142.0(next-cloudinary@6.16.0)(next@14.2.28)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.11)
+        specifier: ^1.142.2
+        version: 1.142.2(next-cloudinary@6.16.0)(next@14.2.28)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.11)
       '@oaknational/oak-consent-client':
         specifier: ^2.1.0
         version: 2.1.0(react-dom@18.2.0)(react@18.2.0)(zod@3.23.8)
@@ -6630,8 +6630,8 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  /@oaknational/oak-components@1.142.0(next-cloudinary@6.16.0)(next@14.2.28)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.11):
-    resolution: {integrity: sha512-31z09FWt1H/HtumOUGUusmruS0w2PH/Hxm3lgvBI6x4CVypqhL+XSVwrjSKyoXFsbgcuH8p4tYlCroJ8XPDulw==}
+  /@oaknational/oak-components@1.142.2(next-cloudinary@6.16.0)(next@14.2.28)(react-dom@18.2.0)(react@18.2.0)(styled-components@5.3.11):
+    resolution: {integrity: sha512-/OVSoxjuAe64fO2TNZm0dhWj92wnfnGV9eDetVpRPWyjCLG/ST93vpk06h0Ppf8SzTLbCYJMyz9sQv+5ftW5Ng==}
     peerDependencies:
       next: '>=14.2.12'
       next-cloudinary: '>=6.16.0'


### PR DESCRIPTION
Update: bumps Oak component, dot had removed



~~Fixes the dot seen here. The root cause isn't yet known, but this is how we've patched the other radio buttons. To investigate!~~
<img width="1126" height="664" alt="SCR-20250908-mamq" src="https://github.com/user-attachments/assets/87ea7008-14e9-4acb-834e-12a04f014f07" />

