### PR TITLE
chore: add feature flag comment for 'new rag schema'

### DIFF
--- a/packages/aila/src/core/prompt/builders/AilaLessonPromptBuilder.ts
+++ b/packages/aila/src/core/prompt/builders/AilaLessonPromptBuilder.ts
@@ -80,6 +80,11 @@ export class AilaLessonPromptBuilder extends AilaPromptBuilder {
       };
     }
 
+    /**
+     * In the 'agentic' system, RAG is handled directly, i.e. this class is not used.
+     * If we want to test the new RAG schema with the 'mega prompt' system, we can
+     * enable feature flag 'rag-schema-2024-12' for certain users.
+     */
     const newRagEnabled = await posthogAiBetaServerClient.isFeatureEnabled(
       "rag-schema-2024-12",
       userId,


### PR DESCRIPTION
## Description

- just adds a comment for clarification

The situation now is that we have two feature flags that relate two the new RAG schema/Agentic system/Maths recommender:
- **rag-schema-2024-12**: if enabled, sessions that are using the 'mega prompt' flow will fetch RAG data from the new RAG schema. Currently this is disabled for all users. 
- **agentic-aila-may-25**: if enabled, sessions will have `aila.options.useAgenticAila` set to true. Sessions will use the agentic system, which in turn always points at the new RAG schema. Currently enabled for internal users testing maths recommender.