### PR TITLE
fix: remove length constraints from migrator input schema to fix rag

### DIFF
--- a/packages/aila/src/protocol/schemas/versioning/migrateLessonPlan.ts
+++ b/packages/aila/src/protocol/schemas/versioning/migrateLessonPlan.ts
@@ -3,7 +3,7 @@ import { aiLogger } from "@oakai/logger";
 import { type ZodTypeAny, z } from "zod";
 
 import type { PartialLessonPlan } from "../../schema";
-import { LessonPlanSchema, PartialLessonPlanSchema } from "../../schema";
+import { CompletedLessonPlanSchemaWithoutLength } from "../../schema";
 import type { LatestQuiz } from "../quiz";
 import { QuizV1Schema, QuizV2Schema } from "../quiz";
 import { convertQuizV1ToV2, isQuizV1 } from "../quiz/conversion/quizV1ToV2";
@@ -22,10 +22,13 @@ export const MigratableQuizSchema = z.union([
 ]);
 
 // Proper input schema for lesson plan migration
-export const LessonPlanMigrationInputSchema = LessonPlanSchema.extend({
-  starterQuiz: MigratableQuizSchema.optional(),
-  exitQuiz: MigratableQuizSchema.optional(),
-});
+export const LessonPlanMigrationInputSchema =
+  // HACK: This loose type is needed for RAG lessons which can violate length requirements
+  //       eg: misconceptions can be an empty array
+  CompletedLessonPlanSchemaWithoutLength.partial().extend({
+    starterQuiz: MigratableQuizSchema.optional(),
+    exitQuiz: MigratableQuizSchema.optional(),
+  });
 
 export type LessonPlanMigrationInput = z.infer<
   typeof LessonPlanMigrationInputSchema

--- a/packages/rag/lib/search/preparseResult.ts
+++ b/packages/rag/lib/search/preparseResult.ts
@@ -1,4 +1,4 @@
-import { PartialLessonPlanSchema } from "../../../aila/src/protocol/schema";
+import { CompletedLessonPlanSchemaWithoutLength } from "../../../aila/src/protocol/schema";
 import { migrateLessonPlan } from "../../../aila/src/protocol/schemas/versioning/migrateLessonPlan";
 import type { DeepPartial, RagLessonPlanResult } from "../../types";
 
@@ -16,7 +16,7 @@ export async function preparseResult(result: DeepPartial<RagLessonPlanResult>) {
       keywords: result?.lessonPlan?.keywords?.slice(0, 5),
     },
     persistMigration: null,
-    outputSchema: PartialLessonPlanSchema,
+    outputSchema: CompletedLessonPlanSchemaWithoutLength,
   });
   return {
     ...result,


### PR DESCRIPTION
We have at least one maths RAG lesson with empty misconceptions (`[]`). This is allowed in RAG as it uses a schema without lengths. When we put the lesson through the schema migrator, we get an error which bubbles up to the user (on staging at least, it could be swallowed in production)

It's failing the zod parse going into the migrator as it uses PartialLessonPlan - which has min:1 on the misconceptions field. We don't really need a strict input schema (it's mostly to stop us passing a wildly different data type into the migrator) so I've set it to the permissive CompletedLessonPlanSchemaWithoutLength used by RAG

The problem lesson:
```
 ragLessonPlanId: '8740',
  oakLessonId: 3576,
  oakLessonSlug: 'make-different-sized-angles-by-rotating-two-lines-around-a-fixed-point'
```