### PR TITLE
fix: perssit non-maths aila agentic RAG data

### DIFF
--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -5,6 +5,7 @@ import { getRagLessonPlansByIds } from "@oakai/rag";
 
 import type { ReadableStreamDefaultController } from "stream/web";
 import invariant from "tiny-invariant";
+import { z } from "zod";
 
 import { DEFAULT_NUMBER_OF_RECORDS_IN_RAG } from "../../constants";
 import { AilaThreatDetectionError } from "../../features/threatDetection/types";
@@ -256,6 +257,12 @@ export class AilaStreamHandler {
                 log.error("Failed to migrate lesson plan", { error });
               }
             }
+
+            this._chat.relevantLessons = relevantLessonPlans.map((lesson) => ({
+              lessonPlanId: lesson.id,
+              title: z.object({ title: z.string() }).parse(lesson.content)
+                .title,
+            }));
 
             return migratedLessonPlans;
           }


### PR DESCRIPTION
## Description

- Previously RAG data was not being persisted in non-maths agentic flow
- This PR stores the RAG lesson metadata agent the chat session
