### PR TITLE
feat: remove starter and exit quizzes from maths lessons

### DIFF
--- a/packages/exports/src/gSuite/slides/clearSpeakerNoteTags.ts
+++ b/packages/exports/src/gSuite/slides/clearSpeakerNoteTags.ts
@@ -1,0 +1,96 @@
+import type { slides_v1 } from "@googleapis/slides";
+
+import type { Result } from "../../types";
+
+function getSpeakerNotesText(slide: slides_v1.Schema$Page): string {
+  const notesPage = slide.slideProperties?.notesPage;
+  const speakerNotesObjectId = notesPage?.notesProperties?.speakerNotesObjectId;
+
+  if (!speakerNotesObjectId) {
+    return "";
+  }
+
+  const speakerNotesElement = notesPage?.pageElements?.find(
+    (el) => el.objectId === speakerNotesObjectId,
+  );
+
+  return (speakerNotesElement?.shape?.text?.textElements ?? [])
+    .map((te) => te.textRun?.content)
+    .join("");
+}
+
+function removeInternalTags(text: string): string {
+  // Remove HTML comment style internal tags
+  return text
+    .replace(/<!-- INTERNAL_TAG: \w+ -->/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+export async function clearSpeakerNoteTags({
+  googleSlides,
+  presentationId,
+}: {
+  googleSlides: slides_v1.Slides;
+  presentationId: string;
+}): Promise<Result<null>> {
+  try {
+    const response = await googleSlides.presentations.get({
+      presentationId,
+    });
+
+    const requests: slides_v1.Schema$Request[] = [];
+
+    for (const slide of response?.data?.slides ?? []) {
+      const notesPage = slide.slideProperties?.notesPage;
+      const speakerNotesObjectId =
+        notesPage?.notesProperties?.speakerNotesObjectId;
+
+      if (!speakerNotesObjectId) {
+        continue;
+      }
+
+      const originalText = getSpeakerNotesText(slide);
+      const cleanedText = removeInternalTags(originalText);
+
+      if (originalText !== cleanedText) {
+        // Delete all existing text
+        requests.push({
+          deleteText: {
+            objectId: speakerNotesObjectId,
+            textRange: {
+              type: "ALL",
+            },
+          },
+        });
+
+        // Insert cleaned text if there's any content left
+        if (cleanedText.length > 0) {
+          requests.push({
+            insertText: {
+              objectId: speakerNotesObjectId,
+              insertionIndex: 0,
+              text: cleanedText,
+            },
+          });
+        }
+      }
+    }
+
+    if (requests.length > 0) {
+      await googleSlides.presentations.batchUpdate({
+        presentationId,
+        requestBody: {
+          requests,
+        },
+      });
+    }
+
+    return { data: null };
+  } catch (error) {
+    return {
+      error,
+      message: "Failed to clear speaker notes template tags",
+    };
+  }
+}

--- a/packages/exports/src/gSuite/slides/deleteSlides.ts
+++ b/packages/exports/src/gSuite/slides/deleteSlides.ts
@@ -2,63 +2,13 @@ import type { slides_v1 } from "@googleapis/slides";
 
 import type { Result } from "../../types";
 
-export type CycleNumber = 1 | 2 | 3;
-
-export type QuestionNumber =
-  | 1
-  | 2
-  | 3
-  | 4
-  | 5
-  | 6
-  | 7
-  | 8
-  | 9
-  | 10
-  | 11
-  | 12
-  | 13
-  | 14
-  | 15
-  | 16
-  | 17
-  | 18
-  | 19
-  | 20;
-
 // This type reflects the values available in the "speaker notes" of the template slides document
-export type SpeakerNotesTag =
-  | `cycle${CycleNumber}`
-  | `question${QuestionNumber}`;
+// eg: <!-- INTERNAL_TAG: starterQuiz -->
+export type SpeakerNotesTag = "starterQuiz" | "exitQuiz";
 
-export const QUESTION_TAGS = {
-  1: "question1",
-  2: "question2",
-  3: "question3",
-  4: "question4",
-  5: "question5",
-  6: "question6",
-  7: "question7",
-  8: "question8",
-  9: "question9",
-  10: "question10",
-  11: "question11",
-  12: "question12",
-  13: "question13",
-  14: "question14",
-  15: "question15",
-  16: "question16",
-  17: "question17",
-  18: "question18",
-  19: "question19",
-  20: "question20",
-} as const satisfies Record<QuestionNumber, SpeakerNotesTag>;
-
-export const CYCLE_TAGS = {
-  1: "cycle1",
-  2: "cycle2",
-  3: "cycle3",
-} as const satisfies Record<CycleNumber, SpeakerNotesTag>;
+function buildInternalTag(tag: SpeakerNotesTag): string {
+  return `<!-- INTERNAL_TAG: ${tag} -->`;
+}
 
 function getSpeakerNotes(slide: slides_v1.Schema$Page): string {
   const notesPage = slide.slideProperties?.notesPage;
@@ -96,7 +46,9 @@ export async function deleteSlides({
     }));
 
     const slidesToDelete = mappedSlides.filter((slide) =>
-      speakerNotesTagsToDelete.some((tag) => slide.speakerNotes.includes(tag)),
+      speakerNotesTagsToDelete.some((tag) =>
+        slide.speakerNotes.includes(buildInternalTag(tag)),
+      ),
     );
 
     const requests: slides_v1.Schema$Request[] = slidesToDelete.map(


### PR DESCRIPTION
## Description

We don't have an easy way to render inline latex or images in Google Slides. These are only needed in maths and only in quizzes. For now, we can remove starter and exit quizzes from slide exports if the subject is maths

We have some existing export code to remove slides in a document based on a tag in the speaker notes. It looks like we're not actually using that any more as the tags aren't in the template. But we can adapt that approach to tag quiz slides

## Issue(s)

Fixes #

## How to test

1. Generate a maths slide file
2. See that the quizzes are missing
3. Generate a non-maths slides file
4. See that the quizzes are there and there are no internal tags in the speaker notes

