### PR TITLE
fix: extra brace in mobile download URL

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-list/in-chat-download-buttons.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-list/in-chat-download-buttons.tsx
@@ -41,7 +41,7 @@ export const InChatDownloadButtons = () => {
         <Link
           href={
             demo.isSharingEnabled
-              ? `${getAilaUrl("lesson")}}/${id}/download/`
+              ? `${getAilaUrl("lesson")}/${id}/download/`
               : "#"
           }
           onClick={() => {

--- a/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/export-buttons/MobileExportButtons.tsx
@@ -39,7 +39,7 @@ export const MobileExportButtons = ({
           iconName="download"
           href={
             demo.isSharingEnabled
-              ? `${getAilaUrl("lesson")}}/${id}/download/`
+              ? `${getAilaUrl("lesson")}/${id}/download/`
               : "#"
           }
           onClick={() => {


### PR DESCRIPTION
## Description

- The download button was incorrectly formatter on mobile due to an extra brace

## Issue(s)

Fixes #AI-1578
