### PR TITLE
feat: add Terraform config for Vercel project

### DIFF
--- a/infrastructure/.gitignore
+++ b/infrastructure/.gitignore
@@ -1,0 +1,37 @@
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+#terraform file
+backend.tf
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data, such as
+# password, private keys, and other secrets. These should not be part of version
+# control as they are data points which are potentially sensitive and subject
+# to change depending on the environment.
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally and so
+# are not checked in
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+# example: *tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/infrastructure/project/.terraform.lock.hcl
+++ b/infrastructure/project/.terraform.lock.hcl
@@ -1,0 +1,42 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/cloudflare/cloudflare" {
+  version     = "5.6.0"
+  constraints = "~> 5.6.0"
+  hashes = [
+    "h1:YJFq/LeaDoqxHF5Js46ZqCeYlzaG9D+V6G39h/vZAkw=",
+    "zh:0f7ad515a0ac56de9ee00f24aadc64773bc9d186c7673672f7c1fd1971e7cc73",
+    "zh:1c7288a4d654860b81ff0d5366f7e7037c144cbd3d8f34d4ba4efd444c01085d",
+    "zh:304ba493a57cf1587f9878999144ee3ff65393ae577ea0304f94cb11e81d2a64",
+    "zh:605509ada3e19777cdd2d4c4e1f99e4b43d8c9e661083f32341d75dc450390ff",
+    "zh:753d2e607cc11cf4f08b9f5b161e2050f2f17bf200f2a6ba1224893b1cdcc476",
+    "zh:b0d557ea5e9a384b844d1d50d9627e61318583004d1a1113dce64c984267a139",
+    "zh:db8f65cc2ae10f1c3cb9e64e1e89a9222fb81ac6f832e796d0369596f1e74713",
+    "zh:f8057a7c670e038ec1a0fd4a490ad352cf94ac82db35f0e525d24503ceb511d2",
+    "zh:f809ab383cca0a5f83072981c64208cbd7fa67e986a86ee02dd2c82333221e32",
+  ]
+}
+
+provider "registry.terraform.io/vercel/vercel" {
+  version     = "3.14.1"
+  constraints = "~> 3.14.1"
+  hashes = [
+    "h1:Ec3llkbekKcXPdxJRHLPUk3K0z/OYhjHJf1JLkH9b9Q=",
+    "zh:0878e45047756391f35e10863081583569505c82e7a29b3111c05794126fa8cd",
+    "zh:088a9bb13ad1b4585dd313bdedebb8104e5c928c6c5faad112289c68415947cc",
+    "zh:156857e3e1c8901d915dd9c4f63df707fc75ab9978ebe5c27902385551ae96bd",
+    "zh:30c22296a33f6a11145406a6280e32c45193cafbe8cf6458d241849543453dea",
+    "zh:372f92b9d5b486f148767fea6639c2fd9f663a9c8a137d83dd75ac665508922c",
+    "zh:388d4362c9a0f56b87918555b619e5457da6e08ff4462ff3f6540e8cff9e9e03",
+    "zh:4c30a058f9396e6c3b98b7f44fbcfebecf74d48bcb5f00946fac698a312fa6b9",
+    "zh:647a449bcc0aa8e20aa96bace35a33b0f74e56c87d4d4c542624f443ba6a4509",
+    "zh:7906580b1b3b5b1104f0884c6a18d9370db1099d3aba699a6a6403ab71551f6b",
+    "zh:7e0d7ffabd8e18728e70b5cc74438a4527608933ca8ef6956f844b95a2124df2",
+    "zh:8f94f98445033dbaa5646afed939bc3c3f4fc2e44be1e89670db2c550f4ad811",
+    "zh:9d75137885e6cce79808384f589f29eaa6600edd4890e46c7982fe275f55b2ac",
+    "zh:c7286440ce93455775a2fad38f7229b303351912f1d823a8d374684d863e4eb9",
+    "zh:c9b21733ca6b26c7ff4bbb984bffcc4442c6d20b027ebaaab413c2b5f9cae6f6",
+    "zh:f26e0763dbe6a6b2195c94b44696f2110f7f55433dc142839be16b9697fa5597",
+  ]
+}

--- a/infrastructure/project/main.tf
+++ b/infrastructure/project/main.tf
@@ -20,7 +20,11 @@ module "vercel" {
   framework                        = "nextjs"
   project_visibility               = "public"
   git_repo                         = "oaknational/oak-ai-lesson-assistant"
-  protection_bypass_for_automation = false
+  root_directory                   = "apps/nextjs"
+  build_command                    = "turbo build"
+  ignore_command                   = "bash vercel-ignore-build.sh"
+  production_branch                = "production"
+  protection_bypass_for_automation = true
 
   # TODO: Add ["labs.thenational.academy"] after migrating from old Vercel project
   domains = []

--- a/infrastructure/project/main.tf
+++ b/infrastructure/project/main.tf
@@ -1,0 +1,27 @@
+locals {
+  workspace_prefix = "aila-project-"
+}
+
+resource "terraform_data" "workspace_validation" {
+  lifecycle {
+    precondition {
+      condition     = startswith(terraform.workspace, local.workspace_prefix)
+      error_message = "Workspace name \"${terraform.workspace}\" must begin with ${local.workspace_prefix}"
+    }
+  }
+}
+
+module "vercel" {
+  source                           = "github.com/oaknational/oak-terraform-modules//modules/vercel_project?ref=v1.3.9"
+  build_type                       = "website"
+  cloudflare_zone_domain           = var.cloudflare_zone_domain
+  # Env vars managed by Doppler, not Terraform
+  environment_variables            = []
+  framework                        = "nextjs"
+  project_visibility               = "public"
+  git_repo                         = "oaknational/oak-ai-lesson-assistant"
+  protection_bypass_for_automation = false
+
+  # TODO: Add ["labs.thenational.academy"] after migrating from old Vercel project
+  domains = []
+}

--- a/infrastructure/project/terraform.tf
+++ b/infrastructure/project/terraform.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 1.5.7"
+
+  cloud {
+    organization = "oak-national-academy"
+    workspaces {
+      tags = ["repo:oak-ai-lesson-assistant", "config:project"]
+    }
+  }
+}

--- a/infrastructure/project/variables.tf
+++ b/infrastructure/project/variables.tf
@@ -1,0 +1,4 @@
+variable "cloudflare_zone_domain" {
+  description = "Domain name for the zone"
+  type        = string
+}


### PR DESCRIPTION
## Summary

- Adds Terraform configuration to manage the Vercel project via HCP Terraform Cloud
- Following the Infrastructure Handbook "Set up Vercel module" guide
- Workspace `aila-project-website` created in Terraform Cloud under "Vercel Projects"
- `terraform plan` verified: 4 resources to add, 0 to change, 0 to destroy

## Status

- [x] Terraform Cloud workspace created
- [x] `cloudflare_zone_domain` variable set
- [x] `terraform plan` successful
- [x] Infrastructure team review
- [x] `terraform apply` (after merge)
- [ ] Migrate `labs.thenational.academy` domain to new project

## Notes

- Env vars are managed by Doppler, and we've assumed it's out of scope to transfer that system to Terraform
- `domains = []` — custom domain will be added in a follow-up after cutover from the existing Vercel project