### PR TITLE
fix: update oak-components to use fixed cookie consent modal

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -57,7 +57,7 @@
     "@oakai/prettier-config": "*",
     "@oakai/rag": "*",
     "@oakai/teaching-materials": "*",
-    "@oaknational/oak-components": "^2.13.3",
+    "@oaknational/oak-components": "^2.14.0",
     "@oaknational/oak-consent-client": "^2.1.0",
     "@oaknational/oak-curriculum-schema": "1.61.0",
     "@portabletext/react": "^3.1.0",

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -57,7 +57,7 @@
     "@oakai/prettier-config": "*",
     "@oakai/rag": "*",
     "@oakai/teaching-materials": "*",
-    "@oaknational/oak-components": "^2.13.1",
+    "@oaknational/oak-components": "^2.13.3",
     "@oaknational/oak-consent-client": "^2.1.0",
     "@oaknational/oak-curriculum-schema": "1.61.0",
     "@portabletext/react": "^3.1.0",

--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -57,7 +57,7 @@
     "@oakai/prettier-config": "*",
     "@oakai/rag": "*",
     "@oakai/teaching-materials": "*",
-    "@oaknational/oak-components": "^1.174.1",
+    "@oaknational/oak-components": "^2.13.1",
     "@oaknational/oak-consent-client": "^2.1.0",
     "@oaknational/oak-curriculum-schema": "1.61.0",
     "@portabletext/react": "^3.1.0",

--- a/apps/nextjs/src/components/AppComponents/Chat/lesson-plan-section/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/lesson-plan-section/index.tsx
@@ -62,7 +62,7 @@ export const LessonPlanSection = ({
 
   return (
     <DropDownSectionWrapper
-      $borderColor="black"
+      $borderColor="border-primary"
       $bb="border-solid-m"
       $pv="spacing-24"
       ref={sectionRef}

--- a/apps/nextjs/src/components/AppComponents/FormValidationWarning.tsx
+++ b/apps/nextjs/src/components/AppComponents/FormValidationWarning.tsx
@@ -3,7 +3,11 @@ import { OakFlex, OakIcon, OakP } from "@oaknational/oak-components";
 const FormValidationWarning = ({ errorMessage }: { errorMessage: string }) => {
   return (
     <OakFlex $flexDirection="row" $gap="spacing-4" $alignItems="center">
-      <OakIcon iconName="warning" iconWidth="spacing-40" $colorFilter="red" />
+      <OakIcon
+        iconName="warning"
+        iconWidth="spacing-40"
+        $colorFilter="icon-error"
+      />
       <OakP $font="body-2" $color="icon-error">
         {errorMessage}
       </OakP>

--- a/apps/nextjs/src/components/AppComponents/LessonAdapt/AdaptChatSidebar.tsx
+++ b/apps/nextjs/src/components/AppComponents/LessonAdapt/AdaptChatSidebar.tsx
@@ -63,14 +63,16 @@ export function AdaptChatSidebar() {
         {messages.map((message) => (
           <OakBox
             key={message.id}
-            $background={message.role === "user" ? "black" : "bg-neutral"}
+            $background={message.role === "user" ? "bg-inverted" : "bg-neutral"}
             $pa="spacing-12"
             $borderRadius="border-radius-m"
             className={message.role === "assistant" ? "max-w-[320px]" : ""}
           >
             <OakP
               $font="body-3"
-              $color={message.role === "user" ? "white" : "text-primary"}
+              $color={
+                message.role === "user" ? "text-inverted" : "text-primary"
+              }
               style={{ whiteSpace: "pre-wrap" }}
             >
               {message.content}

--- a/apps/nextjs/src/components/AppComponents/LessonAdapt/AdaptLessonContent.tsx
+++ b/apps/nextjs/src/components/AppComponents/LessonAdapt/AdaptLessonContent.tsx
@@ -92,7 +92,7 @@ export function AdaptLessonContent({
       </OakBox>
 
       {/* Tabs section */}
-      <OakBox $background="white" $pa="spacing-24" $pb="spacing-24">
+      <OakBox $background="bg-primary" $pa="spacing-24" $pb="spacing-24">
         <OakFlex $gap="spacing-12" $flexWrap="wrap">
           {tabs.map((tab) => (
             <button
@@ -113,7 +113,7 @@ export function AdaptLessonContent({
       {/* Content section */}
       <OakBox
         $height={"100%"}
-        $background="white"
+        $background="bg-primary"
         $pa="spacing-24"
         $pb="spacing-24"
       >

--- a/apps/nextjs/src/components/AppComponents/LessonAdapt/AdaptLessonContent.tsx
+++ b/apps/nextjs/src/components/AppComponents/LessonAdapt/AdaptLessonContent.tsx
@@ -7,13 +7,11 @@ import {
   OakFlex,
   OakHeading,
   OakP,
-  OakPrimaryButton,
 } from "@oaknational/oak-components";
 
 import { LessonDetailsTab } from "./LessonDetailsTab";
 import { type SlideKlpMapping, ThumbnailsWithKlpTab } from "./ReviewModal";
 import { SlidesTab } from "./SlidesTab";
-import { ThumbnailsTab } from "./ThumbnailsTab";
 
 interface LessonData {
   keyStage: string;
@@ -57,8 +55,6 @@ export function AdaptLessonContent({
   presentationUrl,
   lessonData,
   thumbnails,
-  thumbnailsLoading = false,
-  thumbnailsError = null,
   slideKlpMappings,
 }: AdaptLessonContentProps) {
   const [activeTab, setActiveTab] = useState<string>("Lesson details");

--- a/apps/nextjs/src/components/AppComponents/LessonAdapt/AdaptLessonContent.tsx
+++ b/apps/nextjs/src/components/AppComponents/LessonAdapt/AdaptLessonContent.tsx
@@ -2,12 +2,7 @@
 
 import { useState } from "react";
 
-import {
-  OakBox,
-  OakFlex,
-  OakHeading,
-  OakP,
-} from "@oaknational/oak-components";
+import { OakBox, OakFlex, OakHeading, OakP } from "@oaknational/oak-components";
 
 import { LessonDetailsTab } from "./LessonDetailsTab";
 import { type SlideKlpMapping, ThumbnailsWithKlpTab } from "./ReviewModal";

--- a/apps/nextjs/src/components/AppComponents/LessonAdapt/ReviewModal/ReviewModal.tsx
+++ b/apps/nextjs/src/components/AppComponents/LessonAdapt/ReviewModal/ReviewModal.tsx
@@ -56,7 +56,7 @@ export function ReviewModal({
 
       {/* Modal */}
       <OakBox
-        $background="white"
+        $background="bg-primary"
         $borderRadius="border-radius-m"
         className="relative z-10 flex h-[90vh] w-[90vw] max-w-6xl flex-col overflow-hidden shadow-xl"
       >

--- a/apps/nextjs/src/components/AppComponents/LessonAdapt/ReviewModal/ThumbnailsWithKlpTab.tsx
+++ b/apps/nextjs/src/components/AppComponents/LessonAdapt/ReviewModal/ThumbnailsWithKlpTab.tsx
@@ -129,7 +129,7 @@ export function ThumbnailsWithKlpTab({
                           $borderRadius="border-radius-circle"
                           className="mt-1 flex h-5 w-5 flex-shrink-0 items-center justify-center"
                         >
-                          <OakP $font="body-4" $color="white">
+                          <OakP $font="body-4" $color="text-inverted">
                             {index + 1}
                           </OakP>
                         </OakBox>
@@ -154,7 +154,7 @@ export function ThumbnailsWithKlpTab({
                           $borderRadius="border-radius-circle"
                           className="mt-1 flex h-5 w-5 flex-shrink-0 items-center justify-center"
                         >
-                          <OakP $font="body-4" $color="white">
+                          <OakP $font="body-4" $color="text-inverted">
                             {index + 1}
                           </OakP>
                         </OakBox>
@@ -187,7 +187,7 @@ export function ThumbnailsWithKlpTab({
                   $pa="spacing-8"
                   $borderRadius="border-radius-s"
                 >
-                  <OakP $font="body-3-bold" $color="white">
+                  <OakP $font="body-3-bold" $color="text-inverted">
                     ✓ Covers Diversity Content
                   </OakP>
                 </OakBox>

--- a/apps/nextjs/src/components/AppComponents/Moderation/LockingModerationModalContent.tsx
+++ b/apps/nextjs/src/components/AppComponents/Moderation/LockingModerationModalContent.tsx
@@ -74,7 +74,7 @@ export function LockingModerationModalContent({
             $height={"spacing-120"}
             charLimit={500}
             initialValue={comment}
-            onTextAreaChange={setComment}
+            onChange={(e) => setComment(e.target.value)}
             placeholder="Your feedback"
           />
         )}

--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/index.tsx
@@ -44,7 +44,7 @@ export const QuizSection = ({ quizSection, quizType }: QuizSectionProps) => {
         $borderRadius="border-radius-s"
       >
         <OakFlex $gap="spacing-4" $alignItems="flex-start">
-          <OakIcon $colorFilter="black" iconName="info" alt="" />
+          <OakIcon $colorFilter="icon-primary" iconName="info" alt="" />
           <OakP $font="body-3">
             We weren&apos;t able to generate {quizLabel} for this lesson —
             Oak&apos;s question bank didn&apos;t have {reason}. You can ask me

--- a/apps/nextjs/src/components/AppComponents/TeachingMaterials/StepLayouts/StepFour.tsx
+++ b/apps/nextjs/src/components/AppComponents/TeachingMaterials/StepLayouts/StepFour.tsx
@@ -348,7 +348,7 @@ const StepFour = ({ handleRefineMaterial }: StepFourProps) => {
                         <OakIcon
                           iconName="download"
                           iconWidth="spacing-32"
-                          $colorFilter={"white"}
+                          $colorFilter={"icon-inverted"}
                           data-testid="download-icon-button"
                         />
                       )}

--- a/apps/nextjs/src/components/Header.tsx
+++ b/apps/nextjs/src/components/Header.tsx
@@ -84,7 +84,7 @@ const Header = ({ menuOpen, setMenuOpen, page }: Readonly<HeaderProps>) => {
 
           <div className="h-22 py-8">
             <HamburgerButton onClick={() => setMenuOpen(!menuOpen)}>
-              <OakIcon $colorFilter={"black"} iconName="hamburger" />
+              <OakIcon $colorFilter={"icon-primary"} iconName="hamburger" />
             </HamburgerButton>
           </div>
         </OakFlex>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,8 +146,8 @@ importers:
         specifier: '*'
         version: link:../../packages/teaching-materials
       '@oaknational/oak-components':
-        specifier: ^2.13.1
-        version: 2.13.1(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11)
+        specifier: ^2.13.3
+        version: 2.13.3(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11)
       '@oaknational/oak-consent-client':
         specifier: ^2.1.0
         version: 2.1.0(react-dom@19.2.1)(react@19.2.1)(zod@3.25.76)
@@ -6382,8 +6382,8 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  /@oaknational/oak-components@2.13.1(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11):
-    resolution: {integrity: sha512-J6tLTyCTo/ecrPxHUKMjLbykDmoGoIS6aqNoLV+HS6oB70PWnbkrNcE0OBxQiNgc4ZPb5OoUwQrJXU7k0lAcfQ==}
+  /@oaknational/oak-components@2.13.3(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11):
+    resolution: {integrity: sha512-Bl/XLvb2R8NLdNIe0q+cyI6pPfx8ecok7qT7RibytLtxJdxV1bVy8V0SzGJMugONR/KyZ4nq47nci4FrPzwuDA==}
     peerDependencies:
       next: '>=14.2.12'
       next-cloudinary: '>=6.16.0'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,8 +146,8 @@ importers:
         specifier: '*'
         version: link:../../packages/teaching-materials
       '@oaknational/oak-components':
-        specifier: ^2.13.3
-        version: 2.13.3(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11)
+        specifier: ^2.14.0
+        version: 2.14.0(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11)
       '@oaknational/oak-consent-client':
         specifier: ^2.1.0
         version: 2.1.0(react-dom@19.2.1)(react@19.2.1)(zod@3.25.76)
@@ -6382,8 +6382,8 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  /@oaknational/oak-components@2.13.3(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11):
-    resolution: {integrity: sha512-Bl/XLvb2R8NLdNIe0q+cyI6pPfx8ecok7qT7RibytLtxJdxV1bVy8V0SzGJMugONR/KyZ4nq47nci4FrPzwuDA==}
+  /@oaknational/oak-components@2.14.0(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11):
+    resolution: {integrity: sha512-lLw6mmA8YjNYFdwU9HRn7lkWJ3A37jfjCDKMw0eQaCAOava+Q5Xujo1ZTQh2e+y3kTbuuL92cUYjG+Fg34TcPA==}
     peerDependencies:
       next: '>=14.2.12'
       next-cloudinary: '>=6.16.0'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,8 +146,8 @@ importers:
         specifier: '*'
         version: link:../../packages/teaching-materials
       '@oaknational/oak-components':
-        specifier: ^1.174.1
-        version: 1.174.1(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11)
+        specifier: ^2.13.1
+        version: 2.13.1(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11)
       '@oaknational/oak-consent-client':
         specifier: ^2.1.0
         version: 2.1.0(react-dom@19.2.1)(react@19.2.1)(zod@3.25.76)
@@ -989,73 +989,6 @@ importers:
       typescript:
         specifier: 5.9.2
         version: 5.9.2
-
-  packages/ingest:
-    dependencies:
-      '@google-cloud/storage':
-        specifier: ^7.7.0
-        version: 7.7.0
-      '@oakai/aila':
-        specifier: '*'
-        version: link:../aila
-      '@oakai/core':
-        specifier: '*'
-        version: link:../core
-      '@oakai/db':
-        specifier: '*'
-        version: link:../db
-      '@oakai/logger':
-        specifier: '*'
-        version: link:../logger
-      '@oakai/rag':
-        specifier: '*'
-        version: link:../rag
-      '@paralleldrive/cuid2':
-        specifier: ^2.2.2
-        version: 2.2.2
-      '@types/yargs':
-        specifier: ^17.0.33
-        version: 17.0.33
-      csv-parser:
-        specifier: ^3.0.0
-        version: 3.0.0
-      graphql-request:
-        specifier: ^6.1.0
-        version: 6.1.0(graphql@16.12.0)
-      tsx:
-        specifier: ^4.16.0
-        version: 4.16.0
-      webvtt-parser:
-        specifier: ^2.2.0
-        version: 2.2.0
-      yargs:
-        specifier: ^17.7.2
-        version: 17.7.2
-      zod:
-        specifier: 3.25.76
-        version: 3.25.76
-    devDependencies:
-      '@oakai/eslint-config':
-        specifier: '*'
-        version: link:../eslint-config
-      '@oakai/prettier-config':
-        specifier: '*'
-        version: link:../prettier-config
-      '@types/jest':
-        specifier: ^30.0.0
-        version: 30.0.0
-      '@types/webvtt-parser':
-        specifier: ^2.2.0
-        version: 2.2.0
-      jest:
-        specifier: ^30.0.0
-        version: 30.2.0(@types/node@20.17.9)(ts-node@10.9.2)
-      setup-polly-jest:
-        specifier: ^0.11.0
-        version: 0.11.0(@pollyjs/core@6.0.6)
-      ts-jest:
-        specifier: ^29.2.5
-        version: 29.2.5(@babel/core@7.28.5)(jest@30.2.0)(typescript@5.9.2)
 
   packages/lesson-adapters:
     dependencies:
@@ -6431,11 +6364,6 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@noble/hashes@1.7.0:
-    resolution: {integrity: sha512-HXydb0DgzTpDPwbVeDGCG1gIu7X6+AuU6Zl6av/E/KG8LMsvPntvq+w17CHRpKBmN6Ybdrt1eP3k4cj8DJa78w==}
-    engines: {node: ^14.21.3 || >=16}
-    dev: false
-
   /@nodelib/fs.scandir@2.1.5:
     resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
     engines: {node: '>= 8'}
@@ -6454,8 +6382,8 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  /@oaknational/oak-components@1.174.1(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11):
-    resolution: {integrity: sha512-Y3bxugFKGiORcdaxVfUGL0pUEyizecnd/S3yj3pjClVs9XXPGFB1UzCnOmgvMqBr7sXTMPzetLUexTO/V0smgA==}
+  /@oaknational/oak-components@2.13.1(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11):
+    resolution: {integrity: sha512-J6tLTyCTo/ecrPxHUKMjLbykDmoGoIS6aqNoLV+HS6oB70PWnbkrNcE0OBxQiNgc4ZPb5OoUwQrJXU7k0lAcfQ==}
     peerDependencies:
       next: '>=14.2.12'
       next-cloudinary: '>=6.16.0'
@@ -7819,12 +7747,6 @@ packages:
     dependencies:
       '@opentelemetry/api': 1.9.0
       '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-    dev: false
-
-  /@paralleldrive/cuid2@2.2.2:
-    resolution: {integrity: sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==}
-    dependencies:
-      '@noble/hashes': 1.7.0
     dev: false
 
   /@pkgjs/parseargs@0.11.0:
@@ -11733,10 +11655,6 @@ packages:
   /@types/uuid@9.0.3:
     resolution: {integrity: sha512-taHQQH/3ZyI3zP8M/puluDEIEvtQHVYcC6y3N8ijFtAd28+Ey/G4sg1u2gB01S8MwybLOKAp9/yCMu/uR5l3Ug==}
     dev: false
-
-  /@types/webvtt-parser@2.2.0:
-    resolution: {integrity: sha512-T8n08m3VWAOCVDHWPOtEehnLcVSyQaUmyjIvGCERWRPMyVooUjqWaDsvKD3bcwQSU8TLBW19YTSRx9UxBNfckA==}
-    dev: true
 
   /@types/yargs-parser@21.0.3:
     resolution: {integrity: sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==}


### PR DESCRIPTION
## Description

- Updated `@oaknational/oak-components` to `^2.13.3`
- Added a fix to the component library for a bug where closing the cookie settings modal caused the viewport to jump to the footer section
- Also had to update a few colour tokens to align with new colour token values

## Issue(s)

Fixes #[AI-393]()

## How to test

1. Go to https://oak-ai-lesson-assistant-website-870mwy3s9.vercel.thenational.academy
2. As a new user, click "Cookie settings" on the cookie banner
3. In the modal, click "Allow all" or "Confirm my choices"
4. The modal should close and the viewport should remain where it was — it should not jump to the footer
5. Also verify that clicking "Accept all cookies" directly on the banner still works as before

Test in various browsers (Safari was never affected).

### Colour token changes

The component library update required me to update colour token values in the following places: 

1. `FormValidationWarning.tsx`
    - Check any form validation warning icons appear in red

2. `AdaptChatSidebar.tsx`
    - Check the chat sidebar has a black background in its active/dark state
    - Check text on the dark background is white
    - Check the neutral state still shows the correct lighter background

3. `AdaptLessonContent.tsx`
    - Check the lesson content areas have a white background

4. `ReviewModal/ReviewModal.tsx`
    - Check the review modal has a white background

5. `ReviewModal/ThumbnailsWithKlpTab.tsx`
    - Check KLP numbers, learning cycle numbers, and diversity badges display white text
   on their coloured backgrounds

6. `Chat/lesson-plan-section/index.tsx`
    - Check lesson plan dropdown sections have a black bottom border

7. `SectionContent/QuizSection/index.tsx`
    - Check quiz section icons are black

8. `TeachingMaterials/StepLayouts/StepFour.tsx`
    - Check icons in step four are white (on dark backgrounds)

9. `TeachingMaterials/TeachingMaterialMessage.tsx`
    - Check teaching material message icons are black

10. `Header.tsx`: 
    - Check the header icon is black

**General approach**:

- Compare each screen agains prod
- There shouldnt be any visual differences – flag if anything has changed

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [X] Manually tested across browsers / devices
- [X] Considered impact on accessibility
- [X] Does this PR update a package with a breaking change