### PR TITLE
fix: handle agentic threat detection before generation init

### DIFF
--- a/packages/aila/src/core/Aila.test.ts
+++ b/packages/aila/src/core/Aila.test.ts
@@ -3,8 +3,12 @@ import type { Polly } from "@pollyjs/core";
 import { setupPolly } from "../../tests/mocks/setupPolly";
 import type { AilaCategorisation } from "../features/categorisation";
 import { MockCategoriser } from "../features/categorisation/categorisers/MockCategoriser";
+import { MockThreatDetector } from "../features/threatDetection/detectors/MockThreatDetector";
+import { AilaThreatDetectionError } from "../features/threatDetection/types";
+import * as threatDetectionHandling from "../utils/threatDetection/threatDetectionHandling";
 import { Aila } from "./Aila";
 import { AilaAuthenticationError } from "./AilaError";
+import type { AilaChat } from "./chat/AilaChat";
 import { MockLLMService } from "./llm/MockLLMService";
 
 describe("Aila", () => {
@@ -341,6 +345,67 @@ describe("Aila", () => {
       expect(ailaInstance.document.content.subject).toBeDefined();
       expect(ailaInstance.document.content.keyStage).toBeDefined();
     }, 20000);
+  });
+
+  describe("agentic threat detection", () => {
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it("handles a threat before generation is initialised", async () => {
+      const handledThreatMessage = {
+        type: "error" as const,
+        value: "Threat detected",
+        message: "Threat was detected",
+      };
+
+      const handleThreatDetectionErrorSpy = jest
+        .spyOn(threatDetectionHandling, "handleThreatDetectionError")
+        .mockResolvedValue(handledThreatMessage);
+
+      const ailaInstance = new Aila({
+        document: {
+          content: {},
+        },
+        chat: { id: "123", userId: "user123" },
+        options: {
+          usePersistence: false,
+          useRag: false,
+          useAnalytics: false,
+          useModeration: false,
+          useAgenticAila: true,
+        },
+        plugins: [],
+        services: {
+          chatLlmService: new MockLLMService(),
+          threatDetectors: () => [new MockThreatDetector({ response: true })],
+        },
+      });
+
+      await ailaInstance.initialise();
+
+      const enqueueSpy = jest
+        .spyOn(ailaInstance.chat as AilaChat, "enqueue")
+        .mockResolvedValue(undefined);
+
+      const stream = await ailaInstance.generate({
+        input: "Trigger threat detection",
+      });
+      const reader = stream.getReader();
+
+      await expect(reader.read()).resolves.toEqual({
+        done: true,
+        value: undefined,
+      });
+
+      expect(handleThreatDetectionErrorSpy).toHaveBeenCalledWith({
+        userId: "user123",
+        chatId: "123",
+        error: expect.any(AilaThreatDetectionError),
+        messages: ailaInstance.chat.messages,
+      });
+      expect(enqueueSpy).toHaveBeenCalledWith(handledThreatMessage);
+    });
   });
 
   describe("shutdown", () => {

--- a/packages/aila/src/core/chat/AilaChat.test.ts
+++ b/packages/aila/src/core/chat/AilaChat.test.ts
@@ -64,7 +64,8 @@ describe("AilaChat.generationFailed", () => {
       } as never,
     });
 
-    await expect(chat.generationFailed(new Error("Unexpected failure"))).rejects
-      .toThrow("Generation not initialised");
+    await expect(
+      chat.generationFailed(new Error("Unexpected failure")),
+    ).rejects.toThrow("Generation not initialised");
   });
 });

--- a/packages/aila/src/core/chat/AilaChat.test.ts
+++ b/packages/aila/src/core/chat/AilaChat.test.ts
@@ -1,0 +1,70 @@
+import { AilaThreatDetectionError } from "../../features/threatDetection";
+import * as threatDetectionHandling from "../../utils/threatDetection/threatDetectionHandling";
+import { AilaChat } from "./AilaChat";
+
+describe("AilaChat.generationFailed", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("handles threat detection errors before generation is initialised", async () => {
+    const chat = new AilaChat({
+      id: "chat_123",
+      userId: "user_123",
+      messages: [
+        {
+          id: "msg_1",
+          role: "user",
+          content: "test prompt",
+        },
+      ],
+      aila: {
+        options: {
+          quizSources: [],
+          useAgenticAila: true,
+        },
+      } as never,
+    });
+
+    const handledThreatMessage = {
+      type: "error" as const,
+      value: "Threat detected",
+      message: "Threat was detected",
+    };
+
+    const handleThreatDetectionErrorSpy = jest
+      .spyOn(threatDetectionHandling, "handleThreatDetectionError")
+      .mockResolvedValue(handledThreatMessage);
+    const enqueueSpy = jest.spyOn(chat, "enqueue").mockResolvedValue();
+
+    await expect(
+      chat.generationFailed(
+        new AilaThreatDetectionError("user_123", "Potential threat detected"),
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(handleThreatDetectionErrorSpy).toHaveBeenCalledWith({
+      userId: "user_123",
+      chatId: "chat_123",
+      error: expect.any(AilaThreatDetectionError),
+      messages: chat.messages,
+    });
+    expect(enqueueSpy).toHaveBeenCalledWith(handledThreatMessage);
+  });
+
+  it("still requires generation for non-threat errors", async () => {
+    const chat = new AilaChat({
+      id: "chat_123",
+      userId: "user_123",
+      aila: {
+        options: {
+          quizSources: [],
+          useAgenticAila: true,
+        },
+      } as never,
+    });
+
+    await expect(chat.generationFailed(new Error("Unexpected failure"))).rejects
+      .toThrow("Generation not initialised");
+  });
+});

--- a/packages/aila/src/core/chat/AilaChat.ts
+++ b/packages/aila/src/core/chat/AilaChat.ts
@@ -160,7 +160,6 @@ export class AilaChat implements AilaChatService {
 
   public async generationFailed(error: unknown) {
     log.info("Marking generation as failed", { error });
-    invariant(this._generation, "Generation not initialised");
     this.aila.errorReporter?.reportError(
       error,
       "Error reading from the OpenAI stream",
@@ -175,9 +174,10 @@ export class AilaChat implements AilaChatService {
       });
       await this.enqueue(errorObject);
     } else if (error instanceof Error) {
+      invariant(this._generation, "Generation not initialised");
       await this.enqueueError({ message: error.message });
     }
-    if (!this._aila.options.useAgenticAila) {
+    if (!this._aila.options.useAgenticAila && this._generation) {
       await this.persistGeneration("FAILED");
       log.info("Generation marked as failed");
     }


### PR DESCRIPTION
## Description

In agentic mode, Aila was not correctly handling detected threats on first prompt due to the order in which generation was initialised and errors were handled.

This patch:

- Fixes agentic Aila threat handling so a detected threat can be processed before generation has been initialised
- Adds test coverage for the agentic first-prompt threat path
- Adds test coverage for AilaChat.generationFailed() when handling threat vs non-threat errors

## Issue(s)

Fixes #AI-2078

## How to test

1. Open Aila chat with agentic Aila enabled
2. Send a prompt that is detected as a threat
3. You should see the normal threat-detected UI response instead of a hanging UI (in the console this hanging UI would register as an internal "Generation not initialised" failure and the UI would not be updated)