### PR TITLE
fix: update example lesson key stage from 3 to 2 (AI-2093)

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-start.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-start.tsx
@@ -28,9 +28,9 @@ const log = aiLogger("chat");
 
 export const exampleMessages = [
   {
-    heading: "History • Key stage 3 • The end of Roman Britain ",
+    heading: "History • Key stage 2 • The end of Roman Britain ",
     message:
-      "Create a lesson plan about the end of Roman Britain for key stage 3 history",
+      "Create a lesson plan about the end of Roman Britain for key stage 2 history",
   },
 ];
 

--- a/apps/nextjs/src/stores/lessonPlanTrackingStore/__tests__/fixtures.ts
+++ b/apps/nextjs/src/stores/lessonPlanTrackingStore/__tests__/fixtures.ts
@@ -6,7 +6,7 @@ export const messages = {
   user1RomansExample: {
     role: "user",
     content:
-      "Create a lesson plan about the end of Roman Britain for key stage 3 history",
+      "Create a lesson plan about the end of Roman Britain for key stage 2 history",
   },
   user1Inappropriate: {
     role: "User",

--- a/apps/nextjs/src/stores/lessonPlanTrackingStore/__tests__/tracking.test.ts
+++ b/apps/nextjs/src/stores/lessonPlanTrackingStore/__tests__/tracking.test.ts
@@ -65,7 +65,7 @@ describe("lessonPlanTracking tracking", () => {
       const actions = store.getState().actions;
 
       actions.clickedStart(
-        "Create a lesson plan about the end of Roman Britain for key stage 3 history",
+        "Create a lesson plan about the end of Roman Britain for key stage 2 history",
       );
 
       chatStoreMock.getState.mockReturnValue({
@@ -79,7 +79,7 @@ describe("lessonPlanTracking tracking", () => {
 
       expect(createArgs.track.lessonPlanInitiated).toHaveBeenCalledWith({
         componentType: "example_lesson_button",
-        text: "Create a lesson plan about the end of Roman Britain for key stage 3 history",
+        text: "Create a lesson plan about the end of Roman Britain for key stage 2 history",
         moderatedContentType: null,
         ...ragTrackingFields,
         ...commonTrackingFields,


### PR DESCRIPTION
## Summary
- The example prompt on the chat start screen ("The end of Roman Britain") is meant to demonstrate RAG-based lesson generation, where Aila finds relevant Oak lessons and offers them as a basis
- This content has moved from KS3 to KS2 in the Oak curriculum, so the current example returns no RAG results — the user sees no lessons to base theirs on
- Updated the example to KS2 to match where the content now lives

## Test plan
- [x] Click the example on the chat start screen
- [x] Confirm Aila finds relevant Oak lessons and offers them as options