### PR TITLE
feat: add production domain to Terraform Vercel project

### DIFF
--- a/infrastructure/project/main.tf
+++ b/infrastructure/project/main.tf
@@ -26,6 +26,5 @@ module "vercel" {
   production_branch                = "production"
   protection_bypass_for_automation = true
 
-  # TODO: Add ["labs.thenational.academy"] after migrating from old Vercel project
-  domains = []
+  domains = ["labs.thenational.academy"]
 }


### PR DESCRIPTION
## Summary
- Assigns `labs.thenational.academy` to the Terraform-managed Vercel project
- Follows up on #926
