### PR TITLE
fix: use environment-aware URL for Aila admin user Slack button

### DIFF
--- a/packages/core/src/functions/slack/getExternalFacingUrl.ts
+++ b/packages/core/src/functions/slack/getExternalFacingUrl.ts
@@ -7,5 +7,5 @@ export function getExternalFacingUrl() {
     return vercelProductionUrl;
   }
 
-  return vercelUrl;
+  return process.env.VERCEL_BRANCH_URL ?? vercelUrl;
 }

--- a/packages/core/src/utils/slack.ts
+++ b/packages/core/src/utils/slack.ts
@@ -148,7 +148,7 @@ export function actionsBlock({
             type: "plain_text",
             text: "Aila admin user",
           },
-          url: `https://labs.thenational.academy/admin/users/${userActionsProps.userId}`,
+          url: `https://${getExternalFacingUrl()}/admin/users/${userActionsProps.userId}`,
         },
       ]
     : [];


### PR DESCRIPTION
- Replace hardcoded `labs.thenational.academy` URL in the "Aila admin user" Slack button with `getExternalFacingUrl()`, so the button links to the correct environment (staging/preview/production) matching the deployment that sent the alert

## Issue(s)

Fixes #[AI-2110](https://www.notion.so/oaknationalacademy/Aila-Admin-User-Button-33426cc4e1b1804b89c8cc18b321a140?v=25a2c14c253b4ef6acb73443a0b36a9d&source=copy_link)

## How to test

1. Deploy to a staging/preview environment
2. Trigger a Slack notification (e.g. threat detection or moderation event)
3. In the `#ai-dev-user-events` Slack channel, click the "Aila admin user" button
4. You should see the link points to the staging/preview URL rather than `labs.thenational.academy`

## Screenshots

How it used to look (delete if n/a):
{screenshots}

How it should now look:
{screenshots}

## Checklist

- [x] Manually tested across browsers / devices
- [ ] ~~Considered impact on accessibility~~
- [ ] ~~Does this PR update a package with a breaking change~~