### PR TITLE
feat: check banned status on login AI-2113

### DIFF
--- a/apps/nextjs/src/app/api/check-ban/rate-limit.ts
+++ b/apps/nextjs/src/app/api/check-ban/rate-limit.ts
@@ -1,0 +1,13 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { kv } from "@vercel/kv";
+
+const rateLimiter = new Ratelimit({
+  redis: kv,
+  prefix: "rateLimit:checkBan",
+  limiter: Ratelimit.fixedWindow(5, "60 s"),
+});
+
+export async function checkRateLimit(ip: string): Promise<boolean> {
+  const { success } = await rateLimiter.limit(ip);
+  return success;
+}

--- a/apps/nextjs/src/app/api/check-ban/route.test.ts
+++ b/apps/nextjs/src/app/api/check-ban/route.test.ts
@@ -1,4 +1,4 @@
-import { NextResponse } from "next/server";
+import { clerkClient } from "@clerk/nextjs/server";
 
 import { checkRateLimit } from "./rate-limit";
 import { POST } from "./route";
@@ -10,6 +10,7 @@ const mockCheckRateLimit = jest.mocked(checkRateLimit);
 jest.mock("@clerk/nextjs/server");
 
 const mockGetUserList = jest.fn();
+const mockClerkClient = jest.mocked(clerkClient);
 
 jest.mock("@sentry/node", () => ({
   captureException: jest.fn(),
@@ -33,12 +34,11 @@ describe("POST /api/check-ban", () => {
     jest.clearAllMocks();
     mockLimit.mockResolvedValue(true);
 
-    const { clerkClient } = require("@clerk/nextjs/server");
-    jest.mocked(clerkClient).mockResolvedValue({
+    mockClerkClient.mockResolvedValue({
       users: {
         getUserList: mockGetUserList,
       },
-    });
+    } as unknown as Awaited<ReturnType<typeof clerkClient>>);
 
     mockGetUserList.mockResolvedValue({ data: [] });
   });

--- a/apps/nextjs/src/app/api/check-ban/route.test.ts
+++ b/apps/nextjs/src/app/api/check-ban/route.test.ts
@@ -1,0 +1,161 @@
+import { NextResponse } from "next/server";
+
+import { checkRateLimit } from "./rate-limit";
+import { POST } from "./route";
+
+jest.mock("./rate-limit");
+
+const mockCheckRateLimit = jest.mocked(checkRateLimit);
+
+jest.mock("@clerk/nextjs/server");
+
+const mockGetUserList = jest.fn();
+
+jest.mock("@sentry/node", () => ({
+  captureException: jest.fn(),
+}));
+
+const mockLimit = mockCheckRateLimit;
+
+function createRequest(
+  body: unknown,
+  headers: Record<string, string> = {},
+): Request {
+  return new Request("http://localhost/api/check-ban", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...headers },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/check-ban", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockLimit.mockResolvedValue(true);
+
+    const { clerkClient } = require("@clerk/nextjs/server");
+    jest.mocked(clerkClient).mockResolvedValue({
+      users: {
+        getUserList: mockGetUserList,
+      },
+    });
+
+    mockGetUserList.mockResolvedValue({ data: [] });
+  });
+
+  it("returns 429 when rate limited", async () => {
+    mockLimit.mockResolvedValue(false);
+
+    const res = await POST(
+      createRequest(
+        { email: "test@example.com" },
+        { "x-forwarded-for": "1.2.3.4" },
+      ),
+    );
+
+    expect(res.status).toBe(429);
+    expect(await res.json()).toEqual({ error: "Too many requests" });
+  });
+
+  it("returns 400 when email is missing", async () => {
+    const res = await POST(createRequest({}));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Email is required" });
+  });
+
+  it("returns 400 when email is not a string", async () => {
+    const res = await POST(createRequest({ email: 123 }));
+
+    expect(res.status).toBe(400);
+    expect(await res.json()).toEqual({ error: "Email is required" });
+  });
+
+  it("returns banned: true when user is banned", async () => {
+    mockGetUserList.mockResolvedValue({
+      data: [{ banned: true }],
+    });
+
+    const res = await POST(
+      createRequest(
+        { email: "banned@example.com" },
+
+        { "x-forwarded-for": "1.2.3.4" },
+      ),
+    );
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ banned: true });
+    expect(mockGetUserList).toHaveBeenCalledWith({
+      emailAddress: ["banned@example.com"],
+      limit: 1,
+    });
+  });
+
+  it("returns banned: false when user is not banned", async () => {
+    mockGetUserList.mockResolvedValue({
+      data: [{ banned: false }],
+    });
+
+    const res = await POST(createRequest({ email: "good@example.com" }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ banned: false });
+  });
+
+  it("returns banned: false when user is not found", async () => {
+    mockGetUserList.mockResolvedValue({ data: [] });
+
+    const res = await POST(createRequest({ email: "unknown@example.com" }));
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ banned: false });
+  });
+
+  it("returns 500 when Clerk throws", async () => {
+    mockGetUserList.mockRejectedValue(new Error("Clerk unavailable"));
+
+    const res = await POST(createRequest({ email: "test@example.com" }));
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toEqual({ error: "Failed to check ban status" });
+
+    const Sentry = await import("@sentry/node");
+    expect(Sentry.captureException).toHaveBeenCalled();
+  });
+
+  it("skips rate limiting when no IP header is present", async () => {
+    mockGetUserList.mockResolvedValue({ data: [{ banned: false }] });
+
+    const res = await POST(createRequest({ email: "test@example.com" }));
+
+    expect(mockLimit).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+  });
+
+  it("extracts IP from x-forwarded-for with multiple values", async () => {
+    mockGetUserList.mockResolvedValue({ data: [{ banned: false }] });
+
+    await POST(
+      createRequest(
+        { email: "test@example.com" },
+        { "x-forwarded-for": "10.0.0.1, 10.0.0.2" },
+      ),
+    );
+
+    expect(mockLimit).toHaveBeenCalledWith("10.0.0.1");
+  });
+
+  it("falls back to x-real-ip header", async () => {
+    mockGetUserList.mockResolvedValue({ data: [{ banned: false }] });
+
+    await POST(
+      createRequest(
+        { email: "test@example.com" },
+        { "x-real-ip": "192.168.1.1" },
+      ),
+    );
+
+    expect(mockLimit).toHaveBeenCalledWith("192.168.1.1");
+  });
+});

--- a/apps/nextjs/src/app/api/check-ban/route.ts
+++ b/apps/nextjs/src/app/api/check-ban/route.ts
@@ -1,0 +1,48 @@
+import { clerkClient } from "@clerk/nextjs/server";
+import * as Sentry from "@sentry/node";
+import { Ratelimit } from "@upstash/ratelimit";
+import { kv } from "@vercel/kv";
+import { NextResponse } from "next/server";
+
+const rateLimiter = new Ratelimit({
+  redis: kv,
+  prefix: "rateLimit:checkBan",
+  limiter: Ratelimit.fixedWindow(5, "60 s"),
+});
+
+export async function POST(req: Request) {
+  const ip =
+    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
+  const { success } = await rateLimiter.limit(ip);
+
+  if (!success) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
+  const { email } = await req.json();
+
+  if (!email || typeof email !== "string") {
+    return NextResponse.json({ error: "Email is required" }, { status: 400 });
+  }
+
+  try {
+    const client = await clerkClient();
+    const users = await client.users.getUserList({
+      emailAddress: [email],
+    });
+
+    const user = users.data[0];
+
+    if (user?.banned) {
+      return NextResponse.json({ banned: true });
+    }
+
+    return NextResponse.json({ banned: false });
+  } catch (err) {
+    Sentry.captureException(err);
+    return NextResponse.json(
+      { error: "Failed to check ban status" },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/nextjs/src/app/api/check-ban/route.ts
+++ b/apps/nextjs/src/app/api/check-ban/route.ts
@@ -1,34 +1,55 @@
 import { clerkClient } from "@clerk/nextjs/server";
 import * as Sentry from "@sentry/node";
-import { Ratelimit } from "@upstash/ratelimit";
-import { kv } from "@vercel/kv";
 import { NextResponse } from "next/server";
 
-const rateLimiter = new Ratelimit({
-  redis: kv,
-  prefix: "rateLimit:checkBan",
-  limiter: Ratelimit.fixedWindow(5, "60 s"),
-});
+import { checkRateLimit } from "./rate-limit";
 
+function getClientIp(req: Request): string | null {
+  const headerValue =
+    req.headers.get("x-forwarded-for") ??
+    req.headers.get("x-real-ip") ??
+    req.headers.get("cf-connecting-ip") ??
+    req.headers.get("true-client-ip");
+  const ip = headerValue?.split(",")[0]?.trim();
+  return ip && ip.length > 0 ? ip : null;
+}
 export async function POST(req: Request) {
-  const ip =
-    req.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ?? "unknown";
-  const { success } = await rateLimiter.limit(ip);
+  const ip = getClientIp(req);
 
-  if (!success) {
-    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  if (ip !== null) {
+    const allowed = await checkRateLimit(ip);
+
+    if (!allowed) {
+      return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+    }
   }
 
-  const { email } = await req.json();
-
-  if (!email || typeof email !== "string") {
-    return NextResponse.json({ error: "Email is required" }, { status: 400 });
+  let email: unknown;
+  try {
+    const body = await req.json();
+    if (typeof body !== "object" || body === null || Array.isArray(body)) {
+      return NextResponse.json(
+        { error: "Invalid JSON payload" },
+        { status: 400 },
+      );
+    }
+    email = (body as { email?: unknown }).email;
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid JSON payload" },
+      { status: 400 },
+    );
   }
 
   try {
+    if (!email || typeof email !== "string") {
+      return NextResponse.json({ error: "Email is required" }, { status: 400 });
+    }
     const client = await clerkClient();
+
     const users = await client.users.getUserList({
       emailAddress: [email],
+      limit: 1,
     });
 
     const user = users.data[0];

--- a/apps/nextjs/src/app/sign-in/[[...sign-in]]/DetectEmailLinkBannedUser.tsx
+++ b/apps/nextjs/src/app/sign-in/[[...sign-in]]/DetectEmailLinkBannedUser.tsx
@@ -4,14 +4,13 @@ import { useEffect, useRef } from "react";
 
 import { aiLogger } from "@oakai/logger";
 
-import { useClerk, useSignIn } from "@clerk/nextjs";
+import { useSignIn } from "@clerk/nextjs";
 import * as Sentry from "@sentry/nextjs";
 
 const log = aiLogger("auth");
 
 const DetectEmailLinkBannedUser = () => {
   const clerkSignIn = useSignIn();
-  const clerk = useClerk();
 
   const hasBanChecked = useRef(false);
 

--- a/apps/nextjs/src/app/sign-in/[[...sign-in]]/DetectEmailLinkBannedUser.tsx
+++ b/apps/nextjs/src/app/sign-in/[[...sign-in]]/DetectEmailLinkBannedUser.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+
+import { aiLogger } from "@oakai/logger";
+
+import { useSignIn } from "@clerk/nextjs";
+import * as Sentry from "@sentry/nextjs";
+
+const log = aiLogger("auth");
+
+const DetectEmailLinkBannedUser = () => {
+  const clerkSignIn = useSignIn();
+  const hasBanChecked = useRef(false);
+
+  useEffect(() => {
+    if (!clerkSignIn.isLoaded || hasBanChecked.current) return;
+
+    const signIn = clerkSignIn.signIn;
+    const firstFactor = signIn?.firstFactorVerification;
+
+    const checkBanStatus = async () => {
+      try {
+        const res = await fetch("/api/check-ban", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ email: signIn.identifier }),
+        });
+        const data = await res.json();
+
+        if (data.banned) {
+          signIn.create({});
+          window.location.href = "/legal/account-locked";
+        }
+      } catch (err) {
+        log.error("Failed to check ban status", err);
+        Sentry.captureException(err);
+      }
+    };
+
+    if (
+      firstFactor?.status === "unverified" &&
+      firstFactor?.strategy === "email_link" &&
+      signIn?.identifier
+    ) {
+      hasBanChecked.current = true;
+      checkBanStatus();
+    }
+  }, [clerkSignIn.isLoaded, clerkSignIn.signIn]);
+
+  return null;
+};
+
+export default DetectEmailLinkBannedUser;

--- a/apps/nextjs/src/app/sign-in/[[...sign-in]]/DetectEmailLinkBannedUser.tsx
+++ b/apps/nextjs/src/app/sign-in/[[...sign-in]]/DetectEmailLinkBannedUser.tsx
@@ -26,10 +26,10 @@ const DetectEmailLinkBannedUser = () => {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ email: signIn.identifier }),
         });
-        const data = await res.json();
+        const data: { banned: boolean } = await res.json();
 
         if (data.banned) {
-          signIn.create({});
+          await signIn.create({});
           window.location.href = "/legal/account-locked";
         }
       } catch (err) {
@@ -44,7 +44,7 @@ const DetectEmailLinkBannedUser = () => {
       signIn?.identifier
     ) {
       hasBanChecked.current = true;
-      checkBanStatus();
+      void checkBanStatus();
     }
   }, [clerkSignIn.isLoaded, clerkSignIn.signIn]);
 

--- a/apps/nextjs/src/app/sign-in/[[...sign-in]]/DetectEmailLinkBannedUser.tsx
+++ b/apps/nextjs/src/app/sign-in/[[...sign-in]]/DetectEmailLinkBannedUser.tsx
@@ -4,13 +4,16 @@ import { useEffect, useRef } from "react";
 
 import { aiLogger } from "@oakai/logger";
 
-import { useSignIn } from "@clerk/nextjs";
+import { useClerk, useSignIn } from "@clerk/nextjs";
 import * as Sentry from "@sentry/nextjs";
 
 const log = aiLogger("auth");
 
 const DetectEmailLinkBannedUser = () => {
   const clerkSignIn = useSignIn();
+  const clerk = useClerk();
+  const client = clerk.client;
+
   const hasBanChecked = useRef(false);
 
   useEffect(() => {
@@ -26,10 +29,19 @@ const DetectEmailLinkBannedUser = () => {
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify({ email: signIn.identifier }),
         });
+
+        if (!res.ok) {
+          const errorData = await res.json().catch(() => ({}));
+          throw new Error(`Ban check failed with status ${res.status}`, {
+            cause: errorData,
+          });
+        }
+
         const data: { banned: boolean } = await res.json();
 
         if (data.banned) {
           await signIn.create({});
+
           window.location.href = "/legal/account-locked";
         }
       } catch (err) {
@@ -43,8 +55,8 @@ const DetectEmailLinkBannedUser = () => {
       firstFactor?.strategy === "email_link" &&
       signIn?.identifier
     ) {
-      hasBanChecked.current = true;
       void checkBanStatus();
+      hasBanChecked.current = true;
     }
   }, [clerkSignIn.isLoaded, clerkSignIn.signIn]);
 

--- a/apps/nextjs/src/app/sign-in/[[...sign-in]]/DetectEmailLinkBannedUser.tsx
+++ b/apps/nextjs/src/app/sign-in/[[...sign-in]]/DetectEmailLinkBannedUser.tsx
@@ -12,7 +12,6 @@ const log = aiLogger("auth");
 const DetectEmailLinkBannedUser = () => {
   const clerkSignIn = useSignIn();
   const clerk = useClerk();
-  const client = clerk.client;
 
   const hasBanChecked = useRef(false);
 

--- a/apps/nextjs/src/app/sign-in/[[...sign-in]]/page.tsx
+++ b/apps/nextjs/src/app/sign-in/[[...sign-in]]/page.tsx
@@ -7,6 +7,7 @@ import { useRouter } from "next/navigation";
 
 import SignUpSignInLayout from "@/components/SignUpSignInLayout";
 
+import DetectEmailLinkBannedUser from "./DetectEmailLinkBannedUser";
 import DetectStuckBannedUser from "./DetectStuckBannedUser";
 
 const SignInPage = () => {
@@ -20,8 +21,8 @@ const SignInPage = () => {
           <RedirectToHome />
         </SignedIn>
       </SignUpSignInLayout>
-
       <DetectStuckBannedUser />
+      <DetectEmailLinkBannedUser />
     </>
   );
 };

--- a/apps/nextjs/src/middlewares/auth.middleware.ts
+++ b/apps/nextjs/src/middlewares/auth.middleware.ts
@@ -54,6 +54,7 @@ const publicRoutes = [
   "/sign-up(.*)",
   "/api/webhooks/clerk",
   "/api/fetch-owa-lesson",
+  "/api/check-ban",
 ];
 if (
   process.env.NODE_ENV === "development" ||


### PR DESCRIPTION
## Description

 Summary

  - Added detection for banned users attempting to sign in via email magic link — previously they
  just saw a generic "verification link expired" message
  - Created new /api/check-ban API route that looks up a user by email via Clerk and returns ban
  status
  - Created new DetectEmailLinkBannedUser component that checks ban status when an email link sign-in
   shows as "unverified", and redirects to /legal/account-locked if banned
  - Clears stale Clerk sign-in state after detecting a banned user so the next person on the same
  machine gets a clean form

  Details

  - API route is rate limited (5 req/60s per IP via Upstash) to prevent abuse
  - Route added to publicRoutes in auth middleware since the user isn't authenticated at this point
  - Sentry reporting 

  Test 

  - Sign in with a banned user's email via magic link — should redirect to /legal/account-locked
  - Sign in with a non-banned user's email via magic link — should proceed normally
  - Revisit /sign-in after a banned user redirect — should show clean sign-in form (no re-redirect)
  - Sign in via Google OAuth as a banned user — existing DetectStuckBannedUser still works



## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
