### PR TITLE
feat: add new moderation banner to share page

### DIFF
--- a/apps/nextjs/src/app/aila/lesson/[id]/share/index.tsx
+++ b/apps/nextjs/src/app/aila/lesson/[id]/share/index.tsx
@@ -3,13 +3,16 @@
 import { useEffect, useState } from "react";
 
 import type { PartialLessonPlan } from "@oakai/aila/src/protocol/schema";
+import { parseKeyStage } from "@oakai/core/src/data/parseKeyStage";
 import type { PersistedModerationBase } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
+
+import { getDisplayCategories } from "@oakai/core/src/utils/ailaModeration/severityLevel";
 
 import { OakSmallPrimaryButton } from "@oaknational/oak-components";
 import * as Sentry from "@sentry/react";
 import Link from "next/link";
 
-import { GuidanceRequired } from "@/components/AppComponents/Chat/guidance-required";
+import { ContentGuidanceBanner } from "@/components/AppComponents/Moderation/ContentGuidanceBanner";
 import StaticLessonPlanRenderer from "@/components/AppComponents/static-lesson-plan-renderer";
 import { Icon } from "@/components/Icon";
 import { Logo } from "@/components/Logo";
@@ -38,64 +41,70 @@ export default function ShareChat({
   }, [userHasCopiedLink, setUserHasCopiedLink]);
 
   const keyStageSubjectTuple = [
-    slugToSentenceCase(lessonPlan.keyStage ?? ""),
+    slugToSentenceCase(parseKeyStage(lessonPlan.keyStage ?? "")),
     slugToSentenceCase(lessonPlan.subject ?? ""),
   ].filter(Boolean);
 
   return (
     <div className="flex-1">
-      <div
-        data-testid="share-banner"
-        className="bg-lavender50 px-9 py-14 text-sm lg:px-24"
-      >
-        Created {!!creatorsName && "by " + creatorsName} with{" "}
-        <Link href="/" className="bv-3 text-hyperlink underline">
-          Aila, Oak’s AI lesson assistant
-        </Link>
-        {". "}
-        Please check content carefully before use.
-      </div>
-      <div className="flex items-start justify-between bg-lavender30 px-9 py-9 lg:px-24">
-        <Logo />
-      </div>
-      <div className="flex items-center bg-lavender30 px-9 py-18 pb-32 md:px-14">
-        <div className="absolute hidden h-38 w-38 items-center justify-center rounded-lg xl:left-24 xl:flex">
-          <Icon
-            className="flex items-center justify-center"
-            icon="ai-lesson"
-            size="3xl"
-            color="black"
-          />
+      <div data-testid="share-banner" className="bg-lavender50 px-9">
+        <div className="mx-auto max-w-2xl py-14 text-sm min-[835px]:max-w-[80rem] min-[835px]:px-27">
+          Created {!!creatorsName && "by " + creatorsName} with{" "}
+          <Link href="/" className="bv-3 text-hyperlink underline">
+            Aila, Oak&apos;s AI lesson assistant
+          </Link>
+          {". "}
+          Please check content carefully before use.
         </div>
-        <div className="mx-auto flex h-24 w-full max-w-2xl flex-col items-start justify-center lg:h-32 xl:h-38">
-          <h2
-            data-testid="key-stage-subject"
-            className="mb-10 pt-36 text-base font-medium sm:mt-0"
-          >
-            {keyStageSubjectTuple.join(" • ")}
-          </h2>
-          <h1 className="text-3xl font-bold">{lessonPlan.title}</h1>
-          <div className="mt-10 pb-30">
-            <OakSmallPrimaryButton
-              data-testid="copy-link"
-              onClick={() => {
-                void navigator.clipboard
-                  .writeText(window.location.href)
-                  .then(() => {
-                    setUserHasCopiedLink(true);
-                  })
-                  .catch((e) => {
-                    Sentry.captureException(e);
-                  });
-              }}
-            >
-              {userHasCopiedLink ? " Link copied" : "Copy link"}
-            </OakSmallPrimaryButton>
+      </div>
+      <div className="bg-lavender30 px-9">
+        <div className="mx-auto max-w-2xl min-[835px]:max-w-[80rem] min-[835px]:px-27">
+          <div className="py-9">
+            <Logo />
+          </div>
+          <div className="relative pb-24 pt-18">
+            <div className="absolute left-1 top-14 hidden items-center justify-center py-14 xl:flex">
+              <Icon
+                className="flex items-center justify-center"
+                icon="ai-lesson"
+                size="3xl"
+                color="black"
+              />
+            </div>
+            <div className="mx-auto flex max-w-2xl flex-col items-start gap-14">
+              <h2
+                data-testid="key-stage-subject"
+                className="text-base font-medium"
+              >
+                {keyStageSubjectTuple.join(" • ")}
+              </h2>
+              <h1 className="text-3xl font-bold">{lessonPlan.title}</h1>
+              <OakSmallPrimaryButton
+                data-testid="copy-link"
+                onClick={() => {
+                  void navigator.clipboard
+                    .writeText(window.location.href)
+                    .then(() => {
+                      setUserHasCopiedLink(true);
+                    })
+                    .catch((e) => {
+                      Sentry.captureException(e);
+                    });
+                }}
+              >
+                {userHasCopiedLink ? " Link copied" : "Copy link"}
+              </OakSmallPrimaryButton>
+            </div>
           </div>
         </div>
       </div>
-      <div className="mx-auto max-w-2xl px-9 py-14 pb-30 sm:px-0">
-        {moderation && <GuidanceRequired moderation={moderation} />}
+      <div className="px-9 py-14 pb-30">
+        <div className="mx-auto max-w-2xl">
+        {moderation && (
+          <ContentGuidanceBanner
+            categories={getDisplayCategories(moderation)}
+          />
+        )}
         <div
           data-testid="lesson-plan-markdown"
           className="mb-14 border-b pb-14"
@@ -103,6 +112,7 @@ export default function ShareChat({
           <OakMathJaxContext>
             <StaticLessonPlanRenderer lessonPlan={lessonPlan} />
           </OakMathJaxContext>
+        </div>
         </div>
       </div>
     </div>

--- a/apps/nextjs/src/app/aila/lesson/[id]/share/index.tsx
+++ b/apps/nextjs/src/app/aila/lesson/[id]/share/index.tsx
@@ -5,7 +5,6 @@ import { useEffect, useState } from "react";
 import type { PartialLessonPlan } from "@oakai/aila/src/protocol/schema";
 import { parseKeyStage } from "@oakai/core/src/data/parseKeyStage";
 import type { PersistedModerationBase } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
-
 import { getDisplayCategories } from "@oakai/core/src/utils/ailaModeration/severityLevel";
 
 import { OakSmallPrimaryButton } from "@oaknational/oak-components";
@@ -100,19 +99,19 @@ export default function ShareChat({
       </div>
       <div className="px-9 py-14 pb-30">
         <div className="mx-auto max-w-2xl">
-        {moderation && (
-          <ContentGuidanceBanner
-            categories={getDisplayCategories(moderation)}
-          />
-        )}
-        <div
-          data-testid="lesson-plan-markdown"
-          className="mb-14 border-b pb-14"
-        >
-          <OakMathJaxContext>
-            <StaticLessonPlanRenderer lessonPlan={lessonPlan} />
-          </OakMathJaxContext>
-        </div>
+          {moderation && (
+            <ContentGuidanceBanner
+              categories={getDisplayCategories(moderation)}
+            />
+          )}
+          <div
+            data-testid="lesson-plan-markdown"
+            className="mb-14 border-b pb-14"
+          >
+            <OakMathJaxContext>
+              <StaticLessonPlanRenderer lessonPlan={lessonPlan} />
+            </OakMathJaxContext>
+          </div>
         </div>
       </div>
     </div>

--- a/apps/nextjs/src/app/aila/lesson/[id]/share/page.tsx
+++ b/apps/nextjs/src/app/aila/lesson/[id]/share/page.tsx
@@ -64,19 +64,30 @@ export default async function SharePage({ params }: Readonly<SharePageProps>) {
     return notFound();
   }
 
-  const lastModeration = moderations[moderations.length - 1];
-
   /**
    * We don't want to expose the whole persisted moderation object, as it contains
    * both the justification, which isn't used, and the userComment which is a user
    * input and should not be exposed to the client.
+   *
+   * Unlike the chat (where each message shows its own moderation), the share
+   * page aggregates distinct categories across all session moderations to
+   * give a summary view of the lesson's content guidance.
    */
-  const moderation: PersistedModerationBase | null = lastModeration
-    ? {
-        id: lastModeration.id,
-        categories: lastModeration.categories,
-      }
-    : null;
+  const allCategories = [
+    ...new Set(
+      moderations
+        .flatMap((m) => m.categories)
+        .filter((c): c is string => typeof c === "string"),
+    ),
+  ];
+
+  const moderation: PersistedModerationBase | null =
+    allCategories.length > 0
+      ? {
+          id: moderations[0]!.id,
+          categories: allCategories,
+        }
+      : null;
 
   return (
     <ShareChat

--- a/apps/nextjs/src/components/AppComponents/Moderation/ContentGuidanceBanner.tsx
+++ b/apps/nextjs/src/components/AppComponents/Moderation/ContentGuidanceBanner.tsx
@@ -17,7 +17,7 @@ const severityDisplay: Record<
   "content-guidance": {
     bannerText:
       "The content in this lesson may require additional consideration before delivery.",
-    linkText: "View content guidance.",
+    linkText: "View content guidance",
   },
   "enhanced-scrutiny": {
     bannerText: "This lesson includes content that requires enhanced scrutiny.",

--- a/apps/nextjs/src/components/AppComponents/Moderation/ContentGuidanceModalContent.tsx
+++ b/apps/nextjs/src/components/AppComponents/Moderation/ContentGuidanceModalContent.tsx
@@ -27,9 +27,7 @@ export function ContentGuidanceModalContent({
         <OakBox key={category.shortDescription} $font="body-2">
           <OakP $font="body-2">
             <OakSpan $font="body-2-bold">
-              {"References "}
-              {category.shortDescription.charAt(0).toLowerCase() +
-                category.shortDescription.slice(1)}
+              {category.shortDescription}
               {": "}
             </OakSpan>{" "}
             {category.longDescription}

--- a/apps/nextjs/src/components/AppComponents/Moderation/ContentGuidanceModalContent.tsx
+++ b/apps/nextjs/src/components/AppComponents/Moderation/ContentGuidanceModalContent.tsx
@@ -28,7 +28,8 @@ export function ContentGuidanceModalContent({
           <OakP $font="body-2">
             <OakSpan $font="body-2-bold">
               {"References "}
-              {category.shortDescription.charAt(0).toLowerCase() + category.shortDescription.slice(1)}
+              {category.shortDescription.charAt(0).toLowerCase() +
+                category.shortDescription.slice(1)}
               {": "}
             </OakSpan>{" "}
             {category.longDescription}

--- a/apps/nextjs/src/components/AppComponents/Moderation/ContentGuidanceModalContent.tsx
+++ b/apps/nextjs/src/components/AppComponents/Moderation/ContentGuidanceModalContent.tsx
@@ -27,23 +27,25 @@ export function ContentGuidanceModalContent({
         <OakBox key={category.shortDescription} $font="body-2">
           <OakP $font="body-2">
             <OakSpan $font="body-2-bold">
-              {category.shortDescription}
+              {"References "}
+              {category.shortDescription.charAt(0).toLowerCase() + category.shortDescription.slice(1)}
               {": "}
             </OakSpan>{" "}
             {category.longDescription}
           </OakP>
         </OakBox>
       ))}
-      <OakSecondaryLink
-        element="a"
-        href="https://support.thenational.academy/ailas-safety-guardrails"
-        target="_blank"
-        rel="noopener noreferrer"
-        iconName="external"
-        isTrailingIcon
-      >
-        Learn more about Aila&apos;s safety guardrails.
-      </OakSecondaryLink>
+      <OakP $font="body-2">
+        Please check content carefully. Learn more about{" "}
+        <OakSecondaryLink
+          element="a"
+          href="https://support.thenational.academy/ailas-safety-guardrails"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Aila&apos;s safety guardrails.
+        </OakSecondaryLink>
+      </OakP>
       <OakPrimaryButton onClick={onClose}>Continue</OakPrimaryButton>
     </>
   );
@@ -61,16 +63,21 @@ export function ContentGuidanceModal({
   onClose,
 }: ContentGuidanceModalProps) {
   return (
-    <OakModalCenter isOpen={open} onClose={onClose}>
-      <OakIcon iconName={"info"} $width="spacing-48" $height="spacing-48" />
+    <OakModalCenter
+      isOpen={open}
+      onClose={onClose}
+      modalInnerFlexProps={{ $ph: "spacing-80", $pb: "spacing-56" }}
+    >
       <OakFlex
-        $pb="spacing-56"
         $width="100%"
         $flexDirection="column"
-        $alignItems="flex-start "
+        $alignItems="flex-start"
         $justifyContent="center"
         $gap={"spacing-32"}
       >
+        <OakBox className="hidden md:block">
+          <OakIcon iconName={"info"} $width="spacing-48" $height="spacing-48" />
+        </OakBox>
         <OakHeading $font={["heading-5", "heading-5", "heading-4"]} tag="h1">
           {"Content guidance"}
         </OakHeading>


### PR DESCRIPTION
## Description

- Replaced `GuidanceRequired` with reused `ContentGuidanceBanner` on share page
- Aggregated distinct moderation categories across all session messages
- Updated content guidance modal copy, padding, and hide icon on mobile
- Fix body/header left-alignment
## Issue(s)

Fixes #[AI-2105](https://www.notion.so/oaknationalacademy/Add-new-moderation-banner-to-share-page-32f26cc4e1b180e0b8d9e1a467aba1c5?v=25a2c14c253b4ef6acb73443a0b36a9d&source=copy_link)

## How to test

1. Go to https://oak-ai-lesson-assistant-website-7g3lxfu4p.vercel.thenational.academy/aila/lesson/{id}/share for a lesson with moderation flags
2. Verify content guidance banner appears and "View content guidance" opens modal
3. Ensure the correct moderation categories appear in the modal when it is opened
4. Visit a lesson without flags, there should be no banner shown

## Screenshots

How it used to look (delete if n/a):
<img width="1070" height="640" alt="image" src="https://github.com/user-attachments/assets/6b47f3e7-f1db-4391-a790-f9bb02fa7039" />

How it should now look:
<img width="753" height="377" alt="image" src="https://github.com/user-attachments/assets/1b9eb102-05b5-441f-8da3-0150a5a65862" />
<img width="731" height="548" alt="image" src="https://github.com/user-attachments/assets/585a1a3e-0c89-4c82-9211-2ab4d2821fa1" />

## Checklist

- [X] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] ~~Does this PR update a package with a breaking change~~
