### PR TITLE
fix: silent error in set up chat handler - AI-2124

### DIFF
--- a/apps/nextjs/src/app/api/chat/chatHandler.ts
+++ b/apps/nextjs/src/app/api/chat/chatHandler.ts
@@ -343,22 +343,23 @@ export async function handleChatPostRequest(
   config: Config,
 ): Promise<Response> {
   return await startSpan("chat-api", {}, async (span: TracingSpan) => {
-    const {
-      chatId,
-      messages: frontendMessages,
-      options,
-      llmService,
-      moderationAiClient,
-      oakModerator,
-      threatDetectors,
-    } = await setupChatHandler(req);
-    span.setAttributes({ chat_id: chatId });
-
-    let userId: string | undefined;
+    let chatId = "unknown";
     let aila: Aila | undefined;
-
+    let userId: string | undefined;
     try {
+      const {
+        chatId: resolvedChatId,
+        messages: frontendMessages,
+        options,
+        llmService,
+        moderationAiClient,
+        oakModerator,
+        threatDetectors,
+      } = await setupChatHandler(req);
+
+      let chatId = resolvedChatId;
       userId = await fetchAndCheckUser(chatId);
+      span.setAttributes({ chat_id: chatId });
 
       const { messages: dbMessages, lessonPlan: dbLessonPlan } =
         await loadChatDataFromDatabase(chatId, userId);

--- a/apps/nextjs/src/app/api/chat/chatHandler.ts
+++ b/apps/nextjs/src/app/api/chat/chatHandler.ts
@@ -357,7 +357,7 @@ export async function handleChatPostRequest(
         threatDetectors,
       } = await setupChatHandler(req);
 
-      let chatId = resolvedChatId;
+      chatId = resolvedChatId;
       userId = await fetchAndCheckUser(chatId);
       span.setAttributes({ chat_id: chatId });
 

--- a/apps/nextjs/src/app/api/chat/errorHandling.test.ts
+++ b/apps/nextjs/src/app/api/chat/errorHandling.test.ts
@@ -96,6 +96,31 @@ describe("handleChatException", () => {
     });
   });
 
+  describe("generic Error", () => {
+    it("should return a generic error message without leaking internal details", async () => {
+      const error = new Error("Missing environment variable OPENAI_API_KEY");
+      const prisma = {} as unknown as PrismaClientWithAccelerate;
+
+      const response = await handleChatException(error, "test-chat-id", prisma);
+
+      expect(response.status).toBe(200);
+
+      invariant(
+        response.body instanceof ReadableStream,
+        "Expected response.body to be a ReadableStream",
+      );
+
+      const consumed = await consumeStream(response.body);
+      const message = extractStreamMessage(consumed);
+
+      expect(message).toEqual({
+        type: "error",
+        message: "An unexpected error occurred",
+        value: "Sorry, an unexpected error occurred. Please try again later.",
+      });
+    });
+  });
+
   describe("UserBannedError", () => {
     it("should return an error chat message", async () => {
       const _span = { setTag: jest.fn() } as unknown as TracingSpan;

--- a/apps/nextjs/src/app/api/chat/errorHandling.ts
+++ b/apps/nextjs/src/app/api/chat/errorHandling.ts
@@ -8,10 +8,13 @@ import { handleThreatDetectionError } from "@oakai/aila/src/utils/threatDetectio
 import { UserBannedError } from "@oakai/core";
 import { RateLimitExceededError } from "@oakai/core/src/utils/rateLimiting/errors";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
+import { aiLogger } from "@oakai/logger";
 
 import * as Sentry from "@sentry/node";
 
 import { streamingJSON } from "./protocol";
+
+const log = aiLogger("chat");
 
 async function handleThreatError(
   e: AilaThreatDetectionError,
@@ -58,11 +61,12 @@ async function handleUserBannedError(): Promise<Response> {
 }
 
 async function handleGenericError(e: Error): Promise<Response> {
+  log.error("Unhandled chat error", e);
   return Promise.resolve(
     streamingJSON({
       type: "error",
-      message: e.message,
-      value: `Sorry, an error occurred: ${e.message}`,
+      message: "An unexpected error occurred",
+      value: "Sorry, an unexpected error occurred. Please try again later.",
     } as ErrorDocument),
   );
 }


### PR DESCRIPTION
## Description

- moves setupChatHandler into try catch
- changes generic error message so users don't see error logs from missing ENVS or other issues
- logs, any generic errors.

## Issue(s)

1. Go to https://oak-ai-lesson-assistant-website-nt3u0b0tq.vercel.thenational.academy
devs , remove env should see logged error
QA - Aila lesson works as expected

## Screenshots

<img width="525" height="221" alt="image" src="https://github.com/user-attachments/assets/52a07cca-3039-4bff-a32b-65a38ffb431b" />


## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
