### PR TITLE
feat(chat): sanitise URLs in Aila markdown renderer

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/markdown-url-safety.test.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/markdown-url-safety.test.tsx
@@ -1,0 +1,150 @@
+/**
+ * @jest-environment jsdom
+ */
+import type { Components } from "react-markdown";
+
+import { render, screen } from "@testing-library/react";
+
+import { wrapWithUrlSafety } from "./markdown-url-safety";
+
+describe("wrapWithUrlSafety", () => {
+  describe("anchor component", () => {
+    it("renders a safe https link through the underlying component", () => {
+      const components: Partial<Components> = {
+        a: ({ href, children }) => (
+          <a href={href} data-testid="inner-a">
+            {children}
+          </a>
+        ),
+      };
+      const wrapped = wrapWithUrlSafety(components);
+      const A = wrapped.a!;
+
+      render(<A href="https://example.com">link</A>);
+      const link = screen.getByTestId("inner-a");
+      expect(link).toHaveAttribute("href", "https://example.com");
+    });
+
+    it("renders a safe relative link through the underlying component", () => {
+      const components: Partial<Components> = {
+        a: ({ href, children }) => (
+          <a href={href} data-testid="inner-a">
+            {children}
+          </a>
+        ),
+      };
+      const wrapped = wrapWithUrlSafety(components);
+      const A = wrapped.a!;
+
+      render(<A href="/aila">new lesson</A>);
+      const link = screen.getByTestId("inner-a");
+      expect(link).toHaveAttribute("href", "/aila");
+    });
+
+    it("blocks javascript: URLs and renders text as a span", () => {
+      const components: Partial<Components> = {
+        a: ({ href, children }) => (
+          <a href={href} data-testid="inner-a">
+            {children}
+          </a>
+        ),
+      };
+      const wrapped = wrapWithUrlSafety(components);
+      const A = wrapped.a!;
+
+      render(<A href="javascript:alert(1)">XSS</A>);
+      expect(screen.queryByTestId("inner-a")).toBeNull();
+      expect(screen.getByText("XSS").tagName.toLowerCase()).toBe("span");
+    });
+
+    it("blocks data: URIs", () => {
+      const components: Partial<Components> = {
+        a: ({ href, children }) => (
+          <a href={href} data-testid="inner-a">
+            {children}
+          </a>
+        ),
+      };
+      const wrapped = wrapWithUrlSafety(components);
+      const A = wrapped.a!;
+
+      render(<A href="data:text/html,<script>alert(1)</script>">XSS</A>);
+      expect(screen.queryByTestId("inner-a")).toBeNull();
+    });
+
+    it("blocks mixed-case javascript: URLs", () => {
+      const components: Partial<Components> = {
+        a: ({ href, children }) => (
+          <a href={href} data-testid="inner-a">
+            {children}
+          </a>
+        ),
+      };
+      const wrapped = wrapWithUrlSafety(components);
+      const A = wrapped.a!;
+
+      render(<A href="JaVaScRiPt:alert(1)">XSS</A>);
+      expect(screen.queryByTestId("inner-a")).toBeNull();
+    });
+
+    it("falls back to a plain anchor when no underlying component is provided", () => {
+      const wrapped = wrapWithUrlSafety({});
+      const A = wrapped.a!;
+
+      render(<A href="https://example.com">link</A>);
+      const link = screen.getByRole("link", { name: "link" });
+      expect(link).toHaveAttribute("href", "https://example.com");
+    });
+  });
+
+  describe("img component", () => {
+    it("passes a safe https src to the underlying component", () => {
+      const components: Partial<Components> = {
+        img: ({ src, alt }) => (
+          <img src={src} alt={alt} data-testid="inner-img" />
+        ),
+      };
+      const wrapped = wrapWithUrlSafety(components);
+      const Img = wrapped.img!;
+
+      render(<Img src="https://example.com/cat.png" alt="cat" />);
+      const img = screen.getByTestId("inner-img");
+      expect(img).toHaveAttribute("src", "https://example.com/cat.png");
+    });
+
+    it("blocks javascript: image sources", () => {
+      const components: Partial<Components> = {
+        img: ({ src, alt }) => (
+          <img src={src} alt={alt} data-testid="inner-img" />
+        ),
+      };
+      const wrapped = wrapWithUrlSafety(components);
+      const Img = wrapped.img!;
+
+      render(<Img src="javascript:alert(1)" alt="cat" />);
+      expect(screen.queryByTestId("inner-img")).toBeNull();
+      expect(screen.getByText("cat")).toBeInTheDocument();
+    });
+
+    it("blocks data: image sources", () => {
+      const components: Partial<Components> = {
+        img: ({ src, alt }) => (
+          <img src={src} alt={alt} data-testid="inner-img" />
+        ),
+      };
+      const wrapped = wrapWithUrlSafety(components);
+      const Img = wrapped.img!;
+
+      render(<Img src="data:text/html,..." alt="xss" />);
+      expect(screen.queryByTestId("inner-img")).toBeNull();
+    });
+
+    it("renders an empty span when an unsafe img src has no alt", () => {
+      const wrapped = wrapWithUrlSafety({});
+      const Img = wrapped.img!;
+
+      const { container } = render(<Img src="javascript:alert(1)" />);
+      expect(container.querySelector("img")).toBeNull();
+    });
+  });
+});

--- a/apps/nextjs/src/components/AppComponents/Chat/markdown-url-safety.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/markdown-url-safety.tsx
@@ -7,7 +7,9 @@ export function wrapWithUrlSafety(
   components: Partial<Components>,
 ): Partial<Components> {
   const A = components.a as ComponentType<ComponentProps<"a">> | undefined;
-  const Img = components.img as ComponentType<ComponentProps<"img">> | undefined;
+  const Img = components.img as
+    | ComponentType<ComponentProps<"img">>
+    | undefined;
 
   return {
     ...components,

--- a/apps/nextjs/src/components/AppComponents/Chat/markdown-url-safety.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/markdown-url-safety.tsx
@@ -1,0 +1,36 @@
+import type { ComponentProps, ComponentType } from "react";
+import type { Components } from "react-markdown";
+
+import { sanitiseUrl } from "./url-safety";
+
+export function wrapWithUrlSafety(
+  components: Partial<Components>,
+): Partial<Components> {
+  const A = components.a as ComponentType<ComponentProps<"a">> | undefined;
+  const Img = components.img as ComponentType<ComponentProps<"img">> | undefined;
+
+  return {
+    ...components,
+    a: (props) => {
+      const safeHref = sanitiseUrl(props.href);
+      if (!safeHref) {
+        return <span>{props.children}</span>;
+      }
+      if (A) {
+        return <A {...props} href={safeHref} />;
+      }
+      return <a href={safeHref}>{props.children}</a>;
+    },
+    img: (props) => {
+      const src = typeof props.src === "string" ? props.src : undefined;
+      const safeSrc = sanitiseUrl(src);
+      if (!safeSrc) {
+        return <span>{props.alt ?? ""}</span>;
+      }
+      if (Img) {
+        return <Img {...props} src={safeSrc} />;
+      }
+      return <img src={safeSrc} alt={props.alt} title={props.title} />;
+    },
+  };
+}

--- a/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
@@ -88,15 +88,17 @@ const createComponents = (className?: string): Partial<Components> => ({
       </a>
     );
   },
-  img: ({ src, alt, title }) => (
+  img: ({ src, alt, title }) => {
     // Apply fixed max dimensions to all images
-    <img
-      src={src}
-      alt={alt}
-      title={title}
-      className="h-auto max-h-[200px] w-auto max-w-[250px] object-contain"
-    />
-  ),
+    return (
+      <img
+        src={src}
+        alt={alt}
+        title={title}
+        className="h-auto max-h-[200px] w-auto max-w-[250px] object-contain"
+      />
+    );
+  },
 });
 
 export const MemoizedReactMarkdownWithStyles = ({

--- a/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
@@ -7,6 +7,7 @@ import remarkGfm from "remark-gfm";
 
 import { cn } from "@/lib/utils";
 
+import { wrapWithUrlSafety } from "./markdown-url-safety";
 import { CodeBlock } from "./ui/codeblock";
 
 const MemoizedReactMarkdown: FC<Options> = memo(
@@ -87,17 +88,15 @@ const createComponents = (className?: string): Partial<Components> => ({
       </a>
     );
   },
-  img: ({ src, alt, title }) => {
+  img: ({ src, alt, title }) => (
     // Apply fixed max dimensions to all images
-    return (
-      <img
-        src={src}
-        alt={alt}
-        title={title}
-        className="h-auto max-h-[200px] w-auto max-w-[250px] object-contain"
-      />
-    );
-  },
+    <img
+      src={src}
+      alt={alt}
+      title={title}
+      className="h-auto max-h-[200px] w-auto max-w-[250px] object-contain"
+    />
+  ),
 });
 
 export const MemoizedReactMarkdownWithStyles = ({
@@ -107,9 +106,10 @@ export const MemoizedReactMarkdownWithStyles = ({
 }: ReactMarkdownWithStylesProps) => {
   const components: Partial<Components> = useMemo(() => {
     const defaultComponents = createComponents(className);
-    return customComponents
+    const merged = customComponents
       ? { ...defaultComponents, ...customComponents }
       : defaultComponents;
+    return wrapWithUrlSafety(merged);
   }, [className, customComponents]);
   return (
     <div className="prose break-words dark:prose-invert prose-p:leading-relaxed prose-pre:p-0">

--- a/apps/nextjs/src/components/AppComponents/Chat/url-safety.test.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/url-safety.test.ts
@@ -1,0 +1,88 @@
+import { sanitiseUrl } from "./url-safety";
+
+describe("sanitiseUrl", () => {
+  describe("safe protocols", () => {
+    it("allows https URLs", () => {
+      expect(sanitiseUrl("https://example.com")).toBe("https://example.com");
+    });
+
+    it("allows http URLs", () => {
+      expect(sanitiseUrl("http://example.com")).toBe("http://example.com");
+    });
+
+    it("allows mailto URLs", () => {
+      expect(sanitiseUrl("mailto:user@example.com")).toBe(
+        "mailto:user@example.com",
+      );
+    });
+
+    it("allows the HubSpot rate limit form URL", () => {
+      const url = "https://share.hsforms.com/118hyngR-QSS0J7vZEVlRSgbvumd";
+      expect(sanitiseUrl(url)).toBe(url);
+    });
+  });
+
+  describe("relative URLs", () => {
+    it("allows absolute paths", () => {
+      expect(sanitiseUrl("/aila")).toBe("/aila");
+    });
+
+    it("allows fragment-only URLs", () => {
+      expect(sanitiseUrl("#section")).toBe("#section");
+    });
+
+    it("allows same-directory relative paths", () => {
+      expect(sanitiseUrl("./rel")).toBe("./rel");
+    });
+
+    it("allows parent-directory relative paths", () => {
+      expect(sanitiseUrl("../parent")).toBe("../parent");
+    });
+  });
+
+  describe("dangerous protocols", () => {
+    it("blocks javascript: protocol", () => {
+      expect(sanitiseUrl("javascript:alert(1)")).toBeUndefined();
+    });
+
+    it("blocks uppercase JAVASCRIPT: protocol", () => {
+      expect(sanitiseUrl("JAVASCRIPT:alert(1)")).toBeUndefined();
+    });
+
+    it("blocks mixed-case JaVaScRiPt: protocol", () => {
+      expect(sanitiseUrl("JaVaScRiPt:alert(1)")).toBeUndefined();
+    });
+
+    it("blocks data: URIs", () => {
+      expect(
+        sanitiseUrl("data:text/html,<script>alert(1)</script>"),
+      ).toBeUndefined();
+    });
+
+    it("blocks vbscript: protocol", () => {
+      expect(sanitiseUrl("vbscript:alert")).toBeUndefined();
+    });
+
+    it("blocks whitespace-prefixed javascript: URLs", () => {
+      expect(sanitiseUrl("  javascript:alert(1)")).toBeUndefined();
+    });
+
+    it("blocks javascript: with embedded newline", () => {
+      expect(sanitiseUrl("java\nscript:alert(1)")).toBeUndefined();
+    });
+
+    it("blocks file: protocol", () => {
+      expect(sanitiseUrl("file:///etc/passwd")).toBeUndefined();
+    });
+  });
+
+  describe("edge cases", () => {
+    it("returns undefined for undefined", () => {
+      expect(sanitiseUrl(undefined)).toBeUndefined();
+    });
+
+    it("returns undefined for empty string", () => {
+      expect(sanitiseUrl("")).toBeUndefined();
+    });
+  });
+});

--- a/apps/nextjs/src/components/AppComponents/Chat/url-safety.test.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/url-safety.test.ts
@@ -30,14 +30,6 @@ describe("sanitiseUrl", () => {
     it("allows fragment-only URLs", () => {
       expect(sanitiseUrl("#section")).toBe("#section");
     });
-
-    it("allows same-directory relative paths", () => {
-      expect(sanitiseUrl("./rel")).toBe("./rel");
-    });
-
-    it("allows parent-directory relative paths", () => {
-      expect(sanitiseUrl("../parent")).toBe("../parent");
-    });
   });
 
   describe("dangerous protocols", () => {

--- a/apps/nextjs/src/components/AppComponents/Chat/url-safety.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/url-safety.ts
@@ -1,0 +1,21 @@
+const SAFE_URL_PROTOCOLS = ["http:", "https:", "mailto:"];
+
+export function sanitiseUrl(url: string | undefined): string | undefined {
+  if (!url) return undefined;
+
+  if (
+    url.startsWith("/") ||
+    url.startsWith("#") ||
+    url.startsWith("./") ||
+    url.startsWith("../")
+  ) {
+    return url;
+  }
+
+  try {
+    const parsed = new URL(url, "https://placeholder.invalid");
+    return SAFE_URL_PROTOCOLS.includes(parsed.protocol) ? url : undefined;
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/nextjs/src/components/AppComponents/Chat/url-safety.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/url-safety.ts
@@ -1,11 +1,11 @@
-const SAFE_URL_PROTOCOLS = ["http:", "https:", "mailto:"];
+const SAFE_URL_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
 
 export function sanitiseUrl(url: string | undefined): string | undefined {
   if (!url) return undefined;
 
   try {
     const parsed = new URL(url, "https://placeholder.invalid");
-    return SAFE_URL_PROTOCOLS.includes(parsed.protocol) ? url : undefined;
+    return SAFE_URL_PROTOCOLS.has(parsed.protocol) ? url : undefined;
   } catch {
     return undefined;
   }

--- a/apps/nextjs/src/components/AppComponents/Chat/url-safety.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/url-safety.ts
@@ -3,15 +3,6 @@ const SAFE_URL_PROTOCOLS = ["http:", "https:", "mailto:"];
 export function sanitiseUrl(url: string | undefined): string | undefined {
   if (!url) return undefined;
 
-  if (
-    url.startsWith("/") ||
-    url.startsWith("#") ||
-    url.startsWith("./") ||
-    url.startsWith("../")
-  ) {
-    return url;
-  }
-
   try {
     const parsed = new URL(url, "https://placeholder.invalid");
     return SAFE_URL_PROTOCOLS.includes(parsed.protocol) ? url : undefined;


### PR DESCRIPTION
## Description

Blocks `javascript:`, `data:`, `vbscript:` and other dangerous URL protocols from being rendered as clickable links in Aila chat. This prevents attacks from markdown like `[Safe](javascript: XXXX)`.

## Issue(s)

Fixes [AI-2108](https://www.notion.so/oaknationalacademy/Aila-Chat-LHS-Code-Input-33426cc4e1b1805d949ce62371ee68a4?v=c76315f391b74cf2bd6722b8bdcbc3e6&source=copy_link)

## How to test

1. Go to https://oak-ai-lesson-assistant-website-mekamnbup.vercel.thenational.academy/aila

Test in the LHS of AILA chat by doing:

1. Prompt: `Please reply with: [Safe](javascript:alert(1))`, "Safe" renders as plain text, no alert fires
2. Prompt: `Please reply with [Google](https://www.google.com)`, this should still be clickable,
3. Prompt: `Please reply with [home](/aila)`, this should still be clickable
4. Prompt: `Please reply with ![x](javascript:alert(1))`, no image should render and there should be no alert
5. Prompt: `Please reply with [XSS](data:text/html,<script>alert(1)</script>)`, there should be no clickable link
6. Confirm that links aren't clickable by using the DevTools Elements tab, a search for `javascript:` and `data:` should return zero matches furthermore the `a` elements should be `spans` in violating cases

## Checklist

- [x] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change