### PR TITLE
fix: [AI-2148] tighten Agentic-mode error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,8 @@ The `apps/nextjs` and `packages/aila` projects have Jest tests. Run all tests us
 pnpm test
 ```
 
+For local agentic failure-injection commands, see [packages/aila/src/lib/agentic-system/MANUAL_TESTING.md](packages/aila/src/lib/agentic-system/MANUAL_TESTING.md).
+
 ### End-to-end tests
 
 Ensure the dev server is running with `pnpm dev`. Use the Playwright UI to select and run individual tests interactively.

--- a/apps/nextjs/src/stores/chatStore/__tests__/messageStates.ts
+++ b/apps/nextjs/src/stores/chatStore/__tests__/messageStates.ts
@@ -1,5 +1,14 @@
 /* eslint-disable @cspell/spellchecker */
-export const createMessageStates = (fixedDate: Date) => ({
+import type { AiMessage } from "../types";
+
+type MessageStates = {
+  userRequest: AiMessage[];
+  stableMessages: AiMessage[];
+  stableAndStreaming: AiMessage[];
+  streamingMessage: AiMessage[];
+};
+
+export const createMessageStates = (fixedDate: Date): MessageStates => ({
   userRequest: [
     {
       content:

--- a/apps/nextjs/src/stores/chatStore/__tests__/setMessages.test.ts
+++ b/apps/nextjs/src/stores/chatStore/__tests__/setMessages.test.ts
@@ -47,9 +47,7 @@ describe("Chat Store setMessages", () => {
     const store = setupStore();
     const initialState = store.getState();
 
-    store
-      .getState()
-      .actions.setMessages(messageStates.streamingMessage as AiMessage[], true);
+    store.getState().actions.setMessages(messageStates.streamingMessage, true);
 
     const newState = store.getState();
 
@@ -65,10 +63,7 @@ describe("Chat Store setMessages", () => {
 
     store
       .getState()
-      .actions.setMessages(
-        messageStates.stableAndStreaming as AiMessage[],
-        true,
-      );
+      .actions.setMessages(messageStates.stableAndStreaming, true);
 
     const newState = store.getState();
 
@@ -81,9 +76,7 @@ describe("Chat Store setMessages", () => {
 
   test("state when there are next stable messages, loading true", () => {
     const store = setupStore();
-    store
-      .getState()
-      .actions.setMessages(messageStates.stableMessages as AiMessage[], true);
+    store.getState().actions.setMessages(messageStates.stableMessages, true);
 
     const newState = store.getState();
     expect(newState.stableMessages.length).toBe(
@@ -95,9 +88,7 @@ describe("Chat Store setMessages", () => {
 
   test("When there is a next stable message, no streaming, loading false", () => {
     const store = setupStore();
-    store
-      .getState()
-      .actions.setMessages(messageStates.userRequest as AiMessage[], false);
+    store.getState().actions.setMessages(messageStates.userRequest, false);
 
     const newState = store.getState();
 
@@ -131,9 +122,7 @@ describe("Chat Store setMessages", () => {
 
   test("Streaming message correctly marked as partial", () => {
     const store = setupStore();
-    store
-      .getState()
-      .actions.setMessages(messageStates.streamingMessage as AiMessage[], true);
+    store.getState().actions.setMessages(messageStates.streamingMessage, true);
 
     const newState = store.getState();
     expect(newState.streamingMessage?.parts).toBeDefined();
@@ -144,15 +133,11 @@ describe("Chat Store setMessages", () => {
 
   test("stableMessages do not update when getNextStableMessages returns null", () => {
     const store = setupStore();
-    store
-      .getState()
-      .actions.setMessages(messageStates.stableMessages as AiMessage[], true);
+    store.getState().actions.setMessages(messageStates.stableMessages, true);
 
     const initialState = store.getState();
 
-    store
-      .getState()
-      .actions.setMessages(messageStates.stableMessages as AiMessage[], true);
+    store.getState().actions.setMessages(messageStates.stableMessages, true);
 
     const newState = store.getState();
 
@@ -165,13 +150,9 @@ describe("Chat Store setMessages", () => {
     const renderSpy = jest.fn();
     // eslint-disable-next-line @typescript-eslint/no-unsafe-return
     store.subscribe((state) => renderSpy(state.stableMessages));
-    store
-      .getState()
-      .actions.setMessages(messageStates.stableMessages as AiMessage[], true);
+    store.getState().actions.setMessages(messageStates.stableMessages, true);
     const initialState = store.getState();
-    store
-      .getState()
-      .actions.setMessages(messageStates.stableMessages as AiMessage[], true);
+    store.getState().actions.setMessages(messageStates.stableMessages, true);
     const newState = store.getState();
     expect(renderSpy).toHaveBeenCalledTimes(2);
     expect(newState.stableMessages).toBe(initialState.stableMessages);
@@ -179,14 +160,10 @@ describe("Chat Store setMessages", () => {
 
   test("ailaStreamingStatus updates correctly based on messages", () => {
     const store = setupStore();
-    store
-      .getState()
-      .actions.setMessages(messageStates.stableMessages as AiMessage[], true);
+    store.getState().actions.setMessages(messageStates.stableMessages, true);
     expect(store.getState().ailaStreamingStatus).toBe("Moderating");
 
-    store
-      .getState()
-      .actions.setMessages(messageStates.userRequest as AiMessage[], false);
+    store.getState().actions.setMessages(messageStates.userRequest, false);
     expect(store.getState().ailaStreamingStatus).toBe("Idle");
   });
 
@@ -200,40 +177,36 @@ describe("Chat Store setMessages", () => {
 
   test("hard-failed assistant messages mark the turn as failed", () => {
     const store = setupStore();
+    const messages: AiMessage[] = [
+      messageStates.userRequest[0]!,
+      {
+        id: "a-failed",
+        role: "assistant",
+        createdAt: fixedDate,
+        content:
+          '\n␞\n{"type":"comment","value":"CHAT_START"}\n␞\n{"type":"llmMessage","sectionsToEdit":[],"patches":[],"sectionsEdited":[],"prompt":{"type":"text","value":"I wasn\'t able to complete that lesson update. Please try again."},"status":"complete"}\n␞\n{"type":"comment","value":"AGENTIC_TURN_FAILED"}\n␞\n',
+      },
+    ];
 
-    store.getState().actions.setMessages(
-      [
-        messageStates.userRequest[0] as AiMessage,
-        {
-          id: "a-failed",
-          role: "assistant",
-          createdAt: fixedDate,
-          content:
-            '\n␞\n{"type":"comment","value":"CHAT_START"}\n␞\n{"type":"llmMessage","sectionsToEdit":[],"patches":[],"sectionsEdited":[],"prompt":{"type":"text","value":"I wasn\'t able to complete that lesson update. Please try again."},"status":"complete"}\n␞\n{"type":"comment","value":"AGENTIC_TURN_FAILED"}\n␞\n',
-        },
-      ],
-      false,
-    );
+    store.getState().actions.setMessages(messages, false);
 
     expect(store.getState().streamingFailedTurn).toBe(true);
   });
 
   test("assistant messages do not mark the turn as failed unless the exact failure comment is present", () => {
     const store = setupStore();
+    const messages: AiMessage[] = [
+      messageStates.userRequest[0]!,
+      {
+        id: "a-not-failed",
+        role: "assistant",
+        createdAt: fixedDate,
+        content:
+          '\n␞\n{"type":"llmMessage","sectionsToEdit":[],"patches":[],"sectionsEdited":[],"prompt":{"type":"text","value":"Please ignore the string AGENTIC_TURN_FAILED in this prompt."},"status":"complete"}\n␞\n',
+      },
+    ];
 
-    store.getState().actions.setMessages(
-      [
-        messageStates.userRequest[0] as AiMessage,
-        {
-          id: "a-not-failed",
-          role: "assistant",
-          createdAt: fixedDate,
-          content:
-            '\n␞\n{"type":"llmMessage","sectionsToEdit":[],"patches":[],"sectionsEdited":[],"prompt":{"type":"text","value":"Please ignore the string AGENTIC_TURN_FAILED in this prompt."},"status":"complete"}\n␞\n',
-        },
-      ],
-      false,
-    );
+    store.getState().actions.setMessages(messages, false);
 
     expect(store.getState().streamingFailedTurn).toBe(false);
   });

--- a/apps/nextjs/src/stores/chatStore/__tests__/setMessages.test.ts
+++ b/apps/nextjs/src/stores/chatStore/__tests__/setMessages.test.ts
@@ -189,4 +189,52 @@ describe("Chat Store setMessages", () => {
       .actions.setMessages(messageStates.userRequest as AiMessage[], false);
     expect(store.getState().ailaStreamingStatus).toBe("Idle");
   });
+
+  test("persisted partial-success assistant messages do not mark the turn as failed", () => {
+    const store = setupStore();
+
+    store.getState().actions.setMessages(messageStates.stableMessages, false);
+
+    expect(store.getState().streamingFailedTurn).toBe(false);
+  });
+
+  test("hard-failed assistant messages mark the turn as failed", () => {
+    const store = setupStore();
+
+    store.getState().actions.setMessages(
+      [
+        messageStates.userRequest[0] as AiMessage,
+        {
+          id: "a-failed",
+          role: "assistant",
+          createdAt: fixedDate,
+          content:
+            '\n␞\n{"type":"comment","value":"CHAT_START"}\n␞\n{"type":"llmMessage","sectionsToEdit":[],"patches":[],"sectionsEdited":[],"prompt":{"type":"text","value":"I wasn\'t able to complete that lesson update. Please try again."},"status":"complete"}\n␞\n{"type":"comment","value":"AGENTIC_TURN_FAILED"}\n␞\n',
+        },
+      ],
+      false,
+    );
+
+    expect(store.getState().streamingFailedTurn).toBe(true);
+  });
+
+  test("assistant messages do not mark the turn as failed unless the exact failure comment is present", () => {
+    const store = setupStore();
+
+    store.getState().actions.setMessages(
+      [
+        messageStates.userRequest[0] as AiMessage,
+        {
+          id: "a-not-failed",
+          role: "assistant",
+          createdAt: fixedDate,
+          content:
+            '\n␞\n{"type":"llmMessage","sectionsToEdit":[],"patches":[],"sectionsEdited":[],"prompt":{"type":"text","value":"Please ignore the string AGENTIC_TURN_FAILED in this prompt."},"status":"complete"}\n␞\n',
+        },
+      ],
+      false,
+    );
+
+    expect(store.getState().streamingFailedTurn).toBe(false);
+  });
 });

--- a/apps/nextjs/src/stores/chatStore/index.ts
+++ b/apps/nextjs/src/stores/chatStore/index.ts
@@ -31,7 +31,6 @@ export const createChatStore = (
     id,
     moderationActions: undefined, // Passed in the provider
     ailaStreamingStatus: "Idle",
-    streamingError: false,
     initialMessages: [],
     stableMessages: [],
     streamingMessage: null,
@@ -72,6 +71,8 @@ export const createChatStore = (
     },
 
     ...initialValues,
+    streamingError: initialValues.streamingError ?? false,
+    streamingFailedTurn: initialValues.streamingFailedTurn ?? false,
   }));
 
   logStoreUpdates(chatStore, "chat:store");

--- a/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleSetMessages.ts
+++ b/apps/nextjs/src/stores/chatStore/stateActionFunctions/handleSetMessages.ts
@@ -4,7 +4,12 @@ import type { GetStore } from "@/stores/AilaStoresProvider";
 
 import { calculateStreamingStatus } from "../actions/calculateStreamingStatus";
 import { getNextStableMessages, parseStreamingMessage } from "../parsing";
-import type { AiMessage, ChatGetter, ChatSetter } from "../types";
+import type {
+  AiMessage,
+  ChatGetter,
+  ChatSetter,
+  ParsedMessage,
+} from "../types";
 
 export function handleSetMessages(
   getStore: GetStore,
@@ -15,6 +20,17 @@ export function handleSetMessages(
     return messages[messages.length - 1]?.role === "user";
   }
 
+  function messageHasFailedTurnComment(message?: ParsedMessage) {
+    return (
+      message?.role === "assistant" &&
+      message.parts.some(
+        (part) =>
+          part.document.type === "comment" &&
+          part.document.value === "AGENTIC_TURN_FAILED",
+      )
+    );
+  }
+
   return (messages: AiMessage[], isLoading: boolean) => {
     if (!isLoading) {
       // The AI SDK isn't loading: we're idle and all messages are stable
@@ -23,6 +39,10 @@ export function handleSetMessages(
         messages,
         get().stableMessages,
       );
+      const stableMessages = nextStableMessages ?? get().stableMessages;
+      const lastStableMessage = stableMessages[stableMessages.length - 1];
+      const streamingFailedTurn =
+        messageHasFailedTurnComment(lastStableMessage);
       // NOTE: currently will update the store even if no value needs changing
       set({
         ...(nextStableMessages && {
@@ -30,6 +50,7 @@ export function handleSetMessages(
         }),
         streamingMessage: null,
         ailaStreamingStatus: "Idle",
+        streamingFailedTurn,
       });
     } else if (lastMessageIsUser(messages)) {
       // AI SDK is loading without a message from the API: we're waiting for a response
@@ -45,6 +66,7 @@ export function handleSetMessages(
         streamingMessage: null,
         ailaStreamingStatus: "RequestMade",
         streamingError: false,
+        streamingFailedTurn: false,
       });
     } else {
       // AI SDK is loading with a message from the API: we're streaming

--- a/apps/nextjs/src/stores/chatStore/types.ts
+++ b/apps/nextjs/src/stores/chatStore/types.ts
@@ -33,6 +33,7 @@ export type ChatState = {
   id: string;
   ailaStreamingStatus: AilaStreamingStatus;
   streamingError: boolean;
+  streamingFailedTurn: boolean;
 
   initialMessages: AiMessage[];
   stableMessages: ParsedMessage[];

--- a/apps/nextjs/src/stores/lessonPlanTrackingStore/__tests__/tracking.test.ts
+++ b/apps/nextjs/src/stores/lessonPlanTrackingStore/__tests__/tracking.test.ts
@@ -501,4 +501,48 @@ describe("lessonPlanTracking tracking", () => {
     // NOTE: in the payload but not applicable as a threat doesn't terminate the chat
     it.todo("tracks when a threat is detected");
   });
+
+  describe("ailaStreamingStatusUpdated", () => {
+    it("tracks completion for persisted partial successes", () => {
+      const store = createLessonPlanTrackingStore(createArgs);
+      const trackCompletion = jest.fn();
+
+      store.setState((state) => ({
+        actions: {
+          ...state.actions,
+          trackCompletion,
+        },
+      }));
+
+      chatStoreMock.getState.mockReturnValue({
+        streamingError: false,
+        streamingFailedTurn: false,
+      });
+
+      store.getState().actions.ailaStreamingStatusUpdated("Idle");
+
+      expect(trackCompletion).toHaveBeenCalledTimes(1);
+    });
+
+    it("suppresses completion tracking for true failed turns", () => {
+      const store = createLessonPlanTrackingStore(createArgs);
+      const trackCompletion = jest.fn();
+
+      store.setState((state) => ({
+        actions: {
+          ...state.actions,
+          trackCompletion,
+        },
+      }));
+
+      chatStoreMock.getState.mockReturnValue({
+        streamingError: false,
+        streamingFailedTurn: true,
+      });
+
+      store.getState().actions.ailaStreamingStatusUpdated("Idle");
+
+      expect(trackCompletion).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/nextjs/src/stores/lessonPlanTrackingStore/index.ts
+++ b/apps/nextjs/src/stores/lessonPlanTrackingStore/index.ts
@@ -119,7 +119,7 @@ export const createLessonPlanTrackingStore = ({
           if (streamingStatus === "Idle") {
             const chatStore = getStore("chat");
 
-            if (!chatStore.streamingError) {
+            if (!chatStore.streamingError && !chatStore.streamingFailedTurn) {
               try {
                 get().actions.trackCompletion();
               } catch (error) {

--- a/apps/nextjs/src/utils/serverSideFeatureFlag.test.ts
+++ b/apps/nextjs/src/utils/serverSideFeatureFlag.test.ts
@@ -1,0 +1,88 @@
+import { posthogAiBetaServerClient } from "@oakai/core/src/analytics/posthogAiBetaServerClient";
+
+import { auth, clerkClient } from "@clerk/nextjs/server";
+import { kv } from "@vercel/kv";
+
+import { serverSideFeatureFlag } from "./serverSideFeatureFlag";
+
+jest.mock("@clerk/nextjs/server", () => ({
+  auth: jest.fn(),
+  clerkClient: jest.fn(),
+}));
+
+jest.mock("@vercel/kv", () => ({
+  kv: {
+    get: jest.fn(),
+    set: jest.fn(),
+  },
+}));
+
+jest.mock("@oakai/core/src/analytics/posthogAiBetaServerClient", () => ({
+  posthogAiBetaServerClient: {
+    isFeatureEnabled: jest.fn(),
+  },
+}));
+
+const mockedAuth = jest.mocked(auth);
+const mockedClerkClient = jest.mocked(clerkClient);
+const mockedKvGet = jest.mocked(kv.get);
+const mockedKvSet = jest.mocked(kv.set);
+const mockedIsFeatureEnabled = jest.mocked(
+  posthogAiBetaServerClient.isFeatureEnabled,
+);
+
+describe("serverSideFeatureFlag", () => {
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockedAuth.mockResolvedValue({ userId: "user_123" } as Awaited<
+      ReturnType<typeof auth>
+    >);
+  });
+
+  it("returns true for boolean true cache hits", async () => {
+    mockedKvGet.mockResolvedValue(true);
+
+    await expect(serverSideFeatureFlag("agentic-aila-nov-25")).resolves.toBe(
+      true,
+    );
+
+    expect(mockedKvGet).toHaveBeenCalledWith(
+      "feature_flag:agentic-aila-nov-25:user_123",
+    );
+    expect(mockedIsFeatureEnabled).not.toHaveBeenCalled();
+    expect(mockedClerkClient).not.toHaveBeenCalled();
+  });
+
+  it("returns false for boolean false cache hits", async () => {
+    mockedKvGet.mockResolvedValue(false);
+
+    await expect(serverSideFeatureFlag("agentic-aila-nov-25")).resolves.toBe(
+      false,
+    );
+
+    expect(mockedIsFeatureEnabled).not.toHaveBeenCalled();
+    expect(mockedClerkClient).not.toHaveBeenCalled();
+  });
+
+  it("stores boolean results from PostHog in KV", async () => {
+    mockedKvGet.mockResolvedValue(null);
+    mockedIsFeatureEnabled.mockResolvedValue(true);
+    mockedClerkClient.mockResolvedValue({
+      users: {
+        getUser: jest.fn().mockResolvedValue({
+          emailAddresses: [{ emailAddress: "test@example.com" }],
+        }),
+      },
+    } as Awaited<ReturnType<typeof clerkClient>>);
+
+    await expect(serverSideFeatureFlag("agentic-aila-nov-25")).resolves.toBe(
+      true,
+    );
+
+    expect(mockedKvSet).toHaveBeenCalledWith(
+      "feature_flag:agentic-aila-nov-25:user_123",
+      true,
+      { ex: 60 },
+    );
+  });
+});

--- a/apps/nextjs/src/utils/serverSideFeatureFlag.test.ts
+++ b/apps/nextjs/src/utils/serverSideFeatureFlag.test.ts
@@ -73,7 +73,7 @@ describe("serverSideFeatureFlag", () => {
           emailAddresses: [{ emailAddress: "test@example.com" }],
         }),
       },
-    } as Awaited<ReturnType<typeof clerkClient>>);
+    } as unknown as Awaited<ReturnType<typeof clerkClient>>);
 
     await expect(serverSideFeatureFlag("agentic-aila-nov-25")).resolves.toBe(
       true,

--- a/apps/nextjs/src/utils/serverSideFeatureFlag.ts
+++ b/apps/nextjs/src/utils/serverSideFeatureFlag.ts
@@ -6,6 +6,18 @@ import { kv } from "@vercel/kv";
 
 const log = aiLogger("feature-flags");
 
+function parseCachedFeatureFlagValue(value: unknown): boolean | null {
+  if (value === true || value === "true") {
+    return true;
+  }
+
+  if (value === false || value === "false") {
+    return false;
+  }
+
+  return null;
+}
+
 /**
  * Evaluate a feature flag server-side with full user context.
  *
@@ -19,15 +31,17 @@ export async function serverSideFeatureFlag(
   featureFlagId: string,
 ): Promise<boolean> {
   const { userId } = await auth();
+
   if (!userId) {
     return false;
   }
 
   const cacheKey = `feature_flag:${featureFlagId}:${userId}`;
   const cachedResult = await kv.get(cacheKey);
+  const parsedCachedResult = parseCachedFeatureFlagValue(cachedResult);
 
-  if (cachedResult !== null) {
-    return cachedResult === "true";
+  if (parsedCachedResult !== null) {
+    return parsedCachedResult;
   }
 
   try {
@@ -40,7 +54,7 @@ export async function serverSideFeatureFlag(
         personProperties: { ...(email && { email }) },
       })) ?? false;
 
-    await kv.set(cacheKey, isFeatureFlagEnabled.toString(), { ex: 60 });
+    await kv.set(cacheKey, isFeatureFlagEnabled, { ex: 60 });
 
     return isFeatureFlagEnabled;
   } catch (e) {

--- a/packages/aila/src/core/chat/AilaStreamHandler.test.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.test.ts
@@ -1,0 +1,152 @@
+import { AilaStreamHandler } from "./AilaStreamHandler";
+
+type MockChatOptions = {
+  useAgenticAila: boolean;
+};
+
+type StreamHandlerTestHarness = {
+  startAgentStream: () => Promise<{ status: "success" | "failed" }>;
+  startLLMStream: () => Promise<void>;
+  readFromStream: () => Promise<void>;
+};
+
+function createMockChat({ useAgenticAila }: MockChatOptions) {
+  const enqueue = jest.fn().mockResolvedValue(undefined);
+  const complete = jest.fn().mockImplementation(async () => {
+    await enqueue({
+      type: "comment",
+      value: "CHAT_COMPLETE",
+    });
+  });
+
+  const chat = {
+    id: "chat_123",
+    userId: "user_123",
+    iteration: 1,
+    messages: [{ id: "u1", role: "user", content: "test prompt" }],
+    generation: useAgenticAila ? undefined : { status: "REQUESTED" },
+    aila: {
+      options: {
+        useAgenticAila,
+      },
+      tracing: {
+        span: async (
+          _step: string,
+          _attrs: { op: string },
+          handler: () => Promise<void>,
+        ) => await handler(),
+      },
+      threatDetection: {
+        detectors: [],
+      },
+      errorReporter: {
+        reportError: jest.fn(),
+      },
+    },
+    getPatchEnqueuer: () => ({
+      setController: jest.fn(),
+    }),
+    initialiseChunks: jest.fn(),
+    setupGeneration: jest.fn().mockImplementation(() => {
+      chat.generation = { status: "REQUESTED" };
+      return Promise.resolve();
+    }),
+    handleSettingInitialState: jest.fn().mockResolvedValue(undefined),
+    handleSubjectWarning: jest.fn().mockResolvedValue(undefined),
+    complete,
+    enqueue,
+  };
+
+  return chat;
+}
+
+async function consumeStream(stream: ReadableStream) {
+  const reader = stream.getReader();
+
+  while (true) {
+    const { done } = await reader.read();
+    if (done) break;
+  }
+}
+
+describe("AilaStreamHandler", () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  function getHarness(handler: AilaStreamHandler): StreamHandlerTestHarness {
+    return handler as unknown as StreamHandlerTestHarness;
+  }
+
+  it("skips completion for failed agentic turns", async () => {
+    const chat = createMockChat({ useAgenticAila: true });
+    const handler = new AilaStreamHandler(chat as never);
+
+    jest
+      .spyOn(getHarness(handler), "startAgentStream")
+      .mockResolvedValue({ status: "failed" });
+
+    await consumeStream(handler.startStreaming());
+
+    expect(chat.complete).not.toHaveBeenCalled();
+    expect(chat.enqueue).not.toHaveBeenCalledWith({
+      type: "comment",
+      value: "CHAT_COMPLETE",
+    });
+  });
+
+  it("completes successful agentic turns", async () => {
+    const chat = createMockChat({ useAgenticAila: true });
+    const handler = new AilaStreamHandler(chat as never);
+
+    jest
+      .spyOn(getHarness(handler), "startAgentStream")
+      .mockResolvedValue({ status: "success" });
+
+    await consumeStream(handler.startStreaming());
+
+    expect(chat.complete).toHaveBeenCalledTimes(1);
+    expect(chat.enqueue).toHaveBeenCalledWith({
+      type: "comment",
+      value: "CHAT_COMPLETE",
+    });
+  });
+
+  it("completes partial-success agentic turns", async () => {
+    const chat = createMockChat({ useAgenticAila: true });
+    const handler = new AilaStreamHandler(chat as never);
+
+    jest
+      .spyOn(getHarness(handler), "startAgentStream")
+      .mockResolvedValue({ status: "success" });
+
+    await consumeStream(handler.startStreaming());
+
+    expect(chat.complete).toHaveBeenCalledTimes(1);
+    expect(chat.enqueue).toHaveBeenCalledWith({
+      type: "comment",
+      value: "CHAT_COMPLETE",
+    });
+  });
+
+  it("keeps non-agentic completion behavior unchanged", async () => {
+    const chat = createMockChat({ useAgenticAila: false });
+    const handler = new AilaStreamHandler(chat as never);
+
+    jest
+      .spyOn(getHarness(handler), "startLLMStream")
+      .mockResolvedValue(undefined);
+    jest
+      .spyOn(getHarness(handler), "readFromStream")
+      .mockResolvedValue(undefined);
+
+    await consumeStream(handler.startStreaming());
+
+    expect(chat.setupGeneration).toHaveBeenCalledTimes(1);
+    expect(chat.complete).toHaveBeenCalledTimes(1);
+    expect(chat.enqueue).toHaveBeenCalledWith({
+      type: "comment",
+      value: "CHAT_COMPLETE",
+    });
+  });
+});

--- a/packages/aila/src/core/chat/AilaStreamHandler.test.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.test.ts
@@ -6,15 +6,42 @@ import {
   parseSubjectsForRagSearch,
 } from "@oakai/rag";
 
+import OpenAI from "openai";
+
 import { createOpenAIMessageToUserAgent } from "../../lib/agentic-system/agents/messageToUserAgent";
 import { createOpenAIPlannerAgent } from "../../lib/agentic-system/agents/plannerAgent";
-import { createSectionAgentRegistry } from "../../lib/agentic-system/agents/sectionAgents/sectionAgentRegistry";
+import { createSectionAgentRegistry as createSectionAgentRegistryFactory } from "../../lib/agentic-system/agents/sectionAgents/sectionAgentRegistry";
 import { ailaTurn } from "../../lib/agentic-system/ailaTurn";
+import type { SectionAgentRegistry } from "../../lib/agentic-system/types";
 import { AilaStreamHandler } from "./AilaStreamHandler";
 import type { Message } from "./types";
 
+const actualOpenAIModule: { default: typeof OpenAI } =
+  jest.requireActual("openai");
+const actualSectionAgentRegistryModule: {
+  createSectionAgentRegistry: typeof createSectionAgentRegistryFactory;
+} = jest.requireActual(
+  "../../lib/agentic-system/agents/sectionAgents/sectionAgentRegistry",
+);
+
+function createMockOpenAIClient() {
+  return new OpenAI({ apiKey: "test" });
+}
+
+function createMockSectionAgentRegistry(): SectionAgentRegistry {
+  return actualSectionAgentRegistryModule.createSectionAgentRegistry({
+    openai: createMockOpenAIClient(),
+    customAgentHandlers: {
+      "starterQuiz--maths": jest.fn(),
+      "exitQuiz--maths": jest.fn(),
+    },
+  });
+}
+
 jest.mock("@oakai/core/src/llm/openai", () => ({
-  createOpenAIClient: jest.fn(() => ({})),
+  createOpenAIClient: jest.fn(
+    () => new actualOpenAIModule.default({ apiKey: "test" }),
+  ),
 }));
 
 jest.mock("@oakai/rag", () => ({
@@ -39,7 +66,13 @@ jest.mock("../../lib/agentic-system/agents/plannerAgent", () => ({
 jest.mock(
   "../../lib/agentic-system/agents/sectionAgents/sectionAgentRegistry",
   () => ({
-    createSectionAgentRegistry: jest.fn(() => ({})),
+    createSectionAgentRegistry: jest.fn(
+      (props: Parameters<typeof createSectionAgentRegistryFactory>[0]) => {
+        return actualSectionAgentRegistryModule.createSectionAgentRegistry(
+          props,
+        );
+      },
+    ),
   }),
 );
 
@@ -60,7 +93,7 @@ const mockedCreateOpenAIMessageToUserAgent = jest.mocked(
 );
 const mockedCreateOpenAIPlannerAgent = jest.mocked(createOpenAIPlannerAgent);
 const mockedCreateSectionAgentRegistry = jest.mocked(
-  createSectionAgentRegistry,
+  createSectionAgentRegistryFactory,
 );
 
 function createObjectStreamReader(chunks: string[] = ["stream chunk"]) {
@@ -146,14 +179,16 @@ async function consumeStream(stream: ReadableStream) {
 describe("AilaStreamHandler", () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockedCreateOpenAIClient.mockReturnValue({});
+    mockedCreateOpenAIClient.mockReturnValue(createMockOpenAIClient());
     mockedGetRagLessonPlansByIds.mockResolvedValue([]);
     mockedGetRelevantLessonPlans.mockResolvedValue([]);
     mockedParseKeyStagesForRagSearch.mockReturnValue([]);
     mockedParseSubjectsForRagSearch.mockReturnValue([]);
     mockedCreateOpenAIMessageToUserAgent.mockReturnValue(jest.fn());
     mockedCreateOpenAIPlannerAgent.mockReturnValue(jest.fn());
-    mockedCreateSectionAgentRegistry.mockReturnValue({});
+    mockedCreateSectionAgentRegistry.mockReturnValue(
+      createMockSectionAgentRegistry(),
+    );
   });
 
   it("skips completion for failed agentic turns", async () => {

--- a/packages/aila/src/core/chat/AilaStreamHandler.test.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.test.ts
@@ -1,14 +1,51 @@
+import { ailaTurn } from "../../lib/agentic-system/ailaTurn";
 import { AilaStreamHandler } from "./AilaStreamHandler";
+import type { Message } from "./types";
+
+jest.mock("@oakai/core/src/llm/openai", () => ({
+  createOpenAIClient: jest.fn(() => ({})),
+}));
+
+jest.mock("@oakai/rag", () => ({
+  getRagLessonPlansByIds: jest.fn().mockResolvedValue([]),
+  getRelevantLessonPlans: jest.fn().mockResolvedValue([]),
+  parseKeyStagesForRagSearch: jest.fn().mockReturnValue([]),
+  parseSubjectsForRagSearch: jest.fn().mockReturnValue([]),
+}));
+
+jest.mock("../../lib/agentic-system/ailaTurn", () => ({
+  ailaTurn: jest.fn(),
+}));
+
+jest.mock("../../lib/agentic-system/agents/messageToUserAgent", () => ({
+  createOpenAIMessageToUserAgent: jest.fn(() => jest.fn()),
+}));
+
+jest.mock("../../lib/agentic-system/agents/plannerAgent", () => ({
+  createOpenAIPlannerAgent: jest.fn(() => jest.fn()),
+}));
+
+jest.mock(
+  "../../lib/agentic-system/agents/sectionAgents/sectionAgentRegistry",
+  () => ({
+    createSectionAgentRegistry: jest.fn(() => ({})),
+  }),
+);
 
 type MockChatOptions = {
   useAgenticAila: boolean;
 };
 
-type StreamHandlerTestHarness = {
-  startAgentStream: () => Promise<{ status: "success" | "failed" }>;
-  startLLMStream: () => Promise<void>;
-  readFromStream: () => Promise<void>;
-};
+const mockedAilaTurn = jest.mocked(ailaTurn);
+
+function createObjectStreamReader(chunks: string[] = ["stream chunk"]) {
+  return new ReadableStream<string>({
+    start(controller) {
+      chunks.forEach((chunk) => controller.enqueue(chunk));
+      controller.close();
+    },
+  }).getReader();
+}
 
 function createMockChat({ useAgenticAila }: MockChatOptions) {
   const enqueue = jest.fn().mockResolvedValue(undefined);
@@ -23,7 +60,8 @@ function createMockChat({ useAgenticAila }: MockChatOptions) {
     id: "chat_123",
     userId: "user_123",
     iteration: 1,
-    messages: [{ id: "u1", role: "user", content: "test prompt" }],
+    messages: [{ id: "u1", role: "user", content: "test prompt" }] as Message[],
+    relevantLessons: null,
     generation: useAgenticAila ? undefined : { status: "REQUESTED" },
     aila: {
       options: {
@@ -42,17 +80,28 @@ function createMockChat({ useAgenticAila }: MockChatOptions) {
       errorReporter: {
         reportError: jest.fn(),
       },
+      document: {
+        content: {},
+      },
+      plugins: [],
     },
     getPatchEnqueuer: () => ({
       setController: jest.fn(),
     }),
     initialiseChunks: jest.fn(),
+    appendChunk: jest.fn(),
     setupGeneration: jest.fn().mockImplementation(() => {
       chat.generation = { status: "REQUESTED" };
       return Promise.resolve();
     }),
     handleSettingInitialState: jest.fn().mockResolvedValue(undefined),
     handleSubjectWarning: jest.fn().mockResolvedValue(undefined),
+    completionMessages: jest
+      .fn()
+      .mockReturnValue([{ id: "u1", role: "user", content: "test prompt" }]),
+    createChatCompletionObjectStream: jest
+      .fn()
+      .mockResolvedValue(createObjectStreamReader()),
     complete,
     enqueue,
   };
@@ -71,20 +120,14 @@ async function consumeStream(stream: ReadableStream) {
 
 describe("AilaStreamHandler", () => {
   afterEach(() => {
-    jest.restoreAllMocks();
+    jest.resetAllMocks();
   });
 
-  function getHarness(handler: AilaStreamHandler): StreamHandlerTestHarness {
-    return handler as unknown as StreamHandlerTestHarness;
-  }
-
   it("skips completion for failed agentic turns", async () => {
+    mockedAilaTurn.mockResolvedValue({ status: "failed" });
+
     const chat = createMockChat({ useAgenticAila: true });
     const handler = new AilaStreamHandler(chat as never);
-
-    jest
-      .spyOn(getHarness(handler), "startAgentStream")
-      .mockResolvedValue({ status: "failed" });
 
     await consumeStream(handler.startStreaming());
 
@@ -96,16 +139,36 @@ describe("AilaStreamHandler", () => {
   });
 
   it("completes successful agentic turns", async () => {
+    mockedAilaTurn.mockImplementationOnce(async ({ callbacks }) => {
+      await callbacks.onTurnComplete({
+        stepsExecuted: [],
+        document: {},
+        ailaMessage:
+          "Here's the updated lesson plan. Do you want to make any more changes?",
+      });
+      return { status: "success" };
+    });
+
     const chat = createMockChat({ useAgenticAila: true });
     const handler = new AilaStreamHandler(chat as never);
 
-    jest
-      .spyOn(getHarness(handler), "startAgentStream")
-      .mockResolvedValue({ status: "success" });
-
     await consumeStream(handler.startStreaming());
 
+    expect(mockedAilaTurn).toHaveBeenCalledTimes(1);
     expect(chat.complete).toHaveBeenCalledTimes(1);
+    expect(chat.enqueue).toHaveBeenCalledWith({
+      type: "state",
+      reasoning: "final",
+      value: {},
+    });
+    expect(chat.appendChunk).toHaveBeenCalledWith(
+      expect.stringContaining('"sectionsEdited":[]'),
+    );
+    expect(chat.appendChunk).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `"value":"Here's the updated lesson plan. Do you want to make any more changes?"`,
+      ),
+    );
     expect(chat.enqueue).toHaveBeenCalledWith({
       type: "comment",
       value: "CHAT_COMPLETE",
@@ -113,16 +176,43 @@ describe("AilaStreamHandler", () => {
   });
 
   it("completes partial-success agentic turns", async () => {
+    mockedAilaTurn.mockImplementationOnce(async ({ callbacks }) => {
+      await callbacks.onTurnComplete({
+        stepsExecuted: [
+          {
+            type: "section",
+            sectionKey: "subject",
+            action: "generate",
+            sectionInstructions: null,
+          },
+        ],
+        document: { subject: "art" },
+        ailaMessage:
+          "The lesson plan has been updated, but the usual summary wasn't available. Please review the changes and let me know what you'd like to adjust next.",
+      });
+      return { status: "success" };
+    });
+
     const chat = createMockChat({ useAgenticAila: true });
     const handler = new AilaStreamHandler(chat as never);
 
-    jest
-      .spyOn(getHarness(handler), "startAgentStream")
-      .mockResolvedValue({ status: "success" });
-
     await consumeStream(handler.startStreaming());
 
+    expect(mockedAilaTurn).toHaveBeenCalledTimes(1);
     expect(chat.complete).toHaveBeenCalledTimes(1);
+    expect(chat.enqueue).toHaveBeenCalledWith({
+      type: "state",
+      reasoning: "final",
+      value: { subject: "art" },
+    });
+    expect(chat.appendChunk).toHaveBeenCalledWith(
+      expect.stringContaining('"sectionsEdited":["subject"]'),
+    );
+    expect(chat.appendChunk).toHaveBeenCalledWith(
+      expect.stringContaining(
+        `"value":"The lesson plan has been updated, but the usual summary wasn't available. Please review the changes and let me know what you'd like to adjust next."`,
+      ),
+    );
     expect(chat.enqueue).toHaveBeenCalledWith({
       type: "comment",
       value: "CHAT_COMPLETE",
@@ -133,16 +223,11 @@ describe("AilaStreamHandler", () => {
     const chat = createMockChat({ useAgenticAila: false });
     const handler = new AilaStreamHandler(chat as never);
 
-    jest
-      .spyOn(getHarness(handler), "startLLMStream")
-      .mockResolvedValue(undefined);
-    jest
-      .spyOn(getHarness(handler), "readFromStream")
-      .mockResolvedValue(undefined);
-
     await consumeStream(handler.startStreaming());
 
     expect(chat.setupGeneration).toHaveBeenCalledTimes(1);
+    expect(chat.createChatCompletionObjectStream).toHaveBeenCalledTimes(1);
+    expect(chat.appendChunk).toHaveBeenCalledWith("stream chunk");
     expect(chat.complete).toHaveBeenCalledTimes(1);
     expect(chat.enqueue).toHaveBeenCalledWith({
       type: "comment",

--- a/packages/aila/src/core/chat/AilaStreamHandler.test.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.test.ts
@@ -160,6 +160,7 @@ function createMockChat({ useAgenticAila }: MockChatOptions) {
     createChatCompletionObjectStream: jest
       .fn()
       .mockResolvedValue(createObjectStreamReader()),
+    persistChat: jest.fn().mockResolvedValue(undefined),
     complete,
     enqueue,
   };

--- a/packages/aila/src/core/chat/AilaStreamHandler.test.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.test.ts
@@ -1,3 +1,14 @@
+import { createOpenAIClient } from "@oakai/core/src/llm/openai";
+import {
+  getRagLessonPlansByIds,
+  getRelevantLessonPlans,
+  parseKeyStagesForRagSearch,
+  parseSubjectsForRagSearch,
+} from "@oakai/rag";
+
+import { createOpenAIMessageToUserAgent } from "../../lib/agentic-system/agents/messageToUserAgent";
+import { createOpenAIPlannerAgent } from "../../lib/agentic-system/agents/plannerAgent";
+import { createSectionAgentRegistry } from "../../lib/agentic-system/agents/sectionAgents/sectionAgentRegistry";
 import { ailaTurn } from "../../lib/agentic-system/ailaTurn";
 import { AilaStreamHandler } from "./AilaStreamHandler";
 import type { Message } from "./types";
@@ -37,6 +48,20 @@ type MockChatOptions = {
 };
 
 const mockedAilaTurn = jest.mocked(ailaTurn);
+const mockedCreateOpenAIClient = jest.mocked(createOpenAIClient);
+const mockedGetRagLessonPlansByIds = jest.mocked(getRagLessonPlansByIds);
+const mockedGetRelevantLessonPlans = jest.mocked(getRelevantLessonPlans);
+const mockedParseKeyStagesForRagSearch = jest.mocked(
+  parseKeyStagesForRagSearch,
+);
+const mockedParseSubjectsForRagSearch = jest.mocked(parseSubjectsForRagSearch);
+const mockedCreateOpenAIMessageToUserAgent = jest.mocked(
+  createOpenAIMessageToUserAgent,
+);
+const mockedCreateOpenAIPlannerAgent = jest.mocked(createOpenAIPlannerAgent);
+const mockedCreateSectionAgentRegistry = jest.mocked(
+  createSectionAgentRegistry,
+);
 
 function createObjectStreamReader(chunks: string[] = ["stream chunk"]) {
   return new ReadableStream<string>({
@@ -119,8 +144,16 @@ async function consumeStream(stream: ReadableStream) {
 }
 
 describe("AilaStreamHandler", () => {
-  afterEach(() => {
-    jest.resetAllMocks();
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCreateOpenAIClient.mockReturnValue({});
+    mockedGetRagLessonPlansByIds.mockResolvedValue([]);
+    mockedGetRelevantLessonPlans.mockResolvedValue([]);
+    mockedParseKeyStagesForRagSearch.mockReturnValue([]);
+    mockedParseSubjectsForRagSearch.mockReturnValue([]);
+    mockedCreateOpenAIMessageToUserAgent.mockReturnValue(jest.fn());
+    mockedCreateOpenAIPlannerAgent.mockReturnValue(jest.fn());
+    mockedCreateSectionAgentRegistry.mockReturnValue({});
   });
 
   it("skips completion for failed agentic turns", async () => {

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -16,6 +16,7 @@ import { createOpenAIPlannerAgent } from "../../lib/agentic-system/agents/planne
 import { createSectionAgentRegistry } from "../../lib/agentic-system/agents/sectionAgents/sectionAgentRegistry";
 import { ailaTurn } from "../../lib/agentic-system/ailaTurn";
 import { createAilaTurnCallbacks } from "../../lib/agentic-system/compatibility/ailaTurnCallbacks";
+import type { AilaTurnOutcome } from "../../lib/agentic-system/types";
 import { extractPromptTextFromMessages } from "../../utils/extractPromptTextFromMessages";
 import { AilaChatError } from "../AilaError";
 import { ReportStorage, createQuizTracker } from "../quiz/reporting";
@@ -23,6 +24,11 @@ import type { AilaChat } from "./AilaChat";
 import type { PatchEnqueuer } from "./PatchEnqueuer";
 
 const log = aiLogger("aila:stream");
+
+function agenticTurnSucceeded(outcome: AilaTurnOutcome | null): boolean {
+  return outcome?.status === "success";
+}
+
 export class AilaStreamHandler {
   private readonly _chat: AilaChat;
   private _controller?: ReadableStreamDefaultController;
@@ -91,6 +97,7 @@ export class AilaStreamHandler {
   ) {
     log.info("Starting stream", { chatId: this._chat.id });
     this.setupController(controller);
+    let agenticTurnOutcome: AilaTurnOutcome | null = null;
     try {
       if (!this._chat.aila.options.useAgenticAila) {
         await this.span("set-up-generation", async () => {
@@ -109,7 +116,7 @@ export class AilaStreamHandler {
 
       if (this._chat.aila.options.useAgenticAila) {
         await this.span("start-agent-stream", async () => {
-          await this.startAgentStream();
+          agenticTurnOutcome = await this.startAgentStream();
         });
       } else {
         await this.span("set-initial-state", async () => {
@@ -133,6 +140,9 @@ export class AilaStreamHandler {
         this._chat.id,
       );
     } catch (e) {
+      if (this._chat.aila.options.useAgenticAila) {
+        agenticTurnOutcome = { status: "failed" };
+      }
       log.info("Caught error in stream", {
         error: e,
         type: e?.constructor?.name,
@@ -147,8 +157,15 @@ export class AilaStreamHandler {
       log.info("Stream error", e, this._chat.iteration, this._chat.id);
     } finally {
       const status = this._chat.generation?.status;
-      log.info("In finally block", { status, chatId: this._chat.id });
-      if (status !== "FAILED") {
+      const shouldComplete = this._chat.aila.options.useAgenticAila
+        ? agenticTurnSucceeded(agenticTurnOutcome)
+        : status !== "FAILED";
+      log.info("In finally block", {
+        status,
+        agenticTurnOutcome,
+        chatId: this._chat.id,
+      });
+      if (shouldComplete) {
         try {
           await this.span("chat-completion", async () => {
             await this._chat.complete();
@@ -174,7 +191,7 @@ export class AilaStreamHandler {
     this._patchEnqueuer.setController(controller);
   }
 
-  private async startAgentStream() {
+  private async startAgentStream(): Promise<AilaTurnOutcome> {
     await this._chat.enqueue({
       type: "comment",
       value: "CHAT_START",
@@ -205,7 +222,7 @@ export class AilaStreamHandler {
         })
       : [];
 
-    await ailaTurn({
+    return await ailaTurn({
       callbacks: ailaTurnCallbacks,
       persistedState: {
         messages: extractPromptTextFromMessages(this._chat.messages),

--- a/packages/aila/src/lib/agentic-system/MANUAL_TESTING.md
+++ b/packages/aila/src/lib/agentic-system/MANUAL_TESTING.md
@@ -1,0 +1,38 @@
+# Agentic Failure Injection
+
+Use `AILA_AGENTIC_FORCE_FAIL` to force agentic failure paths during local manual testing.
+
+## Commands
+
+```bash
+AILA_AGENTIC_FORCE_FAIL=planner pnpm dev
+AILA_AGENTIC_FORCE_FAIL=planner_throw pnpm dev
+AILA_AGENTIC_FORCE_FAIL=section pnpm dev
+AILA_AGENTIC_FORCE_FAIL=section:keywords pnpm dev
+AILA_AGENTIC_FORCE_FAIL=section_throw pnpm dev
+AILA_AGENTIC_FORCE_FAIL=section_throw:keywords pnpm dev
+AILA_AGENTIC_FORCE_FAIL=message_to_user pnpm dev
+AILA_AGENTIC_FORCE_FAIL=message_to_user_throw pnpm dev
+```
+
+## Values
+
+```text
+planner
+planner_throw
+section
+section:<sectionKey>
+section_throw
+section_throw:<sectionKey>
+message_to_user
+message_to_user_throw
+```
+
+This hook is enabled for non-production local/dev use only.
+
+## Notes
+
+- `message_to_user` and `message_to_user_throw` only trigger on turns that reach the message-to-user stage.
+- They are bypassed on turns that end earlier, for example when relevant lessons are fetched and returned directly.
+- On turns with no applied steps, these values surface the hard-failure message.
+- On turns with applied steps, they surface the fallback partial-success summary message.

--- a/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.test.ts
@@ -81,6 +81,7 @@ describe("sectionToGenericPromptAgent", () => {
       onPlannerComplete: jest.fn(),
       onSectionComplete: jest.fn(),
       onTurnComplete: jest.fn(),
+      onTurnFailed: jest.fn(),
     },
   };
 

--- a/packages/aila/src/lib/agentic-system/ailaTurn.e2e.test.ts
+++ b/packages/aila/src/lib/agentic-system/ailaTurn.e2e.test.ts
@@ -38,9 +38,13 @@ const runTurn = async (
       messageCapture = ailaMessage;
       return Promise.resolve();
     },
+    onTurnFailed: () => Promise.resolve(),
   };
 
-  await ailaTurn({ persistedState, runtime, callbacks });
+  const outcome = await ailaTurn({ persistedState, runtime, callbacks });
+  if (outcome.status !== "success") {
+    throw new Error("Turn did not complete successfully.");
+  }
   if (!nextDocCapture)
     throw new Error("Turn did not complete with a next document.");
 

--- a/packages/aila/src/lib/agentic-system/ailaTurn.test.ts
+++ b/packages/aila/src/lib/agentic-system/ailaTurn.test.ts
@@ -1,0 +1,524 @@
+import { ailaTurn } from "./ailaTurn";
+import type {
+  AilaPersistedState,
+  AilaRuntimeContext,
+  AilaTurnCallbacks,
+} from "./types";
+
+function createCallbacks() {
+  return {
+    onPlannerComplete: jest.fn(),
+    onSectionComplete: jest.fn(),
+    onTurnComplete: jest.fn().mockResolvedValue(undefined),
+    onTurnFailed: jest.fn().mockResolvedValue(undefined),
+  } satisfies AilaTurnCallbacks;
+}
+
+function createPersistedState(): AilaPersistedState {
+  return {
+    messages: [{ id: "u1", role: "user", content: "Update the subject" }],
+    initialDocument: {},
+    relevantLessons: null,
+  };
+}
+
+function createRuntime(
+  overrides: Partial<AilaRuntimeContext> = {},
+): AilaRuntimeContext {
+  return {
+    config: { mathsQuizEnabled: true },
+    plannerAgent: jest.fn(),
+    sectionAgents: {} as AilaRuntimeContext["sectionAgents"],
+    messageToUserAgent: jest.fn(),
+    fetchRelevantLessons: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+describe("ailaTurn", () => {
+  const originalForceFail = process.env.AILA_AGENTIC_FORCE_FAIL;
+
+  afterEach(() => {
+    if (originalForceFail === undefined) {
+      delete process.env.AILA_AGENTIC_FORCE_FAIL;
+    } else {
+      process.env.AILA_AGENTIC_FORCE_FAIL = originalForceFail;
+    }
+  });
+
+  it("hard-fails when the planner fails", async () => {
+    const callbacks = createCallbacks();
+    const runtime = createRuntime({
+      plannerAgent: jest
+        .fn()
+        .mockResolvedValue({ error: { message: "planner failed" } }),
+    });
+
+    const outcome = await ailaTurn({
+      persistedState: createPersistedState(),
+      runtime,
+      callbacks,
+    });
+
+    expect(outcome).toEqual({ status: "failed" });
+    expect(callbacks.onPlannerComplete).toHaveBeenCalledWith({
+      sectionKeys: [],
+    });
+    expect(callbacks.onTurnFailed).toHaveBeenCalledWith({
+      stepsExecuted: [],
+      ailaMessage:
+        "I wasn't able to complete that lesson update. Please try again.",
+    });
+    expect(callbacks.onTurnComplete).not.toHaveBeenCalled();
+  });
+
+  it("hard-fails when a section agent fails", async () => {
+    const callbacks = createCallbacks();
+    const runtime = createRuntime({
+      plannerAgent: jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          decision: "plan",
+          parsedUserMessage: "Update the subject",
+          plan: [
+            {
+              type: "section",
+              sectionKey: "subject",
+              action: "generate",
+              sectionInstructions: null,
+            },
+          ],
+        },
+      }),
+      sectionAgents: {
+        "subject--default": {
+          id: "subject--default",
+          description: "subject",
+          handler: jest
+            .fn()
+            .mockResolvedValue({ error: { message: "section failed" } }),
+        },
+      } as unknown as AilaRuntimeContext["sectionAgents"],
+    });
+
+    const outcome = await ailaTurn({
+      persistedState: createPersistedState(),
+      runtime,
+      callbacks,
+    });
+
+    expect(outcome).toEqual({ status: "failed" });
+    expect(callbacks.onPlannerComplete).toHaveBeenCalledWith({
+      sectionKeys: ["subject"],
+    });
+    expect(callbacks.onTurnFailed).toHaveBeenCalledWith({
+      stepsExecuted: [],
+      ailaMessage:
+        "I wasn't able to complete that lesson update. Please try again.",
+    });
+    expect(callbacks.onTurnComplete).not.toHaveBeenCalled();
+  });
+
+  it("persists partial success when a later section agent fails", async () => {
+    const callbacks = createCallbacks();
+    const runtime = createRuntime({
+      plannerAgent: jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          decision: "plan",
+          parsedUserMessage: "Update the lesson",
+          plan: [
+            {
+              type: "section",
+              sectionKey: "subject",
+              action: "generate",
+              sectionInstructions: null,
+            },
+            {
+              type: "section",
+              sectionKey: "title",
+              action: "generate",
+              sectionInstructions: null,
+            },
+          ],
+        },
+      }),
+      sectionAgents: {
+        "subject--default": {
+          id: "subject--default",
+          description: "subject",
+          handler: jest.fn().mockResolvedValue({
+            error: null,
+            data: "art",
+          }),
+        },
+        "title--default": {
+          id: "title--default",
+          description: "title",
+          handler: jest
+            .fn()
+            .mockResolvedValue({ error: { message: "title failed" } }),
+        },
+      } as unknown as AilaRuntimeContext["sectionAgents"],
+    });
+
+    const outcome = await ailaTurn({
+      persistedState: createPersistedState(),
+      runtime,
+      callbacks,
+    });
+
+    expect(outcome).toEqual({ status: "success" });
+    expect(callbacks.onSectionComplete).toHaveBeenCalledWith([
+      { op: "add", path: "/subject", value: "art" },
+    ]);
+    expect(callbacks.onTurnComplete).toHaveBeenCalledWith({
+      stepsExecuted: [
+        {
+          type: "section",
+          sectionKey: "subject",
+          action: "generate",
+          sectionInstructions: null,
+        },
+      ],
+      document: { subject: "art" },
+      ailaMessage:
+        "The lesson plan has been updated, but the usual summary wasn't available. Please review the changes and let me know what you'd like to adjust next.",
+    });
+    expect(callbacks.onTurnFailed).not.toHaveBeenCalled();
+  });
+
+  it("salvages a message-to-user failure after successful edits", async () => {
+    const callbacks = createCallbacks();
+    const runtime = createRuntime({
+      plannerAgent: jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          decision: "plan",
+          parsedUserMessage: "Update the subject",
+          plan: [
+            {
+              type: "section",
+              sectionKey: "subject",
+              action: "generate",
+              sectionInstructions: null,
+            },
+          ],
+        },
+      }),
+      sectionAgents: {
+        "subject--default": {
+          id: "subject--default",
+          description: "subject",
+          handler: jest.fn().mockResolvedValue({
+            error: null,
+            data: "art",
+          }),
+        },
+      } as unknown as AilaRuntimeContext["sectionAgents"],
+      messageToUserAgent: jest
+        .fn()
+        .mockResolvedValue({ error: { message: "message agent failed" } }),
+    });
+
+    const outcome = await ailaTurn({
+      persistedState: createPersistedState(),
+      runtime,
+      callbacks,
+    });
+
+    expect(outcome).toEqual({ status: "success" });
+    expect(callbacks.onSectionComplete).toHaveBeenCalledWith([
+      { op: "add", path: "/subject", value: "art" },
+    ]);
+    expect(callbacks.onTurnComplete).toHaveBeenCalledWith({
+      stepsExecuted: [
+        {
+          type: "section",
+          sectionKey: "subject",
+          action: "generate",
+          sectionInstructions: null,
+        },
+      ],
+      document: { subject: "art" },
+      ailaMessage:
+        "The lesson plan has been updated, but the usual summary wasn't available. Please review the changes and let me know what you'd like to adjust next.",
+    });
+    expect(callbacks.onTurnFailed).not.toHaveBeenCalled();
+  });
+
+  it("supports forced planner failures via env var", async () => {
+    process.env.AILA_AGENTIC_FORCE_FAIL = "planner";
+
+    const callbacks = createCallbacks();
+    const plannerAgent = jest.fn().mockResolvedValue({
+      error: null,
+      data: {
+        decision: "exit",
+        parsedUserMessage: "unused",
+        reasonType: "clarification_needed",
+        reasonJustification: "unused",
+        additionalInfo: null,
+      },
+    });
+    const runtime = createRuntime({ plannerAgent });
+
+    const outcome = await ailaTurn({
+      persistedState: createPersistedState(),
+      runtime,
+      callbacks,
+    });
+
+    expect(outcome).toEqual({ status: "failed" });
+    expect(plannerAgent).not.toHaveBeenCalled();
+    expect(callbacks.onTurnFailed).toHaveBeenCalled();
+  });
+
+  it("supports forced planner throws via env var", async () => {
+    process.env.AILA_AGENTIC_FORCE_FAIL = "planner_throw";
+
+    const callbacks = createCallbacks();
+    const plannerAgent = jest.fn();
+    const runtime = createRuntime({ plannerAgent });
+
+    const outcome = await ailaTurn({
+      persistedState: createPersistedState(),
+      runtime,
+      callbacks,
+    });
+
+    expect(outcome).toEqual({ status: "failed" });
+    expect(plannerAgent).not.toHaveBeenCalled();
+    expect(callbacks.onTurnFailed).toHaveBeenCalledWith({
+      stepsExecuted: [],
+      ailaMessage:
+        "I wasn't able to complete that lesson update. Please try again.",
+    });
+    expect(callbacks.onTurnComplete).not.toHaveBeenCalled();
+  });
+
+  it("supports forced section throws via env var", async () => {
+    process.env.AILA_AGENTIC_FORCE_FAIL = "section_throw:subject";
+
+    const callbacks = createCallbacks();
+    const sectionHandler = jest.fn();
+    const runtime = createRuntime({
+      plannerAgent: jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          decision: "plan",
+          parsedUserMessage: "Update the subject",
+          plan: [
+            {
+              type: "section",
+              sectionKey: "subject",
+              action: "generate",
+              sectionInstructions: null,
+            },
+          ],
+        },
+      }),
+      sectionAgents: {
+        "subject--default": {
+          id: "subject--default",
+          description: "subject",
+          handler: sectionHandler,
+        },
+      } as unknown as AilaRuntimeContext["sectionAgents"],
+    });
+
+    const outcome = await ailaTurn({
+      persistedState: createPersistedState(),
+      runtime,
+      callbacks,
+    });
+
+    expect(outcome).toEqual({ status: "failed" });
+    expect(sectionHandler).not.toHaveBeenCalled();
+    expect(callbacks.onTurnFailed).toHaveBeenCalledWith({
+      stepsExecuted: [],
+      ailaMessage:
+        "I wasn't able to complete that lesson update. Please try again.",
+    });
+    expect(callbacks.onTurnComplete).not.toHaveBeenCalled();
+  });
+
+  it("supports forced message-to-user failures via env var", async () => {
+    process.env.AILA_AGENTIC_FORCE_FAIL = "message_to_user";
+
+    const callbacks = createCallbacks();
+    const messageToUserAgent = jest.fn();
+    const runtime = createRuntime({
+      plannerAgent: jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          decision: "plan",
+          parsedUserMessage: "Update the subject",
+          plan: [
+            {
+              type: "section",
+              sectionKey: "subject",
+              action: "generate",
+              sectionInstructions: null,
+            },
+          ],
+        },
+      }),
+      sectionAgents: {
+        "subject--default": {
+          id: "subject--default",
+          description: "subject",
+          handler: jest.fn().mockResolvedValue({
+            error: null,
+            data: "art",
+          }),
+        },
+      } as unknown as AilaRuntimeContext["sectionAgents"],
+      messageToUserAgent,
+    });
+
+    const outcome = await ailaTurn({
+      persistedState: createPersistedState(),
+      runtime,
+      callbacks,
+    });
+
+    expect(outcome).toEqual({ status: "success" });
+    expect(messageToUserAgent).not.toHaveBeenCalled();
+    expect(callbacks.onTurnComplete).toHaveBeenCalledWith({
+      stepsExecuted: [
+        {
+          type: "section",
+          sectionKey: "subject",
+          action: "generate",
+          sectionInstructions: null,
+        },
+      ],
+      document: { subject: "art" },
+      ailaMessage:
+        "The lesson plan has been updated, but the usual summary wasn't available. Please review the changes and let me know what you'd like to adjust next.",
+    });
+  });
+
+  it("supports forced message-to-user throws via env var", async () => {
+    process.env.AILA_AGENTIC_FORCE_FAIL = "message_to_user_throw";
+
+    const callbacks = createCallbacks();
+    const messageToUserAgent = jest.fn();
+    const runtime = createRuntime({
+      plannerAgent: jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          decision: "plan",
+          parsedUserMessage: "Update the subject",
+          plan: [
+            {
+              type: "section",
+              sectionKey: "subject",
+              action: "generate",
+              sectionInstructions: null,
+            },
+          ],
+        },
+      }),
+      sectionAgents: {
+        "subject--default": {
+          id: "subject--default",
+          description: "subject",
+          handler: jest.fn().mockResolvedValue({
+            error: null,
+            data: "art",
+          }),
+        },
+      } as unknown as AilaRuntimeContext["sectionAgents"],
+      messageToUserAgent,
+    });
+
+    const outcome = await ailaTurn({
+      persistedState: createPersistedState(),
+      runtime,
+      callbacks,
+    });
+
+    expect(outcome).toEqual({ status: "success" });
+    expect(messageToUserAgent).not.toHaveBeenCalled();
+    expect(callbacks.onTurnComplete).toHaveBeenCalledWith({
+      stepsExecuted: [
+        {
+          type: "section",
+          sectionKey: "subject",
+          action: "generate",
+          sectionInstructions: null,
+        },
+      ],
+      document: { subject: "art" },
+      ailaMessage:
+        "The lesson plan has been updated, but the usual summary wasn't available. Please review the changes and let me know what you'd like to adjust next.",
+    });
+    expect(callbacks.onTurnFailed).not.toHaveBeenCalled();
+  });
+
+  it("persists partial success when a later section throws", async () => {
+    const callbacks = createCallbacks();
+    const runtime = createRuntime({
+      plannerAgent: jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          decision: "plan",
+          parsedUserMessage: "Update the lesson",
+          plan: [
+            {
+              type: "section",
+              sectionKey: "subject",
+              action: "generate",
+              sectionInstructions: null,
+            },
+            {
+              type: "section",
+              sectionKey: "title",
+              action: "generate",
+              sectionInstructions: null,
+            },
+          ],
+        },
+      }),
+      sectionAgents: {
+        "subject--default": {
+          id: "subject--default",
+          description: "subject",
+          handler: jest.fn().mockResolvedValue({
+            error: null,
+            data: "art",
+          }),
+        },
+        "title--default": {
+          id: "title--default",
+          description: "title",
+          handler: jest.fn().mockRejectedValue(new Error("title threw")),
+        },
+      } as unknown as AilaRuntimeContext["sectionAgents"],
+    });
+
+    const outcome = await ailaTurn({
+      persistedState: createPersistedState(),
+      runtime,
+      callbacks,
+    });
+
+    expect(outcome).toEqual({ status: "success" });
+    expect(callbacks.onTurnComplete).toHaveBeenCalledWith({
+      stepsExecuted: [
+        {
+          type: "section",
+          sectionKey: "subject",
+          action: "generate",
+          sectionInstructions: null,
+        },
+      ],
+      document: { subject: "art" },
+      ailaMessage:
+        "The lesson plan has been updated, but the usual summary wasn't available. Please review the changes and let me know what you'd like to adjust next.",
+    });
+    expect(callbacks.onTurnFailed).not.toHaveBeenCalled();
+  });
+});

--- a/packages/aila/src/lib/agentic-system/ailaTurn.ts
+++ b/packages/aila/src/lib/agentic-system/ailaTurn.ts
@@ -8,16 +8,20 @@ import { executePlanSteps } from "./execution/executePlanSteps";
 import { executePlanningPhase } from "./execution/executePlanningPhase";
 import { handleRelevantLessons } from "./execution/handleRelevantLessons";
 import {
-  terminateWithGenericError,
+  terminateWithFailure,
   terminateWithResponse,
 } from "./execution/termination";
-import type { AilaExecutionContext, AilaTurnArgs } from "./types";
+import type {
+  AilaExecutionContext,
+  AilaTurnArgs,
+  AilaTurnOutcome,
+} from "./types";
 
 export async function ailaTurn({
   persistedState,
   runtime,
   callbacks,
-}: AilaTurnArgs): Promise<void> {
+}: AilaTurnArgs): Promise<AilaTurnOutcome> {
   const context: AilaExecutionContext = {
     persistedState,
     runtime,
@@ -38,38 +42,36 @@ export async function ailaTurn({
 
   try {
     /**
-     * 1. Execute the planning phase
+     * 1. Decide what the turn should do next.
      */
-    const shouldContinue = await executePlanningPhase(context);
-    if (!shouldContinue) return;
+    const planningOutcome = await executePlanningPhase(context);
+    if (planningOutcome.status !== "continue") return planningOutcome;
 
     /**
-     * 2. Execute the planned steps sequentially
+     * 2. Apply any section changes.
      */
-    const planExecuted = await executePlanSteps(context);
-    if (!planExecuted) return;
+    const planOutcome = await executePlanSteps(context);
+    if (planOutcome.status !== "continue") return planOutcome;
 
     /**
-     * 3. Handle relevant lessons fetching if needed
+     * 3. Refresh relevant lessons if the document metadata changed.
      */
-    const lessonsHandled = await handleRelevantLessons(context);
-    if (!lessonsHandled) return;
+    const lessonsOutcome = await handleRelevantLessons(context);
+    if (lessonsOutcome.status !== "continue") return lessonsOutcome;
 
     /**
-     * 4. Generate and deliver the final response
+     * 4. Send the final user-facing message for the turn.
      */
-    await terminateWithResponse(context);
+    return await terminateWithResponse(context);
   } catch (error) {
     const errorContext = {
       message: error instanceof Error ? error.message : "Unknown error",
       stack: error instanceof Error ? error.stack : undefined,
     };
-    context.currentTurn.errors.push(errorContext);
-    // Ensure llmMessage was opened if error occurred before planning completed
+    // Open the llmMessage wrapper before shared failure handling.
     if (!context.currentTurn.plannerOutput) {
       context.callbacks.onPlannerComplete({ sectionKeys: [] });
     }
-    // Handle unexpected errors
-    await terminateWithGenericError(context);
+    return await terminateWithFailure(errorContext, context);
   }
 }

--- a/packages/aila/src/lib/agentic-system/compatibility/ailaTurnCallbacks.test.ts
+++ b/packages/aila/src/lib/agentic-system/compatibility/ailaTurnCallbacks.test.ts
@@ -44,12 +44,13 @@ describe("ailaTurnCallbacks", () => {
   });
   test("onTurnComplete", async () => {
     let chunks = "";
+    const enqueue = jest.fn().mockResolvedValue(undefined);
     const { onTurnComplete } = createAilaTurnCallbacks({
       chat: {
         appendChunk: (chunk) => {
           chunks = chunks + chunk;
         },
-        enqueue: jest.fn().mockResolvedValue(undefined),
+        enqueue,
       },
       controller: {
         enqueue: jest.fn(),
@@ -64,6 +65,41 @@ describe("ailaTurnCallbacks", () => {
     expect(chunks).toEqual(
       `],"sectionsEdited":[],"prompt":{"type":"text","value":"We've updated the subject, title, and key learning points"},"status":"complete"}`,
     );
+    expect(enqueue).toHaveBeenCalledWith({
+      type: "state",
+      reasoning: "final",
+      value: { subject: "art" },
+    });
+  });
+
+  test("onTurnFailed does not enqueue final state", async () => {
+    let chunks = "";
+    const enqueue = jest.fn().mockResolvedValue(undefined);
+    const { onTurnFailed } = createAilaTurnCallbacks({
+      chat: {
+        appendChunk: (chunk) => {
+          chunks = chunks + chunk;
+        },
+        enqueue,
+      },
+      controller: {
+        enqueue: jest.fn(),
+      } as unknown as ReadableStreamDefaultController,
+    });
+
+    await onTurnFailed({
+      stepsExecuted: [],
+      ailaMessage:
+        "I wasn't able to complete that lesson update. Please try again.",
+    });
+
+    expect(chunks).toEqual(
+      `],"sectionsEdited":[],"prompt":{"type":"text","value":"I wasn't able to complete that lesson update. Please try again."},"status":"complete"}`,
+    );
+    expect(enqueue).toHaveBeenCalledWith({
+      type: "comment",
+      value: "AGENTIC_TURN_FAILED",
+    });
   });
 
   test("onSectionComplete with multiple patches", () => {

--- a/packages/aila/src/lib/agentic-system/compatibility/ailaTurnCallbacks.ts
+++ b/packages/aila/src/lib/agentic-system/compatibility/ailaTurnCallbacks.ts
@@ -32,5 +32,12 @@ export function createAilaTurnCallbacks({
         value: args.document,
       });
     },
+    onTurnFailed: async (args) => {
+      onTurnComplete(args);
+      await chat.enqueue({
+        type: "comment",
+        value: "AGENTIC_TURN_FAILED",
+      });
+    },
   };
 }

--- a/packages/aila/src/lib/agentic-system/execution/executePlanSteps.ts
+++ b/packages/aila/src/lib/agentic-system/execution/executePlanSteps.ts
@@ -1,12 +1,22 @@
 import { aiLogger } from "@oakai/logger";
 
-import { enablePatches, produceWithPatches } from "immer";
+import { type Draft, enablePatches, produceWithPatches } from "immer";
 
+import type { PartialLessonPlan } from "../../../protocol/schema";
 import { CompletedLessonPlanSchema } from "../../../protocol/schema";
 import { sectionStepToAgentId } from "../agents/sectionAgents/sectionStepToAgentId";
 import { immerPatchToJsonPatch } from "../compatibility/helpers/immerPatchToJsonPatch";
-import type { AilaExecutionContext } from "../types";
-import { terminateWithError } from "./termination";
+import type { PlanStep } from "../schema";
+import type {
+  AgentResult,
+  AilaExecutionContext,
+  AilaTurnPhaseOutcome,
+} from "../types";
+import {
+  shouldForceSectionFailure,
+  shouldForceSectionThrow,
+} from "../utils/faultInjection";
+import { terminateWithFailure } from "./termination";
 
 const log = aiLogger("aila:agents");
 
@@ -14,77 +24,118 @@ enablePatches();
 
 /**
  * Execute each step in the plan sequentially using immer to track changes.
- * @returns false if the turn should end due to error, true if successful
+ * @returns `continue` if step execution finished, otherwise a terminal turn outcome
  */
 export async function executePlanSteps(
   context: AilaExecutionContext,
-): Promise<boolean> {
+): Promise<AilaTurnPhaseOutcome> {
   const plannerDecision = context.currentTurn.plannerOutput;
   if (!plannerDecision || plannerDecision.decision !== "plan") {
-    return true; // No plan to execute
+    return { status: "continue" };
   }
 
   for (const step of plannerDecision.plan) {
     context.currentTurn.currentStep = step;
-    context.currentTurn.stepsExecuted.push(step);
-
-    if (step.action === "delete") {
-      const [nextDoc, patches] = produceWithPatches(
-        context.currentTurn.document,
-        (draft) => {
-          delete draft[step.sectionKey];
-        },
-      );
-      context.currentTurn.document = nextDoc;
-      context.callbacks.onSectionComplete(patches.map(immerPatchToJsonPatch));
-      continue;
-    }
-
-    // Execute generation step
-    const agentId = sectionStepToAgentId(step, {
-      config: context.runtime.config,
-      document: context.currentTurn.document,
-    });
-    const agent = context.runtime.sectionAgents[agentId];
-    const result = await agent.handler(context);
-
-    if (result.error) {
-      log.error(
-        `Section generation failed [${step.sectionKey}]: ${result.error.message}`,
-      );
-      await terminateWithError(result.error, context, step.sectionKey);
-      return false;
-    }
-
-    if (result.note) {
-      log.info(
-        `Section generated with note [${step.sectionKey}]: ${result.note}`,
-      );
-      context.currentTurn.notes.push({
-        message: result.note,
-        sectionKey: step.sectionKey,
-      });
-    }
-
-    const sectionSchema = CompletedLessonPlanSchema.shape[step.sectionKey];
-    const validated = sectionSchema.parse(result.data);
-
-    // We use immer to generate JSON patches at the granularity we control.
-    // Patches are generated at the exact path we mutate:
-    // - `draft.starterQuiz = newQuiz` → patch at `/starterQuiz` (top-level)
-    // - `draft.starterQuiz.questions[0] = q` → patch at `/starterQuiz/questions/0` (fine-grained)
-    // Currently we do top-level assignments because the streaming schema only accepts
-    // top-level patches. If we later want fine-grained updates, we change how we mutate.
-    const [nextDoc, patches] = produceWithPatches(
-      context.currentTurn.document,
-      (draft) => {
-        (draft as Record<string, unknown>)[step.sectionKey] = validated;
-      },
-    );
-
-    context.currentTurn.document = nextDoc;
-    context.callbacks.onSectionComplete(patches.map(immerPatchToJsonPatch));
+    const stepOutcome = await executePlanStep(context, step);
+    if (stepOutcome.status !== "continue") return stepOutcome;
   }
 
-  return true;
+  return { status: "continue" };
+}
+
+async function executePlanStep(
+  context: AilaExecutionContext,
+  step: PlanStep,
+): Promise<AilaTurnPhaseOutcome> {
+  if (step.action === "delete") {
+    executeDeleteStep(context, step);
+    return { status: "continue" };
+  }
+
+  return await executeGenerateStep(context, step);
+}
+
+function executeDeleteStep(context: AilaExecutionContext, step: PlanStep) {
+  commitStepUpdate(context, step, (draft) => {
+    delete draft[step.sectionKey];
+  });
+}
+
+async function executeGenerateStep(
+  context: AilaExecutionContext,
+  step: PlanStep,
+): Promise<AilaTurnPhaseOutcome> {
+  const result = await runSectionAgent(context, step);
+
+  if (result.error) {
+    log.error(
+      `Section generation failed [${step.sectionKey}]: ${result.error.message}`,
+    );
+    return await terminateWithFailure(result.error, context, step.sectionKey);
+  }
+
+  if (result.note) {
+    log.info(
+      `Section generated with note [${step.sectionKey}]: ${result.note}`,
+    );
+    context.currentTurn.notes.push({
+      message: result.note,
+      sectionKey: step.sectionKey,
+    });
+  }
+
+  const sectionSchema = CompletedLessonPlanSchema.shape[step.sectionKey];
+  const validated = sectionSchema.parse(result.data);
+
+  // We use immer to generate JSON patches at the granularity we control.
+  // Patches are generated at the exact path we mutate:
+  // - `draft.starterQuiz = newQuiz` → patch at `/starterQuiz` (top-level)
+  // - `draft.starterQuiz.questions[0] = q` → patch at `/starterQuiz/questions/0` (fine-grained)
+  // Currently we do top-level assignments because the streaming schema only accepts
+  // top-level patches. If we later want fine-grained updates, we change how we mutate.
+  commitStepUpdate(context, step, (draft) => {
+    (draft as Record<string, unknown>)[step.sectionKey] = validated;
+  });
+
+  return { status: "continue" };
+}
+
+async function runSectionAgent(
+  context: AilaExecutionContext,
+  step: PlanStep,
+): Promise<AgentResult<unknown>> {
+  const agentId = sectionStepToAgentId(step, {
+    config: context.runtime.config,
+    document: context.currentTurn.document,
+  });
+  const agent = context.runtime.sectionAgents[agentId];
+  const forceSectionThrow = shouldForceSectionThrow(step.sectionKey);
+  const forceSectionFailure = shouldForceSectionFailure(step.sectionKey);
+
+  if (forceSectionThrow) {
+    throw new Error(`Forced agentic section throw [${step.sectionKey}]`);
+  }
+
+  return forceSectionFailure
+    ? {
+        error: {
+          message: `Forced agentic section failure [${step.sectionKey}]`,
+        },
+      }
+    : await agent.handler(context);
+}
+
+function commitStepUpdate(
+  context: AilaExecutionContext,
+  step: PlanStep,
+  updateDocument: (draft: Draft<PartialLessonPlan>) => void,
+) {
+  const [nextDoc, patches] = produceWithPatches(
+    context.currentTurn.document,
+    updateDocument,
+  );
+
+  context.currentTurn.document = nextDoc;
+  context.callbacks.onSectionComplete(patches.map(immerPatchToJsonPatch));
+  context.currentTurn.stepsExecuted.push(step);
 }

--- a/packages/aila/src/lib/agentic-system/execution/executePlanningPhase.ts
+++ b/packages/aila/src/lib/agentic-system/execution/executePlanningPhase.ts
@@ -1,31 +1,39 @@
-import type { AilaExecutionContext } from "../types";
-import { terminateWithError, terminateWithResponse } from "./termination";
+import type { AilaExecutionContext, AilaTurnPhaseOutcome } from "../types";
+import {
+  shouldForcePlannerFailure,
+  shouldForcePlannerThrow,
+} from "../utils/faultInjection";
+import { terminateWithFailure, terminateWithResponse } from "./termination";
 
 /**
  * Execute the planning phase using the planner agent
- * @returns false if the turn should end, true if it should continue
+ * @returns `continue` to move to step execution, otherwise a terminal turn outcome
  */
 export async function executePlanningPhase(
   context: AilaExecutionContext,
-): Promise<boolean> {
-  const plannerResponse = await context.runtime.plannerAgent({
-    messages: context.persistedState.messages,
-    document: context.persistedState.initialDocument,
-    relevantLessons: context.persistedState.relevantLessons,
-  });
+): Promise<AilaTurnPhaseOutcome> {
+  if (shouldForcePlannerThrow()) {
+    throw new Error("Forced agentic planner throw");
+  }
+
+  const plannerResponse = shouldForcePlannerFailure()
+    ? { error: { message: "Forced agentic planner failure" } }
+    : await context.runtime.plannerAgent({
+        messages: context.persistedState.messages,
+        document: context.persistedState.initialDocument,
+        relevantLessons: context.persistedState.relevantLessons,
+      });
 
   if (plannerResponse.error) {
     context.callbacks.onPlannerComplete({ sectionKeys: [] });
-    await terminateWithError(plannerResponse.error, context);
-    return false;
+    return await terminateWithFailure(plannerResponse.error, context);
   }
 
   context.currentTurn.plannerOutput = plannerResponse.data;
 
   if (context.currentTurn.plannerOutput.decision === "exit") {
     context.callbacks.onPlannerComplete({ sectionKeys: [] });
-    await terminateWithResponse(context);
-    return false;
+    return await terminateWithResponse(context);
   }
 
   context.callbacks.onPlannerComplete({
@@ -34,5 +42,5 @@ export async function executePlanningPhase(
     ),
   });
 
-  return true;
+  return { status: "continue" };
 }

--- a/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.ts
+++ b/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.ts
@@ -1,23 +1,23 @@
-import type { AilaExecutionContext } from "../types";
+import type { AilaExecutionContext, AilaTurnPhaseOutcome } from "../types";
 import { terminateWithResponse } from "./termination";
 
 /**
  * Handle fetching relevant lessons if document metadata has changed
- * @returns false if the turn should end to show lessons, true if it should continue
+ * @returns `continue` to keep going, otherwise a terminal turn outcome
  */
 export async function handleRelevantLessons(
   context: AilaExecutionContext,
-): Promise<boolean> {
+): Promise<AilaTurnPhaseOutcome> {
   const { title, subject, keyStage, basedOn } = context.currentTurn.document;
 
   if (!title || !subject || !keyStage) {
     // if any of the above sections are missing, do not refetch RAG lessons
-    return true;
+    return { status: "continue" };
   }
 
   if (basedOn) {
     // if the user has already chosen a lesson to adapt, do not refetch RAG lessons
-    return true;
+    return { status: "continue" };
   }
 
   const hasDocumentMetadataChanged =
@@ -27,16 +27,15 @@ export async function handleRelevantLessons(
 
   if (!hasDocumentMetadataChanged) {
     // if above sections remain unchanged, do not refetch RAG lessons
-    return true;
+    return { status: "continue" };
   }
   context.currentTurn.relevantLessons =
     await context.runtime.fetchRelevantLessons({ title, subject, keyStage });
   context.currentTurn.relevantLessonsFetched = true;
 
   if (context.currentTurn.relevantLessons.length > 0) {
-    await terminateWithResponse(context);
-    return false;
+    return await terminateWithResponse(context);
   }
 
-  return true;
+  return { status: "continue" };
 }

--- a/packages/aila/src/lib/agentic-system/execution/termination.ts
+++ b/packages/aila/src/lib/agentic-system/execution/termination.ts
@@ -1,20 +1,37 @@
 import type { SectionKey } from "../schema";
-import type { AilaExecutionContext } from "../types";
+import type { AilaExecutionContext, AilaTurnOutcome } from "../types";
+import {
+  shouldForceMessageToUserFailure,
+  shouldForceMessageToUserThrow,
+} from "../utils/faultInjection";
 import {
   displayRelevantLessons,
-  genericErrorMessage,
+  hardFailureMessage,
+  messageToUserFallbackMessage,
 } from "../utils/fixedResponses";
 
 /**
- * Handle errors that occur during the turn execution
+ * Handle hard failures that occur during turn execution.
  */
-export async function terminateWithError(
+export async function terminateWithFailure(
   error: { message: string },
   context: AilaExecutionContext,
   sectionKey?: SectionKey,
-): Promise<void> {
+): Promise<AilaTurnOutcome> {
+  if (context.currentTurn.stepsExecuted.length > 0) {
+    context.currentTurn.errors.push({ ...error, sectionKey });
+    return await terminateWithCustomMessage(
+      messageToUserFallbackMessage(),
+      context,
+    );
+  }
+
   context.currentTurn.errors.push({ ...error, sectionKey });
-  await terminateWithResponse(context);
+  await context.callbacks.onTurnFailed({
+    stepsExecuted: context.currentTurn.stepsExecuted,
+    ailaMessage: hardFailureMessage(),
+  });
+  return { status: "failed" };
 }
 
 /**
@@ -22,48 +39,55 @@ export async function terminateWithError(
  */
 export async function terminateWithResponse(
   context: AilaExecutionContext,
-): Promise<void> {
+): Promise<AilaTurnOutcome> {
   if (context.currentTurn.relevantLessonsFetched) {
     const { relevantLessons } = context.currentTurn;
-    if (!relevantLessons?.length) {
-      await terminateWithCustomMessage("No relevant lessons found.", context);
-      return;
-    } else {
-      const message = displayRelevantLessons(
-        relevantLessons.map((lesson) => lesson.lessonPlan),
-      );
-      await terminateWithCustomMessage(message, context);
-      return;
+    const message = relevantLessons?.length
+      ? displayRelevantLessons(relevantLessons.map((l) => l.lessonPlan))
+      : "No relevant lessons found.";
+    return await terminateWithCustomMessage(message, context);
+  }
+
+  if (shouldForceMessageToUserFailure()) {
+    return await resolveMessageToUserError(
+      { message: "Forced agentic message-to-user failure" },
+      context,
+    );
+  }
+
+  if (shouldForceMessageToUserThrow()) {
+    throw new Error("Forced agentic message-to-user throw");
+  }
+
+  try {
+    const messageResult = await context.runtime.messageToUserAgent({
+      messages: context.persistedState.messages,
+      prevDoc: context.persistedState.initialDocument,
+      nextDoc: context.currentTurn.document,
+      stepsExecuted: context.currentTurn.stepsExecuted,
+      errors: context.currentTurn.errors,
+      notes: context.currentTurn.notes,
+      plannerOutput: context.currentTurn.plannerOutput,
+      relevantLessons: context.persistedState.relevantLessons,
+      relevantLessonsFetched: context.currentTurn.relevantLessonsFetched,
+    });
+
+    if (messageResult.error) {
+      return await resolveMessageToUserError(messageResult.error, context);
     }
+
+    return await terminateWithCustomMessage(
+      messageResult.data.message,
+      context,
+    );
+  } catch (error) {
+    return await resolveMessageToUserError(
+      {
+        message: error instanceof Error ? error.message : "Unknown error",
+      },
+      context,
+    );
   }
-
-  const messageResult = await context.runtime.messageToUserAgent({
-    messages: context.persistedState.messages,
-    prevDoc: context.persistedState.initialDocument,
-    nextDoc: context.currentTurn.document,
-    stepsExecuted: context.currentTurn.stepsExecuted,
-    errors: context.currentTurn.errors,
-    notes: context.currentTurn.notes,
-    plannerOutput: context.currentTurn.plannerOutput,
-    relevantLessons: context.persistedState.relevantLessons,
-    relevantLessonsFetched: context.currentTurn.relevantLessonsFetched,
-  });
-
-  if (messageResult.error) {
-    await terminateWithGenericError(context);
-    return;
-  }
-
-  await terminateWithCustomMessage(messageResult.data.message, context);
-}
-
-/**
- * Handle cases where the presentation agent itself fails
- */
-export async function terminateWithGenericError(
-  context: AilaExecutionContext,
-): Promise<void> {
-  await terminateWithCustomMessage(genericErrorMessage(), context);
 }
 
 /**
@@ -72,10 +96,26 @@ export async function terminateWithGenericError(
 export async function terminateWithCustomMessage(
   message: string,
   context: AilaExecutionContext,
-): Promise<void> {
+): Promise<AilaTurnOutcome> {
   await context.callbacks.onTurnComplete({
     stepsExecuted: context.currentTurn.stepsExecuted,
     document: context.currentTurn.document,
     ailaMessage: message,
   });
+  return { status: "success" };
+}
+
+async function resolveMessageToUserError(
+  error: { message: string },
+  context: AilaExecutionContext,
+): Promise<AilaTurnOutcome> {
+  if (context.currentTurn.stepsExecuted.length === 0) {
+    return await terminateWithFailure(error, context);
+  }
+
+  context.currentTurn.errors.push(error);
+  return await terminateWithCustomMessage(
+    messageToUserFallbackMessage(),
+    context,
+  );
 }

--- a/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
@@ -352,6 +352,10 @@ async function runOnce(scenario: ScenarioConfig): Promise<RunCapture> {
           turnMessage = ailaMessage;
           return Promise.resolve();
         },
+        onTurnFailed: ({ ailaMessage }) => {
+          turnMessage = ailaMessage;
+          return Promise.resolve();
+        },
       };
 
       await ailaTurn({ persistedState: persisted, runtime, callbacks });

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
-codeHash: e9d51427ad374d628104ec70b9c592e9979d45399e91385ba9c08e79ba751afe
-generated: 2026-04-22T13:19:26.182Z
+codeHash: 1f4e1d2bbcc9baf26dee99550828b73422989b1a59dec54f0561bd460b7acc22
+generated: 2026-04-22T15:07:48.958Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -7,8 +7,8 @@ summary:
       flag: 2
       pass: 1
     additional-materials-tone:
-      pass: 1
-      skip: 2
+      pass: 2
+      skip: 1
     cycle-verbosity:
       pass: 3
     keyword-casing:
@@ -19,10 +19,10 @@ summary:
       pass: 3
   no-rag-lesson:
     plan-groupings:
-      flag: 3
-    additional-materials-tone:
-      skip: 2
       pass: 1
+      flag: 2
+    additional-materials-tone:
+      skip: 3
     cycle-verbosity:
       pass: 3
     keyword-casing:

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
-codeHash: 5499b3383906dd052cbc174e2a515face573d7cd591457cf8aaaf7546244dd19
-generated: 2026-02-24T12:45:22.745Z
+codeHash: e9d51427ad374d628104ec70b9c592e9979d45399e91385ba9c08e79ba751afe
+generated: 2026-04-22T13:19:26.182Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -7,8 +7,8 @@ summary:
       flag: 2
       pass: 1
     additional-materials-tone:
-      pass: 2
-      skip: 1
+      pass: 1
+      skip: 2
     cycle-verbosity:
       pass: 3
     keyword-casing:
@@ -21,7 +21,8 @@ summary:
     plan-groupings:
       flag: 3
     additional-materials-tone:
-      skip: 3
+      skip: 2
+      pass: 1
     cycle-verbosity:
       pass: 3
     keyword-casing:

--- a/packages/aila/src/lib/agentic-system/types.ts
+++ b/packages/aila/src/lib/agentic-system/types.ts
@@ -69,6 +69,10 @@ export type AilaTurnCallbacks = {
     document: PartialLessonPlan;
     ailaMessage: string;
   }) => void | Promise<void>;
+  onTurnFailed: (props: {
+    stepsExecuted: PlanStep[];
+    ailaMessage: string;
+  }) => void | Promise<void>;
 };
 
 export type AilaTurnArgs = {
@@ -77,10 +81,9 @@ export type AilaTurnArgs = {
   callbacks: AilaTurnCallbacks;
 };
 
-export type AilaTurnResult = {
-  persistedState: AilaPersistedState;
-  currentTurn: AilaCurrentTurn;
-};
+export type AilaTurnOutcome = { status: "success" } | { status: "failed" };
+
+export type AilaTurnPhaseOutcome = { status: "continue" } | AilaTurnOutcome;
 
 export type AilaExecutionContext = {
   persistedState: AilaPersistedState;

--- a/packages/aila/src/lib/agentic-system/utils/faultInjection.ts
+++ b/packages/aila/src/lib/agentic-system/utils/faultInjection.ts
@@ -1,0 +1,117 @@
+import { aiLogger } from "@oakai/logger";
+
+import type { SectionKey } from "../schema";
+
+const log = aiLogger("aila:agents");
+
+type ForcedFailure =
+  | { stage: "planner" }
+  | { stage: "planner_throw" }
+  | { stage: "message_to_user" }
+  | { stage: "message_to_user_throw" }
+  | { stage: "section"; sectionKey?: SectionKey }
+  | { stage: "section_throw"; sectionKey?: SectionKey };
+
+function isFaultInjectionEnabled() {
+  return (
+    process.env.NODE_ENV !== "production" &&
+    process.env.NEXT_PUBLIC_ENVIRONMENT !== "prd"
+  );
+}
+
+function parseForcedFailure(rawValue: string): ForcedFailure | null {
+  if (rawValue === "planner") {
+    return { stage: "planner" };
+  }
+
+  if (rawValue === "planner_throw") {
+    return { stage: "planner_throw" };
+  }
+
+  if (rawValue === "message_to_user") {
+    return { stage: "message_to_user" };
+  }
+
+  if (rawValue === "message_to_user_throw") {
+    return { stage: "message_to_user_throw" };
+  }
+
+  if (rawValue === "section") {
+    return { stage: "section" };
+  }
+
+  if (rawValue === "section_throw") {
+    return { stage: "section_throw" };
+  }
+
+  if (rawValue.startsWith("section:")) {
+    return {
+      stage: "section",
+      sectionKey: rawValue.slice("section:".length) as SectionKey,
+    };
+  }
+
+  if (rawValue.startsWith("section_throw:")) {
+    return {
+      stage: "section_throw",
+      sectionKey: rawValue.slice("section_throw:".length) as SectionKey,
+    };
+  }
+
+  return null;
+}
+
+function getForcedFailure(): ForcedFailure | null {
+  if (!isFaultInjectionEnabled()) {
+    return null;
+  }
+
+  const rawValue = process.env.AILA_AGENTIC_FORCE_FAIL;
+  if (!rawValue) {
+    return null;
+  }
+
+  const forcedFailure = parseForcedFailure(rawValue);
+  if (!forcedFailure) {
+    log.warn("Ignoring invalid AILA_AGENTIC_FORCE_FAIL value", {
+      value: rawValue,
+    });
+    return null;
+  }
+
+  return forcedFailure;
+}
+
+export function shouldForcePlannerFailure() {
+  return getForcedFailure()?.stage === "planner";
+}
+
+export function shouldForcePlannerThrow() {
+  return getForcedFailure()?.stage === "planner_throw";
+}
+
+export function shouldForceSectionFailure(sectionKey: SectionKey) {
+  const forcedFailure = getForcedFailure();
+
+  return (
+    forcedFailure?.stage === "section" &&
+    (!forcedFailure.sectionKey || forcedFailure.sectionKey === sectionKey)
+  );
+}
+
+export function shouldForceSectionThrow(sectionKey: SectionKey) {
+  const forcedFailure = getForcedFailure();
+
+  return (
+    forcedFailure?.stage === "section_throw" &&
+    (!forcedFailure.sectionKey || forcedFailure.sectionKey === sectionKey)
+  );
+}
+
+export function shouldForceMessageToUserFailure() {
+  return getForcedFailure()?.stage === "message_to_user";
+}
+
+export function shouldForceMessageToUserThrow() {
+  return getForcedFailure()?.stage === "message_to_user_throw";
+}

--- a/packages/aila/src/lib/agentic-system/utils/fixedResponses.ts
+++ b/packages/aila/src/lib/agentic-system/utils/fixedResponses.ts
@@ -6,6 +6,10 @@ ${relevantLessons.map((lesson, i) => `${i + 1}. ${lesson.title}`).join("\n")}
 Would you like to base your lesson on one of these? Otherwise we can create one from scratch!`;
 }
 
-export function genericErrorMessage(): string {
-  return "We encountered an error while processing your request.";
+export function hardFailureMessage(): string {
+  return "I wasn't able to complete that lesson update. Please try again.";
+}
+
+export function messageToUserFallbackMessage(): string {
+  return "The lesson plan has been updated, but the usual summary wasn't available. Please review the changes and let me know what you'd like to adjust next.";
 }

--- a/packages/db/client/index.ts
+++ b/packages/db/client/index.ts
@@ -4,6 +4,7 @@ import { PrismaClient } from "@prisma/client";
 import { withAccelerate } from "@prisma/extension-accelerate";
 
 const log = aiLogger("db");
+const shouldLogQueries = process.env.LOG_DB_QUERIES === "true";
 
 const createPrismaClient = () => {
   const client = new PrismaClient({
@@ -11,14 +12,18 @@ const createPrismaClient = () => {
       { emit: "stdout", level: "error" },
       // Prisma supports DEBUG strings (eg: prisma*, prisma:client), but they're noisy debug messages.
       // Instead, we forward the typical logs based on ai:db
-      { emit: "event", level: "query" },
       { emit: "event", level: "warn" },
+      ...(shouldLogQueries
+        ? [{ emit: "event" as const, level: "query" as const }]
+        : []),
     ],
   });
 
-  client.$on("query", (e) => {
-    log.info(e.query);
-  });
+  if (shouldLogQueries) {
+    client.$on("query", (e) => {
+      log.info(e.query);
+    });
+  }
   client.$on("warn", (e) => {
     log.info(e.message);
   });

--- a/turbo.json
+++ b/turbo.json
@@ -106,6 +106,7 @@
     }
   },
   "globalEnv": [
+    "AILA_AGENTIC_FORCE_FAIL",
     "AILA_FIXTURES_ENABLED",
     "AILA_QUIZ_GENERATORS",
     "CLERK_*",


### PR DESCRIPTION
## Description 

This PR tightens Agentic Aila error handling ahead of rollout, while preserving partial progress when some section updates have already been applied.

The main change is to distinguish between:

- true hard failures, where no section updates were successfully applied
- partial successes, where one or more section updates were applied before a later failure

With this change:

- zero-progress agentic turns now fail cleanly and do not persist
- turns with applied section updates now persist those updates and finish with a fallback user-facing message if a later step fails
- failed agentic turns emit an explicit failed-turn marker for frontend handling and tracking
- successful partial turns continue through the normal persistence path

This PR also makes the agentic turn flow easier to follow by introducing explicit phase outcomes and refactoring plan-step execution.

Separately, it fixes a bug in `serverSideFeatureFlag()` where cached boolean true values were being treated as false on cache hits. That fix is shared infrastructure and is not specific to Agentic Aila.

## Production impact

The agentic turn-handling changes remain behind the Agentic Aila path and are not active in the current production non-agentic chat flow.

The only shared runtime change is the server-side feature flag cache fix.

## Other changes

- Adds fault-injection hooks and manual-testing notes for agentic failure paths so engineers can test failures locally
- Makes failed-turn detection use the parsed protocol comment instead of string matching
- Suppresses completion tracking for true failed agentic turns while allowing persisted partial successes
- chore: Makes Prisma query logging opt-in via `LOG_DB_QUERIES=true`

## Testing

Validated with targeted Jest suites for:

- agentic turn execution and stream completion
- failed-turn frontend/store handling
- lesson-plan tracking behavior
- server-side feature flag cache regression

## Testing Plan

No code changes have been made to non-agentic Aila, so the only testing requirement for this PR is to verify that non-Agentic Aila continues to function as expected.