### PR TITLE
chore: add cloud-ops dependabot and CODEOWNERS config [ENG-1499]

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,5 @@
+# Tag cloud-ops for any terraform changes
+infrastructure/ @oaknational/cloud-ops
+
+# Tag cloud-ops for any changes to terraform workflows
+.github/workflows/terraform_*.yml @oaknational/cloud-ops

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,19 @@
+version: 2
+updates:
+
+# Track updates for Github Actions workflows from oak-terraform-actions repository.
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    allow:
+      - dependency-name: "oaknational/oak-terraform-actions"
+      - dependency-name: "oaknational/oak-release-actions"
+    schedule:
+      interval: "daily"
+
+# Track updates for Terraform modules from oak-terraform-modules repository.
+  - package-ecosystem: "terraform"
+    directories: ["infrastructure/**/*"]
+    allow:
+      - dependency-name: "*::github::oaknational/oak-terraform-modules::*"
+    schedule:
+      interval: "daily"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,6 @@
 version: 2
 updates:
-
-# Track updates for Github Actions workflows from oak-terraform-actions repository.
+  # Track updates for Github Actions workflows from oak-terraform-actions repository.
   - package-ecosystem: "github-actions"
     directory: "/"
     allow:
@@ -10,7 +9,7 @@ updates:
     schedule:
       interval: "daily"
 
-# Track updates for Terraform modules from oak-terraform-modules repository.
+  # Track updates for Terraform modules from oak-terraform-modules repository.
   - package-ecosystem: "terraform"
     directories: ["infrastructure/**/*"]
     allow:


### PR DESCRIPTION
## Description

- use dependabot to update terraform modules and terraform related github actions
- use codeowners to tag cloud-ops in the resulting PRs

## Issue(s)

[ENG-1499](https://www.notion.so/oaknationalacademy/Run-our-custom-Terraform-linter-as-a-step-in-our-terraform-checks-GH-action-32126cc4e1b1801084c4ebdf155b462a)