### PR TITLE
chore: remove unused final state - AI-2151

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/Chat/utils/index.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/Chat/utils/index.ts
@@ -1,5 +1,3 @@
-import type { Message } from "ai/react";
-
 interface IdPart {
   type: "id";
   value: string;

--- a/apps/nextjs/src/components/AppComponents/Chat/Chat/utils/index.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/Chat/utils/index.ts
@@ -1,10 +1,4 @@
-import type { PartialLessonPlan } from "@oakai/aila/src/protocol/schema";
-import { aiLogger } from "@oakai/logger";
-
 import type { Message } from "ai/react";
-import { z } from "zod";
-
-const log = aiLogger("chat");
 
 interface IdPart {
   type: "id";
@@ -38,46 +32,6 @@ export function findMessageIdFromContent({
       }
     })
     .find(isIdPart)?.value;
-}
-
-interface StatePart {
-  type: "state";
-  value: PartialLessonPlan;
-}
-
-const statePartSchema = z.object({
-  type: z.literal("state"),
-  value: z.object({}).passthrough(),
-});
-
-export function findLatestServerSideState(
-  workingMessages: Message[],
-): PartialLessonPlan | undefined {
-  log.info("Finding latest server-side state", { workingMessages });
-  const lastMessage = workingMessages[workingMessages.length - 1];
-  if (!lastMessage?.content.includes('"type":"state"')) {
-    log.info("No server state found");
-    return undefined;
-  }
-
-  const stateParts = lastMessage.content
-    .split("␞")
-    .map((s) => {
-      try {
-        const parsed = JSON.parse(s.trim());
-        return statePartSchema.safeParse(parsed);
-      } catch {
-        // ignore invalid JSON
-        return { success: false };
-      }
-    })
-    .filter((result): result is z.SafeParseSuccess<StatePart> => result.success)
-    .map((result) => result.data);
-
-  const latestState = stateParts[stateParts.length - 1]?.value;
-
-  log.info("Got latest server state", { state: latestState });
-  return latestState;
 }
 
 export function openSharePage(chat: { id: string }) {

--- a/apps/nextjs/src/hooks/useDemoLocking.test.ts
+++ b/apps/nextjs/src/hooks/useDemoLocking.test.ts
@@ -1,0 +1,269 @@
+import type { PartialLessonPlan } from "@oakai/aila/src/protocol/schema";
+
+import type { AiMessage } from "@/stores/chatStore";
+
+import {
+  findFirstCompleteAssistantMessage,
+  replayLessonPlanFromMessages,
+} from "./useDemoLocking";
+
+const fixedDate = new Date("2023-01-01T12:00:00.000Z");
+
+// Helper to create a message with patches
+const createAssistantMessageWithPatches = (
+  id: string,
+  patches: Array<{ op: "add" | "replace"; path: string; value: unknown }>,
+): AiMessage => {
+  const patchContent = patches
+    .map(
+      (patch) =>
+        `{\n  "type": "patch",\n  "reasoning": "test",\n  "value": ${JSON.stringify(patch)},\n  "status": "complete"\n}`,
+    )
+    .map((patch) => `␞\n${patch}\n␞`)
+    .join("\n");
+
+  return {
+    id,
+    role: "assistant",
+    content: patchContent,
+    createdAt: fixedDate,
+  };
+};
+
+const createUserMessage = (id: string, content: string): AiMessage => {
+  return {
+    id,
+    role: "user",
+    content,
+    createdAt: fixedDate,
+  };
+};
+
+const isLessonCompleteMock = (lesson: PartialLessonPlan): boolean => {
+  // A lesson is complete when it has title and subject
+  return !!(lesson.title && lesson.subject);
+};
+
+describe("useDemoLocking helpers", () => {
+  describe("replayLessonPlanFromMessages", () => {
+    it("returns empty object when there are no messages", () => {
+      const messages: AiMessage[] = [];
+      const result = replayLessonPlanFromMessages(messages);
+
+      expect(result).toEqual({});
+    });
+
+    it("skips user messages", () => {
+      const messages: AiMessage[] = [createUserMessage("u1", "Hello")];
+      const result = replayLessonPlanFromMessages(messages);
+
+      expect(result).toEqual({});
+    });
+
+    it("applies patches from assistant messages in order", () => {
+      const messages: AiMessage[] = [
+        createAssistantMessageWithPatches("a1", [
+          { op: "add", path: "/title", value: "My Lesson" },
+        ]),
+        createAssistantMessageWithPatches("a2", [
+          { op: "add", path: "/subject", value: "English" },
+        ]),
+      ];
+
+      const result = replayLessonPlanFromMessages(messages);
+
+      expect(result).toEqual({
+        title: "My Lesson",
+        subject: "English",
+      });
+    });
+
+    it("handles multiple patches in a single message", () => {
+      const messages: AiMessage[] = [
+        createAssistantMessageWithPatches("a1", [
+          { op: "add", path: "/title", value: "My Lesson" },
+          { op: "add", path: "/subject", value: "Math" },
+        ]),
+      ];
+
+      const result = replayLessonPlanFromMessages(messages);
+
+      expect(result).toEqual({
+        title: "My Lesson",
+        subject: "Math",
+      });
+    });
+
+    it("replaces values when using replace operation", () => {
+      const messages: AiMessage[] = [
+        createAssistantMessageWithPatches("a1", [
+          { op: "add", path: "/title", value: "First Title" },
+        ]),
+        createAssistantMessageWithPatches("a2", [
+          { op: "replace", path: "/title", value: "Second Title" },
+        ]),
+      ];
+
+      const result = replayLessonPlanFromMessages(messages);
+
+      expect(result.title).toBe("Second Title");
+    });
+
+    it("mixes user and assistant messages, only applying assistant patches", () => {
+      const messages: AiMessage[] = [
+        createUserMessage("u1", "Create a lesson"),
+        createAssistantMessageWithPatches("a1", [
+          { op: "add", path: "/title", value: "Lesson Title" },
+        ]),
+        createUserMessage("u2", "Continue"),
+        createAssistantMessageWithPatches("a2", [
+          { op: "add", path: "/subject", value: "Science" },
+        ]),
+      ];
+
+      const result = replayLessonPlanFromMessages(messages);
+
+      expect(result).toEqual({
+        title: "Lesson Title",
+        subject: "Science",
+      });
+    });
+  });
+
+  describe("findFirstCompleteAssistantMessage", () => {
+    it("returns null when no messages", () => {
+      const messages: AiMessage[] = [];
+      const result = findFirstCompleteAssistantMessage(
+        messages,
+        isLessonCompleteMock,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("returns null when completeness is never achieved", () => {
+      const messages: AiMessage[] = [
+        createAssistantMessageWithPatches("a1", [
+          { op: "add", path: "/title", value: "Just a title" },
+        ]),
+      ];
+
+      const result = findFirstCompleteAssistantMessage(
+        messages,
+        isLessonCompleteMock,
+      );
+
+      expect(result).toBeNull();
+    });
+
+    it("returns the message where completeness first becomes true", () => {
+      const messages: AiMessage[] = [
+        createUserMessage("u1", "Start"),
+        createAssistantMessageWithPatches("a1", [
+          { op: "add", path: "/title", value: "Lesson" },
+        ]),
+        createAssistantMessageWithPatches("a2", [
+          { op: "add", path: "/subject", value: "Math" },
+        ]),
+      ];
+
+      const result = findFirstCompleteAssistantMessage(
+        messages,
+        isLessonCompleteMock,
+      );
+
+      expect(result?.id).toBe("a2");
+    });
+
+    it("returns first complete message even if later messages exist", () => {
+      const messages: AiMessage[] = [
+        createAssistantMessageWithPatches("a1", [
+          { op: "add", path: "/title", value: "Lesson" },
+          { op: "add", path: "/subject", value: "Math" },
+        ]),
+        createAssistantMessageWithPatches("a2", [
+          { op: "add", path: "/topic", value: "Algebra" },
+        ]),
+      ];
+
+      const result = findFirstCompleteAssistantMessage(
+        messages,
+        isLessonCompleteMock,
+      );
+
+      expect(result?.id).toBe("a1");
+    });
+
+    it("skips incomplete messages before finding complete one", () => {
+      const messages: AiMessage[] = [
+        createAssistantMessageWithPatches("a1", [
+          { op: "add", path: "/title", value: "First" },
+        ]),
+        createUserMessage("u1", "User input"),
+        createAssistantMessageWithPatches("a2", [
+          { op: "add", path: "/subject", value: "English" },
+        ]),
+      ];
+
+      const result = findFirstCompleteAssistantMessage(
+        messages,
+        isLessonCompleteMock,
+      );
+
+      expect(result?.id).toBe("a2");
+    });
+
+    it("correctly handles completeness flip with custom predicate", () => {
+      const strictComplete = (lesson: PartialLessonPlan): boolean => {
+        // Considered complete when has 3+ required fields
+        const fieldsPresent = [
+          lesson.title,
+          lesson.subject,
+          lesson.keyStage,
+        ].filter(Boolean).length;
+        return fieldsPresent >= 3;
+      };
+
+      const messages: AiMessage[] = [
+        createAssistantMessageWithPatches("a1", [
+          { op: "add", path: "/title", value: "Lesson" },
+        ]),
+        createAssistantMessageWithPatches("a2", [
+          { op: "add", path: "/subject", value: "Math" },
+        ]),
+        createAssistantMessageWithPatches("a3", [
+          { op: "add", path: "/keyStage", value: "Key Stage 3" },
+        ]),
+      ];
+
+      const result = findFirstCompleteAssistantMessage(
+        messages,
+        strictComplete,
+      );
+
+      expect(result?.id).toBe("a3");
+    });
+
+    it("remains on first complete message even if messages come after", () => {
+      const messages: AiMessage[] = [
+        createAssistantMessageWithPatches("a1", [
+          { op: "add", path: "/title", value: "Lesson" },
+          { op: "add", path: "/subject", value: "Math" },
+        ]),
+        createUserMessage("u1", "More input"),
+        createAssistantMessageWithPatches("a2", [
+          { op: "add", path: "/topic", value: "Geometry" },
+        ]),
+      ];
+
+      const result = findFirstCompleteAssistantMessage(
+        messages,
+        isLessonCompleteMock,
+      );
+
+      expect(result?.id).toBe("a1");
+      // Verify that a2 is ignored
+      expect(result?.id).not.toBe("a2");
+    });
+  });
+});

--- a/apps/nextjs/src/hooks/useDemoLocking.test.ts
+++ b/apps/nextjs/src/hooks/useDemoLocking.test.ts
@@ -1,11 +1,30 @@
+/**
+ * @jest-environment jsdom
+ */
 import type { PartialLessonPlan } from "@oakai/aila/src/protocol/schema";
 
+import { renderHook } from "@testing-library/react";
+
+import { useDemoUser } from "@/components/ContextProviders/Demo";
+import { isLessonComplete } from "@/lib/analytics/helpers";
+import { useChatStore } from "@/stores/AilaStoresProvider";
 import type { AiMessage } from "@/stores/chatStore";
 
 import {
   findFirstCompleteAssistantMessage,
   replayLessonPlanFromMessages,
+  useDemoLocking,
 } from "./useDemoLocking";
+
+jest.mock("@/components/ContextProviders/Demo", () => ({
+  useDemoUser: jest.fn(),
+}));
+jest.mock("@/lib/analytics/helpers", () => ({
+  isLessonComplete: jest.fn(),
+}));
+jest.mock("@/stores/AilaStoresProvider", () => ({
+  useChatStore: jest.fn(),
+}));
 
 const fixedDate = new Date("2023-01-01T12:00:00.000Z");
 
@@ -40,7 +59,7 @@ const createUserMessage = (id: string, content: string): AiMessage => {
 };
 
 const isLessonCompleteMock = (lesson: PartialLessonPlan): boolean => {
-  // A lesson is complete when it has title and subject
+  // A lesson is complete when it has title and subject for the tests
   return !!(lesson.title && lesson.subject);
 };
 
@@ -262,8 +281,190 @@ describe("useDemoLocking helpers", () => {
       );
 
       expect(result?.id).toBe("a1");
-      // Verify that a2 is ignored
-      expect(result?.id).not.toBe("a2");
+    });
+  });
+
+  describe("useDemoLocking hook", () => {
+    const mockUseDemoUser = jest.mocked(useDemoUser);
+    const mockUseChatStore = jest.mocked(useChatStore);
+    const mockIsLessonComplete = jest.mocked(isLessonComplete);
+
+    beforeEach(() => {
+      jest.clearAllMocks();
+
+      // Set up default mocks
+      mockUseDemoUser.mockReturnValue({
+        isDemoUser: false,
+        demo: undefined,
+        isSharingEnabled: true,
+      });
+      mockUseChatStore.mockReturnValue([]);
+      mockIsLessonComplete.mockReturnValue(false);
+    });
+
+    it("returns false when user is not a demo user", () => {
+      mockUseDemoUser.mockReturnValue({
+        isDemoUser: false,
+        demo: undefined,
+        isSharingEnabled: true,
+      });
+      mockUseChatStore.mockReturnValue([]);
+
+      const { result } = renderHook(() => useDemoLocking());
+
+      expect(result.current).toBe(false);
+    });
+
+    it("returns false when demo user has no complete lesson", () => {
+      mockUseDemoUser.mockReturnValue({
+        isDemoUser: true,
+        demo: {
+          appSessionsRemaining: 1,
+          additionalMaterialsSessionsRemaining: 1,
+          appSessionsPerMonth: 5,
+          contactHref: "https://example.com",
+        },
+        isSharingEnabled: true,
+      });
+      const incompleteMessages: AiMessage[] = [
+        createAssistantMessageWithPatches("a1", [
+          { op: "add", path: "/title", value: "Just a title" },
+        ]),
+      ];
+      mockUseChatStore.mockReturnValue(incompleteMessages);
+
+      const { result } = renderHook(() => useDemoLocking());
+
+      expect(result.current).toBe(false);
+    });
+
+    it("returns false when demo user has complete lesson but fewer user messages than threshold", () => {
+      mockUseDemoUser.mockReturnValue({
+        isDemoUser: true,
+        demo: {
+          appSessionsRemaining: 1,
+          additionalMaterialsSessionsRemaining: 1,
+          appSessionsPerMonth: 5,
+          contactHref: "https://example.com",
+        },
+        isSharingEnabled: true,
+      });
+      const messages: AiMessage[] = [
+        createAssistantMessageWithPatches("a1", [
+          { op: "add", path: "/title", value: "Complete" },
+          { op: "add", path: "/subject", value: "Math" },
+        ]),
+        createUserMessage("u1", "Edit 1"),
+      ];
+      mockUseChatStore.mockReturnValue(messages);
+      mockIsLessonComplete.mockImplementation((lesson: PartialLessonPlan) => {
+        return !!(lesson.title && lesson.subject);
+      });
+
+      const { result } = renderHook(() => useDemoLocking());
+
+      // With NEXT_PUBLIC_DEMO_MESSAGES_AFTER_COMPLETE = 3, 1 user message should be false
+      expect(result.current).toBe(false);
+    });
+
+    it("returns true when demo user reaches the message threshold after completion", () => {
+      mockUseDemoUser.mockReturnValue({
+        isDemoUser: true,
+        demo: {
+          appSessionsRemaining: 1,
+          additionalMaterialsSessionsRemaining: 1,
+          appSessionsPerMonth: 5,
+          contactHref: "https://example.com",
+        },
+        isSharingEnabled: true,
+      });
+      // Simulate exactly NEXT_PUBLIC_DEMO_MESSAGES_AFTER_COMPLETE user messages after complete
+      const messages: AiMessage[] = [
+        createAssistantMessageWithPatches("a1", [
+          { op: "add", path: "/title", value: "Complete" },
+          { op: "add", path: "/subject", value: "Math" },
+        ]),
+        createUserMessage("u1", "Edit 1"),
+        createUserMessage("u2", "Edit 2"),
+        createUserMessage("u3", "Edit 3"),
+      ];
+      mockUseChatStore.mockReturnValue(messages);
+      mockIsLessonComplete.mockImplementation((lesson: PartialLessonPlan) => {
+        return !!(lesson.title && lesson.subject);
+      });
+
+      const { result } = renderHook(() => useDemoLocking());
+
+      // With NEXT_PUBLIC_DEMO_MESSAGES_AFTER_COMPLETE = 3, exactly 3 user messages should be true
+      expect(result.current).toBe(true);
+    });
+
+    it("returns true when demo user exceeds threshold after completion", () => {
+      mockUseDemoUser.mockReturnValue({
+        isDemoUser: true,
+        demo: {
+          appSessionsRemaining: 1,
+          additionalMaterialsSessionsRemaining: 1,
+          appSessionsPerMonth: 5,
+          contactHref: "https://example.com",
+        },
+        isSharingEnabled: true,
+      });
+      // Simulate more than NEXT_PUBLIC_DEMO_MESSAGES_AFTER_COMPLETE user messages
+      const messages: AiMessage[] = [
+        createAssistantMessageWithPatches("a1", [
+          { op: "add", path: "/title", value: "Complete" },
+          { op: "add", path: "/subject", value: "Math" },
+        ]),
+        createUserMessage("u1", "Edit 1"),
+        createUserMessage("u2", "Edit 2"),
+        createUserMessage("u3", "Edit 3"),
+        createUserMessage("u4", "Edit 4"),
+      ];
+      mockUseChatStore.mockReturnValue(messages);
+      mockIsLessonComplete.mockImplementation((lesson: PartialLessonPlan) => {
+        return !!(lesson.title && lesson.subject);
+      });
+
+      const { result } = renderHook(() => useDemoLocking());
+
+      // With NEXT_PUBLIC_DEMO_MESSAGES_AFTER_COMPLETE = 3, more than 3 should still be true (>= comparison)
+      expect(result.current).toBe(true);
+    });
+
+    it("counts only user messages after the first complete message", () => {
+      mockUseDemoUser.mockReturnValue({
+        isDemoUser: true,
+        demo: {
+          appSessionsRemaining: 1,
+          additionalMaterialsSessionsRemaining: 1,
+          appSessionsPerMonth: 5,
+          contactHref: "https://example.com",
+        },
+        isSharingEnabled: true,
+      });
+      const messages: AiMessage[] = [
+        createUserMessage("u1", "Start"),
+        createAssistantMessageWithPatches("a1", [
+          { op: "add", path: "/title", value: "Lesson" },
+        ]),
+        createUserMessage("u2", "Edit before complete"),
+        createAssistantMessageWithPatches("a2", [
+          { op: "add", path: "/subject", value: "Math" },
+        ]),
+        // First complete message is a2, count user messages after this
+        createUserMessage("u3", "Edit 1 after complete"),
+        createUserMessage("u4", "Edit 2 after complete"),
+      ];
+      mockUseChatStore.mockReturnValue(messages);
+      mockIsLessonComplete.mockImplementation((lesson: PartialLessonPlan) => {
+        return !!(lesson.title && lesson.subject);
+      });
+
+      const { result } = renderHook(() => useDemoLocking());
+
+      // Only u3 and u4 should be counted (2 messages), which is less than threshold (3)
+      expect(result.current).toBe(false);
     });
   });
 });

--- a/apps/nextjs/src/hooks/useDemoLocking.ts
+++ b/apps/nextjs/src/hooks/useDemoLocking.ts
@@ -103,15 +103,14 @@ export function useDemoLocking() {
   const demo = useDemoUser();
   const stableMessages = useChatStore((state) => state.stableMessages);
 
-  if (!demo.isDemoUser) {
-    return false;
-  }
-
-  // Find the first assistant message where completeness flips from false to true
   const firstCompleteMessage = useMemo(
     () => findFirstCompleteAssistantMessage(stableMessages, isLessonComplete),
     [stableMessages],
   );
+
+  if (!demo.isDemoUser) {
+    return false;
+  }
 
   if (!firstCompleteMessage) {
     return false;

--- a/apps/nextjs/src/hooks/useDemoLocking.ts
+++ b/apps/nextjs/src/hooks/useDemoLocking.ts
@@ -1,28 +1,14 @@
-import { useEffect, useState } from "react";
-
-import type { LessonPlanKey } from "@oakai/aila/src/protocol/schema";
-
-import type { Message } from "ai";
+import {
+  applyLessonPlanPatchImmutable,
+  extractPatches,
+} from "@oakai/aila/src/protocol/jsonPatchProtocol";
+import type { PartialLessonPlan } from "@oakai/aila/src/protocol/schema";
+import { aiLogger } from "@oakai/logger";
 
 import { useDemoUser } from "@/components/ContextProviders/Demo";
+import { isLessonComplete } from "@/lib/analytics/helpers";
 import { useChatStore } from "@/stores/AilaStoresProvider";
-
-const KEYS_TO_COMPLETE = [
-  "title",
-  "subject",
-  "keyStage",
-  "learningOutcome",
-  "learningCycles",
-  "priorKnowledge",
-  "keyLearningPoints",
-  "misconceptions",
-  "keywords",
-  "starterQuiz",
-  "cycle1",
-  "cycle2",
-  "cycle3",
-  "exitQuiz",
-] satisfies LessonPlanKey[];
+import type { AiMessage } from "@/stores/chatStore";
 
 if (!process.env.NEXT_PUBLIC_DEMO_MESSAGES_AFTER_COMPLETE) {
   throw new Error("NEXT_PUBLIC_DEMO_MESSAGES_AFTER_COMPLETE is not set");
@@ -32,56 +18,106 @@ const DEMO_MESSAGES_AFTER_COMPLETE = parseInt(
   10,
 );
 
-const stateLineHasAllSections = (line: string) => {
-  if (!line.includes('"type":"state"')) {
-    return false;
+const log = aiLogger("demo");
+
+export function replayLessonPlanFromMessages(
+  messages: AiMessage[],
+): PartialLessonPlan {
+  let accumulatedLessonPlan: PartialLessonPlan = {};
+
+  for (const message of messages) {
+    if (message.role !== "assistant") {
+      continue;
+    }
+
+    const { validPatches } = extractPatches(message.content);
+
+    for (const patch of validPatches) {
+      const updated = applyLessonPlanPatchImmutable(
+        accumulatedLessonPlan,
+        patch,
+      );
+      if (updated) {
+        accumulatedLessonPlan = updated;
+        log.info("Applied patch", patch.value.path);
+      } else {
+        log.info("Patch failed to apply", patch.value.path);
+      }
+    }
   }
 
-  return KEYS_TO_COMPLETE.every((key) => line.includes(`"${key}":`));
-};
+  return accumulatedLessonPlan;
+}
 
 /**
- * Demo users are allowed to make 10 edits to the lesson plan once all sections are complete
+ * Finds the first assistant message where the lesson plan becomes complete.
+ * Returns the message object or null if no completion occurred.
+ */
+export function findFirstCompleteAssistantMessage(
+  messages: AiMessage[],
+  isComplete: (lesson: PartialLessonPlan) => boolean,
+): AiMessage | null {
+  let accumulatedLessonPlan: PartialLessonPlan = {};
+  let wasComplete = false;
+
+  for (const message of messages) {
+    if (message.role !== "assistant") {
+      continue;
+    }
+
+    const { validPatches } = extractPatches(message.content);
+
+    for (const patch of validPatches) {
+      const updated = applyLessonPlanPatchImmutable(
+        accumulatedLessonPlan,
+        patch,
+      );
+      if (updated) {
+        accumulatedLessonPlan = updated;
+      }
+    }
+
+    const isNowComplete = isComplete(accumulatedLessonPlan);
+
+    // Completeness flipped from false to true at this message
+    if (!wasComplete && isNowComplete) {
+      return message;
+    }
+
+    wasComplete = isNowComplete;
+  }
+
+  return null;
+}
+
+/**
+ * Demo users are allowed to make N edits to the lesson plan once all sections
+ * are complete, where N is NEXT_PUBLIC_DEMO_MESSAGES_AFTER_COMPLETE.
+ *
+ * Completeness is determined by replaying patches from stable messages in order
+ * and checking when isLessonComplete flips to true for the first time.
  */
 export function useDemoLocking() {
-  const isLoading = useChatStore((state) => state.ailaStreamingStatus);
-  const stableMessages = useChatStore((state) => state.stableMessages);
   const demo = useDemoUser();
-
-  const [firstCompleteResponse, setFirstCompleteResponse] =
-    useState<Message | null>(null);
-
-  useEffect(() => {
-    if (
-      !demo.isDemoUser ||
-      // Don't calculate while the content is streaming
-      isLoading ||
-      // Don't calculate if we already know the first complete response
-      firstCompleteResponse
-    ) {
-      return;
-    }
-
-    const message = stableMessages.find(
-      (m) =>
-        m.role === "assistant" &&
-        m.content.split("\n").find(stateLineHasAllSections),
-    );
-    if (message) {
-      setFirstCompleteResponse(message);
-    }
-  }, [demo.isDemoUser, isLoading, stableMessages, firstCompleteResponse]);
+  const stableMessages = useChatStore((state) => state.stableMessages);
 
   if (!demo.isDemoUser) {
     return false;
   }
 
-  if (!firstCompleteResponse) {
+  // Find the first assistant message where completeness flips from false to true
+  const firstCompleteMessage = findFirstCompleteAssistantMessage(
+    stableMessages,
+    isLessonComplete,
+  );
+
+  if (!firstCompleteMessage) {
     return false;
   }
 
+  // Count user messages after the completion point
   const completeMessageIndex = stableMessages.findIndex(
-    (m) => m.id === firstCompleteResponse.id,
+    (m) => m.id === firstCompleteMessage.id,
   );
   const userMessagesAfterComplete = stableMessages.filter(
     (m, i) => i > completeMessageIndex && m.role === "user",

--- a/apps/nextjs/src/hooks/useDemoLocking.ts
+++ b/apps/nextjs/src/hooks/useDemoLocking.ts
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 import {
   applyLessonPlanPatchImmutable,
   extractPatches,
@@ -106,9 +108,9 @@ export function useDemoLocking() {
   }
 
   // Find the first assistant message where completeness flips from false to true
-  const firstCompleteMessage = findFirstCompleteAssistantMessage(
-    stableMessages,
-    isLessonComplete,
+  const firstCompleteMessage = useMemo(
+    () => findFirstCompleteAssistantMessage(stableMessages, isLessonComplete),
+    [stableMessages],
   );
 
   if (!firstCompleteMessage) {

--- a/packages/aila/src/lib/agentic-system/compatibility/ailaTurnCallbacks.ts
+++ b/packages/aila/src/lib/agentic-system/compatibility/ailaTurnCallbacks.ts
@@ -24,13 +24,6 @@ export function createAilaTurnCallbacks({
   return {
     onPlannerComplete,
     onSectionComplete,
-    onTurnComplete: async (args) => {
-      onTurnComplete(args);
-      await chat.enqueue({
-        type: "state",
-        reasoning: "final",
-        value: args.document,
-      });
-    },
+    onTurnComplete,
   };
 }


### PR DESCRIPTION
## Description

Details in - https://www.notion.so/oaknationalacademy/Decide-whether-the-client-should-reconcile-with-the-final-server-state-34826cc4e1b180b5ac3aec412c1e7a29

> The agentic backend emits a final full lesson state, but the client does not appear to use it. 

In the lesson plan store we refetch the lesson plan and update from the database every time messageFinished is called. This action is called in onFinish ( aisdk useChat). We can remove the unused client passing function and ‘final’ state as we sync with database after every message.


```
 messageFinished: () => {
        log.info("Message finished");
        set({ isAcceptingChanges: false, ...initialPerMessageState });
        void handleRefetch(set, get, trpcUtils)();
      },

```

-remove final state from `ailaTurnCallbacks.ts`
-remove unused `findLatestServerSideState`

- useDemoLocking was using ` type: "state" , reasoning: "final" `to work out when a lesson had finish to limit the amounts of edits after lesson completion. This was broken as it was treating i`sLoading` as a boolean rather than streaming statuses. It was returning early and never limited the edits for demo users. This has been refactored to replay the lesson by looping through patches and extract lessons parts to determine a completed lesson before counting edits.


## How to test

- Full lesson flow works as before
- demo users have a limit to edits after lesson completion (3)
<img width="548" height="182" alt="image" src="https://github.com/user-attachments/assets/2010751b-bbeb-4526-bcff-3d24e211e54a" />

## follow ups
- Investigate conditional refresh rather than fetching after every message



## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
