### PR TITLE
fix(core): [AI-2156] enforce Slack field length limits for notifications

### DIFF
--- a/apps/nextjs/src/app/lesson-adapt/LessonAdaptView.tsx
+++ b/apps/nextjs/src/app/lesson-adapt/LessonAdaptView.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-/* eslint-disable no-console */
 import { useState } from "react";
 
 import {

--- a/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
@@ -557,7 +557,7 @@ describe("Agentic Issue Scoring", () => {
       const scorerTotals: Record<string, Record<string, number>> = {};
       for (const run of scenario.runs) {
         for (const { scorerId, result } of run.scores) {
-          if (!scorerTotals[scorerId]) scorerTotals[scorerId] = {};
+          scorerTotals[scorerId] ??= {};
           const counts = scorerTotals[scorerId];
           counts[result.heuristic] = (counts[result.heuristic] ?? 0) + 1;
         }

--- a/packages/core/src/functions/slack/notifyModeration.ts
+++ b/packages/core/src/functions/slack/notifyModeration.ts
@@ -1,5 +1,8 @@
 import {
   actionsBlock,
+  createHeaderBlock,
+  createLabeledMarkdownField,
+  createMarkdownField,
   slackNotificationChannelId,
   slackWebClient,
   userIdBlock,
@@ -19,29 +22,24 @@ export async function notifyModeration(event: NotifyModerationInput) {
     channel: slackNotificationChannelId,
     text: heading,
     blocks: [
-      {
-        type: "header",
-        text: {
-          type: "plain_text",
-          text: heading,
-        },
-      },
+      createHeaderBlock(heading),
       userIdBlock(event.user.id),
       {
         type: "section",
         fields: [
-          {
-            type: "mrkdwn",
-            text: `*Chat*: <https://${getExternalFacingUrl()}/aila/${args.chatId}|aila/${args.chatId}>`,
-          },
-          {
-            type: "mrkdwn",
-            text: `*Justification*: ${args.justification}`,
-          },
-          {
-            type: "mrkdwn",
-            text: `*Categories*: \`${args.categories.join("`, `")}\``,
-          },
+          createMarkdownField(
+            `*Chat*: <https://${getExternalFacingUrl()}/aila/${args.chatId}|aila/${args.chatId}>`,
+            "moderation.chat",
+          ),
+          createLabeledMarkdownField(
+            "*Justification*: ",
+            args.justification,
+            "moderation.justification",
+          ),
+          createMarkdownField(
+            `*Categories*: \`${args.categories.join("`, `")}\``,
+            "moderation.categories",
+          ),
         ],
       },
       actionsBlock({

--- a/packages/core/src/functions/slack/notifyThreatDetectionTeachingMaterials.schema.ts
+++ b/packages/core/src/functions/slack/notifyThreatDetectionTeachingMaterials.schema.ts
@@ -5,21 +5,6 @@ import {
   threatDetectionResultSchema,
 } from "../../threatDetection/types";
 
-/**
- * Schema for formatted threat detection data sent to Slack
- */
-export const threatDetectionForSlackSchema = z.object({
-  flagged: z.boolean(),
-  userInput: z.string(),
-  detectedThreats: z.array(
-    z.object({
-      detectorType: z.string(),
-      detectorId: z.string().optional(),
-    }),
-  ),
-  requestId: z.string().optional(),
-});
-
 export const notifyThreatDetectionTeachingMaterialsSchema = z.object({
   user: z.object({
     id: z.string(),

--- a/packages/core/src/models/lessons.ts
+++ b/packages/core/src/models/lessons.ts
@@ -246,7 +246,6 @@ export class Lessons {
       where: { answer, lessonId, questionId: quizQuestionId },
     });
     if (!existingAnswer) {
-      let quizAnswerId: string | undefined;
       try {
         const quizAnswer = await this.prisma.quizAnswer.create({
           data: {
@@ -256,7 +255,6 @@ export class Lessons {
             distractor: answer !== question.answer,
           },
         });
-        quizAnswerId = quizAnswer.id;
         log.info("Created quiz question answer", quizAnswer);
       } catch (e) {
         // For now, swallow the error until we can change the unique index

--- a/packages/core/src/models/snippets.ts
+++ b/packages/core/src/models/snippets.ts
@@ -285,7 +285,7 @@ If you don't know the answer, just respond with "None", don't try to make up an 
 
     const content = `Question: ${question.question} – Correct Answer: ${correctAnswer.answer}`;
 
-    const snippet = await this.prisma.snippet.create({
+    await this.prisma.snippet.create({
       data: {
         content,
         sourceContent: content,

--- a/packages/core/src/threatDetection/modelArmor/__tests__/ModelArmorClient.test.ts
+++ b/packages/core/src/threatDetection/modelArmor/__tests__/ModelArmorClient.test.ts
@@ -127,7 +127,7 @@ describe("createWorkloadIdentityAccessTokenProvider", () => {
       );
 
     const getAccessToken = createWorkloadIdentityAccessTokenProvider({
-      getSubjectToken: async () => "subject-token",
+      getSubjectToken: () => Promise.resolve("subject-token"),
       projectNumber: "123456789",
       serviceAccountEmail: "svc@example.iam.gserviceaccount.com",
       workloadIdentityPoolId: "pool-id",

--- a/packages/core/src/utils/slack.test.ts
+++ b/packages/core/src/utils/slack.test.ts
@@ -1,0 +1,76 @@
+import type * as SlackModule from "./slack";
+
+describe("slack utils", () => {
+  beforeAll(() => {
+    process.env.SLACK_NOTIFICATION_CHANNEL_ID = "slack-channel";
+    process.env.SLACK_AI_OPS_NOTIFICATION_CHANNEL_ID = "slack-ai-ops-channel";
+    process.env.SLACK_BOT_USER_OAUTH_TOKEN = "token";
+    process.env.NEXT_PUBLIC_POSTHOG_PROJECT = "posthog-project";
+    process.env.NEXT_PUBLIC_CLERK_INSTANCE = "clerk-instance";
+    process.env.NEXT_PUBLIC_CLERK_APP_ID = "clerk-app";
+  });
+
+  afterEach(() => {
+    jest.resetModules();
+  });
+
+  async function loadSlackModule(): Promise<typeof SlackModule> {
+    return import("./slack");
+  }
+
+  it("truncates header text to Slack's header limit", async () => {
+    const { createHeaderBlock, slackTextLimits } = await loadSlackModule();
+
+    const header = createHeaderBlock(
+      "x".repeat(slackTextLimits.headerText + 50),
+    );
+
+    expect(header.text.text).toHaveLength(slackTextLimits.headerText);
+    expect(header.text.text.endsWith("... [truncated]")).toBe(true);
+  });
+
+  it("keeps threat metadata visible when the user input is too long", async () => {
+    const { createThreatSectionBlock, slackTextLimits } =
+      await loadSlackModule();
+
+    const block = createThreatSectionBlock({
+      id: "interaction-123",
+      userInput: "x".repeat(5000),
+      detectedThreats: [
+        { detectorType: "prompt_injection", detectorId: "detector-123" },
+      ],
+      requestId: "request-123",
+      userAction: "CHAT_SESSION",
+    });
+
+    const detailsField = block.fields?.[1];
+
+    expect(detailsField?.text.length).toBeLessThanOrEqual(
+      slackTextLimits.sectionFieldText,
+    );
+    expect(detailsField?.text).toContain("*Detected Threats:*");
+    expect(detailsField?.text).toContain("request-123");
+    expect(detailsField?.text).toContain("... [truncated]");
+  });
+
+  it("truncates long moderation justifications to Slack's field limit", async () => {
+    const { createModerationSectionBlock, slackTextLimits } =
+      await loadSlackModule();
+
+    const block = createModerationSectionBlock({
+      id: "interaction-123",
+      justification: "y".repeat(5000),
+      categories: ["violence"],
+      userAction: "PARTIAL_LESSON_GENERATION",
+      violationType: "MODERATION",
+    });
+
+    const justificationField = block.fields?.[1];
+
+    expect(justificationField?.text.length).toBeLessThanOrEqual(
+      slackTextLimits.sectionFieldText,
+    );
+    expect(justificationField?.text.startsWith("*Justification*: ")).toBe(true);
+    expect(justificationField?.text.endsWith("... [truncated]")).toBe(true);
+  });
+});

--- a/packages/core/src/utils/slack.ts
+++ b/packages/core/src/utils/slack.ts
@@ -1,3 +1,5 @@
+import { aiLogger } from "@oakai/logger";
+
 import type { ActionsBlock, SectionBlock } from "@slack/web-api";
 import { WebClient } from "@slack/web-api";
 
@@ -7,6 +9,56 @@ import type {
   ThreatDetectionResult,
 } from "../threatDetection/types";
 import { generateFriendlyId } from "./friendlyId";
+
+const log = aiLogger("core");
+
+export const slackTextLimits = {
+  headerText: 150,
+  sectionFieldText: 2000,
+} as const;
+
+const SLACK_TRUNCATION_SUFFIX = "... [truncated]";
+
+function truncateSlackText(
+  text: string,
+  maxLength: number,
+  fieldName: string,
+): string {
+  if (text.length <= maxLength) {
+    return text;
+  }
+
+  const suffix =
+    maxLength > SLACK_TRUNCATION_SUFFIX.length
+      ? SLACK_TRUNCATION_SUFFIX
+      : SLACK_TRUNCATION_SUFFIX.slice(0, maxLength);
+  const truncatedText = `${text.slice(0, maxLength - suffix.length)}${suffix}`;
+
+  log.info("Truncated Slack text", {
+    fieldName,
+    originalLength: text.length,
+    truncatedLength: truncatedText.length,
+    maxLength,
+  });
+
+  return truncatedText;
+}
+
+function truncateSlackFieldText(text: string, fieldName: string): string {
+  return truncateSlackText(text, slackTextLimits.sectionFieldText, fieldName);
+}
+
+function truncateSlackLabeledField(
+  label: string,
+  value: string,
+  fieldName: string,
+): string {
+  return `${label}${truncateSlackText(
+    value,
+    Math.max(0, slackTextLimits.sectionFieldText - label.length),
+    fieldName,
+  )}`;
+}
 
 if (
   !process.env.SLACK_NOTIFICATION_CHANNEL_ID ||
@@ -44,14 +96,8 @@ export function userIdBlock(userId: string): SectionBlock {
   return {
     type: "section",
     fields: [
-      {
-        type: "mrkdwn",
-        text: `*User*: \`${userId}\``,
-      },
-      {
-        type: "mrkdwn",
-        text: `(*_${friendlyId}_*)`,
-      },
+      createMarkdownField(`*User*: \`${userId}\``, "user.id"),
+      createMarkdownField(`(*_${friendlyId}_*)`, "user.friendlyId"),
     ],
   };
 }
@@ -64,10 +110,10 @@ export function chatLinkBlock(chatId: string): SectionBlock {
   return {
     type: "section",
     fields: [
-      {
-        type: "mrkdwn",
-        text: `*Chat*: <https://${externalUrl}/aila/${chatId}|aila/${chatId}>`,
-      },
+      createMarkdownField(
+        `*Chat*: <https://${externalUrl}/aila/${chatId}|aila/${chatId}>`,
+        "chat.link",
+      ),
     ],
   };
 }
@@ -180,7 +226,6 @@ export function actionsBlock({
  * Formatted threat detection data for Slack notifications
  */
 export interface SlackThreatDetectionSummary {
-  flagged: boolean;
   userInput: string;
   detectedThreats: Array<{
     detectorType: string;
@@ -195,12 +240,10 @@ export interface SlackThreatDetectionSummary {
  */
 function createSlackThreatDetectionSummary(args: {
   messages: Array<{ content: string }>;
-  flagged: boolean;
   detectedThreats: SlackThreatDetectionSummary["detectedThreats"];
   requestId?: string;
 }): SlackThreatDetectionSummary {
   return {
-    flagged: args.flagged,
     userInput: args.messages.map((message) => message.content).join("\n"),
     detectedThreats: args.detectedThreats,
     requestId: args.requestId,
@@ -241,44 +284,50 @@ export function formatThreatDetectionResultWithMessages(
 ): SlackThreatDetectionSummary {
   return createSlackThreatDetectionSummary({
     messages,
-    flagged: threatDetection.isThreat,
     detectedThreats: getDetectedThreatsSummary(threatDetection),
     requestId: threatDetection.requestId,
   });
 }
 
 /**
- * Format threat detection data as markdown for Slack
+ * Format threat detection data into a Slack section field-safe markdown string
  */
-export function formatThreatAsMarkdown(
+export function formatThreatFieldMarkdown(
   userInput: string,
   detectedThreats: Array<{ detectorType: string; detectorId?: string }>,
   requestId?: string,
 ): string {
-  let markdown = "🚨 *Threat Detected*\n\n";
+  let detailsMarkdown = "";
 
-  // User input section
-  markdown += "*User Input:*\n";
-  markdown += `> ${userInput}\n\n`;
-
-  // Detected threats section
   if (detectedThreats.length > 0) {
-    markdown += "*Detected Threats:*\n";
+    detailsMarkdown += "*Detected Threats:*\n";
     for (const threat of detectedThreats) {
-      markdown += `• *Type:* \`${threat.detectorType}\`\n`;
+      detailsMarkdown += `• *Type:* \`${threat.detectorType}\`\n`;
       if (threat.detectorId) {
-        markdown += `  *Detector:* \`${threat.detectorId}\`\n`;
+        detailsMarkdown += `  *Detector:* \`${threat.detectorId}\`\n`;
       }
     }
-    markdown += "\n";
+    detailsMarkdown += "\n";
   }
 
-  // Request ID for traceability
   if (requestId) {
-    markdown += `*Request ID:* \`${requestId}\``;
+    detailsMarkdown += `*Request ID:* \`${requestId}\``;
   }
 
-  return markdown;
+  const prefix = "🚨 *Threat Detected*\n\n*User Input:*\n> ";
+  const suffix = detailsMarkdown ? `\n\n${detailsMarkdown}` : "";
+  const availableUserInputLength =
+    slackTextLimits.sectionFieldText - prefix.length - suffix.length;
+  const truncatedUserInput = truncateSlackText(
+    userInput,
+    Math.max(0, availableUserInputLength),
+    "threat.userInput",
+  );
+
+  return truncateSlackFieldText(
+    `${prefix}${truncatedUserInput}${suffix}`,
+    "threat.summary",
+  );
 }
 
 /**
@@ -289,7 +338,7 @@ export function createHeaderBlock(text: string) {
     type: "header" as const,
     text: {
       type: "plain_text" as const,
-      text,
+      text: truncateSlackText(text, slackTextLimits.headerText, "header.text"),
     },
   };
 }
@@ -297,10 +346,21 @@ export function createHeaderBlock(text: string) {
 /**
  * Create a simple markdown field block
  */
-export function createMarkdownField(text: string) {
+export function createMarkdownField(text: string, fieldName = "section.field") {
   return {
     type: "mrkdwn" as const,
-    text,
+    text: truncateSlackFieldText(text, fieldName),
+  };
+}
+
+export function createLabeledMarkdownField(
+  label: string,
+  value: string,
+  fieldName: string,
+) {
+  return {
+    type: "mrkdwn" as const,
+    text: truncateSlackLabeledField(label, value, fieldName),
   };
 }
 
@@ -317,15 +377,19 @@ export function createThreatSectionBlock(args: {
   return {
     type: "section",
     fields: [
-      createMarkdownField(`*Id*: ${args.id}`),
-      createMarkdownField(
-        formatThreatAsMarkdown(
+      createMarkdownField(`*Id*: ${args.id}`, "threat.id"),
+      {
+        type: "mrkdwn" as const,
+        text: formatThreatFieldMarkdown(
           args.userInput,
           args.detectedThreats,
           args.requestId,
         ),
+      },
+      createMarkdownField(
+        `*User action*:  ${args.userAction}`,
+        "threat.action",
       ),
-      createMarkdownField(`*User action*:  ${args.userAction}`),
     ],
   };
 }
@@ -343,11 +407,24 @@ export function createModerationSectionBlock(args: {
   return {
     type: "section",
     fields: [
-      createMarkdownField(`*Id*: ${args.id}`),
-      createMarkdownField(`*Justification*: ${args.justification}`),
-      createMarkdownField(`*Categories*: \`${args.categories.join("`, `")}\``),
-      createMarkdownField(`*User action*:  ${args.userAction}`),
-      createMarkdownField(`*Violation type*:  ${args.violationType}`),
+      createMarkdownField(`*Id*: ${args.id}`, "moderation.id"),
+      createLabeledMarkdownField(
+        "*Justification*: ",
+        args.justification,
+        "moderation.justification",
+      ),
+      createMarkdownField(
+        `*Categories*: \`${args.categories.join("`, `")}\``,
+        "moderation.categories",
+      ),
+      createMarkdownField(
+        `*User action*:  ${args.userAction}`,
+        "moderation.action",
+      ),
+      createMarkdownField(
+        `*Violation type*:  ${args.violationType}`,
+        "moderation.violationType",
+      ),
     ],
   };
 }


### PR DESCRIPTION
## Description

This PR fixes production Slack notification failures caused by oversized message fields.

It adds centralised truncation for Slack field/header text in the shared Slack utilities, applies that truncation to moderation and threat-detection notifications, and adds regression tests to verify long payloads are safely shortened while preserving useful metadata such as threat details and request IDs.

## Additional Changes

This PR also includes a few very small opportunistic lint clean-ups that were touched during the change, to reduce tech debt in the codebase.

## Issue(s)

Fixes #AI-2156

## How to test

1. Go to {deployment_url}
2. Trigger a threat detection with:
    a. A short input
    b. A long input (over 2000 characters) 
3. You should see Slack notifications for both - the long message should end with `[truncated]` to indicate it was shortened to fit within the required limits.