### PR TITLE
fix: cache lesson plan exports per content guidance

### DIFF
--- a/packages/api/src/export/exportHelpers.ts
+++ b/packages/api/src/export/exportHelpers.ts
@@ -25,9 +25,11 @@ function contentGuidanceCacheKey(
     return undefined;
   }
 
+  // Don't swap this for localeCompare — the output is hashed, and the sort
+  // needs to be the same on every machine.
   return categories
     .map((c) => `${c.code}:${c.severityLevel}`)
-    .sort()
+    .sort((a, b) => (a < b ? -1 : a > b ? 1 : 0))
     .join("|");
 }
 

--- a/packages/api/src/export/exportHelpers.ts
+++ b/packages/api/src/export/exportHelpers.ts
@@ -1,4 +1,4 @@
-import { LessonSnapshots } from "@oakai/core";
+import { LessonSnapshots } from "@oakai/core/src/models/lessonSnapshots";
 import type { Snapshot } from "@oakai/core/src/models/lessonSnapshots";
 import { Moderations } from "@oakai/core/src/models/moderations";
 import type { DisplayCategory } from "@oakai/core/src/utils/ailaModeration/severityLevel";

--- a/packages/api/src/export/exportHelpers.ts
+++ b/packages/api/src/export/exportHelpers.ts
@@ -1,5 +1,8 @@
 import { LessonSnapshots } from "@oakai/core";
 import type { Snapshot } from "@oakai/core/src/models/lessonSnapshots";
+import { Moderations } from "@oakai/core/src/models/moderations";
+import type { DisplayCategory } from "@oakai/core/src/utils/ailaModeration/severityLevel";
+import { getDisplayCategories } from "@oakai/core/src/utils/ailaModeration/severityLevel";
 import type {
   LessonExportType,
   LessonSnapshot,
@@ -14,6 +17,51 @@ import {
   type OutputSchema,
   ailaGetExportBySnapshotId,
 } from "../router/exports";
+
+function contentGuidanceCacheKey(
+  categories: DisplayCategory[],
+): string | undefined {
+  if (categories.length === 0) {
+    return undefined;
+  }
+
+  return categories
+    .map((c) => `${c.code}:${c.severityLevel}`)
+    .sort()
+    .join("|");
+}
+
+/**
+ * Producers and consumers of the lesson-plan export cache must derive the
+ * cache key identically otherwise the UI surfaces a stale URL.
+ */
+export const getLessonPlanCacheKeyInput = async ({
+  prisma,
+  chatId,
+}: {
+  prisma: PrismaClientWithAccelerate;
+  chatId: string;
+}): Promise<{
+  cacheKeyInput: string | undefined;
+  contentGuidanceCategories: DisplayCategory[];
+}> => {
+  const moderations = await new Moderations(prisma).byAppSessionId(chatId, {
+    includeInvalidated: false,
+  });
+
+  const contentGuidanceCategories = [
+    ...new Map(
+      moderations
+        .flatMap((m) => getDisplayCategories(m))
+        .map((c) => [c.code, c]),
+    ).values(),
+  ];
+
+  return {
+    cacheKeyInput: contentGuidanceCacheKey(contentGuidanceCategories),
+    contentGuidanceCategories,
+  };
+};
 
 export const getUserEmail = async (ctx: {
   auth: SignedInAuthObject;
@@ -39,6 +87,7 @@ export const getLessonSnapshot = async <T>({
   input,
   ctx,
   exportType,
+  cacheKeyInput,
 }: {
   input: {
     data: T;
@@ -50,6 +99,7 @@ export const getLessonSnapshot = async <T>({
     prisma: PrismaClientWithAccelerate;
   };
   exportType: LessonExportType;
+  cacheKeyInput?: string;
 }): Promise<LessonSnapshot> => {
   const lessonSnapshots = new LessonSnapshots(ctx.prisma);
 
@@ -59,6 +109,7 @@ export const getLessonSnapshot = async <T>({
     messageId: input.messageId,
     snapshot: input.data as Snapshot,
     trigger: "EXPORT_BY_USER",
+    cacheKeyInput,
   });
 
   const category = categoryMap[exportType] ?? "exportLessonDoc";
@@ -106,6 +157,7 @@ export const getExistingExportData = async <T>({
   input,
   ctx,
   exportType,
+  cacheKeyInput,
 }: {
   input: {
     data: T;
@@ -117,11 +169,13 @@ export const getExistingExportData = async <T>({
     prisma: PrismaClientWithAccelerate;
   };
   exportType: LessonExportType;
+  cacheKeyInput?: string;
 }) => {
   const lessonSnapshot = await getLessonSnapshot<T>({
     ctx,
     input,
     exportType,
+    cacheKeyInput,
   });
 
   const exportData = await getExportData({

--- a/packages/api/src/export/exportLessonPlan.ts
+++ b/packages/api/src/export/exportLessonPlan.ts
@@ -1,4 +1,3 @@
-import { getDisplayCategories } from "@oakai/core/src/utils/ailaModeration/severityLevel";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 import { exportDocLessonPlan } from "@oakai/exports";
 import type { LessonInputData } from "@oakai/exports/src/schema/input.schema";
@@ -9,7 +8,11 @@ import * as Sentry from "@sentry/nextjs";
 
 import type { OutputSchema } from "../router/exports";
 import { ailaSaveExport, reportErrorResult } from "../router/exports";
-import { getExistingExportData, getUserEmail } from "./exportHelpers";
+import {
+  getExistingExportData,
+  getLessonPlanCacheKeyInput,
+  getUserEmail,
+} from "./exportHelpers";
 
 const log = aiLogger("exports");
 
@@ -27,7 +30,15 @@ export async function exportLessonPlan({
     prisma: PrismaClientWithAccelerate;
   };
 }) {
-  const userEmail = await getUserEmail(ctx);
+  const [userEmail, { cacheKeyInput, contentGuidanceCategories }] =
+    await Promise.all([
+      getUserEmail(ctx),
+      getLessonPlanCacheKeyInput({
+        prisma: ctx.prisma,
+        chatId: input.chatId,
+      }),
+    ]);
+
   if (!userEmail) {
     return {
       error: new Error("User email not found"),
@@ -41,40 +52,11 @@ export async function exportLessonPlan({
     ctx,
     input,
     exportType,
+    cacheKeyInput,
   });
 
-  const moderations = await ctx.prisma.moderation.findMany({
-    where: {
-      appSessionId: input.chatId,
-      invalidatedAt: null,
-    },
-  });
-
-  const contentGuidanceCategories = [
-    ...new Map(
-      moderations
-        .flatMap((m) => getDisplayCategories(m))
-        .map((c) => [c.code, c]),
-    ).values(),
-  ];
-
-  const hasContentGuidance = contentGuidanceCategories.length > 0;
-
-  if (exportData && !hasContentGuidance) {
+  if (exportData) {
     return exportData;
-  }
-
-  if (exportData && hasContentGuidance) {
-    await ctx.prisma.lessonExport.updateMany({
-      where: {
-        lessonSnapshotId: lessonSnapshot.id,
-        exportType,
-        expiredAt: null,
-      },
-      data: {
-        expiredAt: new Date(),
-      },
-    });
   }
 
   const result = await exportDocLessonPlan({
@@ -89,7 +71,7 @@ export async function exportLessonPlan({
       log.info(state);
 
       Sentry.addBreadcrumb({
-        category: "exportWorksheetDocs",
+        category: "exportLessonPlanDoc",
         message: "Export state change",
         data: state,
       });

--- a/packages/api/src/export/exportQuizDoc.ts
+++ b/packages/api/src/export/exportQuizDoc.ts
@@ -65,7 +65,7 @@ export async function exportQuizDoc({
       log.info(state);
 
       Sentry.addBreadcrumb({
-        category: "exportWorksheetDocs",
+        category: "exportQuizDoc",
         message: "Export state change",
         data: state,
       });

--- a/packages/api/src/router/exports.ts
+++ b/packages/api/src/router/exports.ts
@@ -16,7 +16,10 @@ import { kv } from "@vercel/kv";
 import { z } from "zod";
 
 import { exportAdditionalMaterialsDoc } from "../export/exportAdditionalMaterialsDoc";
-import { getExistingExportData } from "../export/exportHelpers";
+import {
+  getExistingExportData,
+  getLessonPlanCacheKeyInput,
+} from "../export/exportHelpers";
 import { exportLessonPlan } from "../export/exportLessonPlan";
 import { exportLessonSlides } from "../export/exportLessonSlides";
 import { exportQuizDoc } from "../export/exportQuizDoc";
@@ -157,10 +160,15 @@ export const exportsRouter = router({
     .mutation(async ({ input, ctx }) => {
       try {
         const exportType = "LESSON_PLAN_DOC";
+        const { cacheKeyInput } = await getLessonPlanCacheKeyInput({
+          prisma: ctx.prisma,
+          chatId: input.chatId,
+        });
         const { exportData } = await getExistingExportData({
           ctx,
           input,
           exportType,
+          cacheKeyInput,
         });
 
         if (exportData) {

--- a/packages/core/src/models/lessonSnapshots.test.ts
+++ b/packages/core/src/models/lessonSnapshots.test.ts
@@ -1,0 +1,36 @@
+import crypto from "crypto";
+
+import type { Snapshot } from "./lessonSnapshots";
+import { getSnapshotHash } from "./lessonSnapshots";
+
+const snapshot: Snapshot = { title: "Photosynthesis" };
+
+describe("getSnapshotHash", () => {
+  it("no cacheKeyInput keeps the original hash", () => {
+    const expected = crypto
+      .createHash("sha256")
+      .update(JSON.stringify(snapshot))
+      .digest("hex");
+
+    expect(getSnapshotHash(snapshot)).toBe(expected);
+    expect(getSnapshotHash(snapshot, undefined)).toBe(expected);
+  });
+
+  it("deterministic for the same inputs", () => {
+    expect(getSnapshotHash(snapshot, "key")).toBe(
+      getSnapshotHash(snapshot, "key"),
+    );
+  });
+
+  it("with vs without cacheKeyInput differ", () => {
+    expect(getSnapshotHash(snapshot, "key")).not.toBe(
+      getSnapshotHash(snapshot),
+    );
+  });
+
+  it("different cacheKeyInputs produce different hashes", () => {
+    expect(getSnapshotHash(snapshot, "key-a")).not.toBe(
+      getSnapshotHash(snapshot, "key-b"),
+    );
+  });
+});

--- a/packages/core/src/models/lessonSnapshots.ts
+++ b/packages/core/src/models/lessonSnapshots.ts
@@ -20,13 +20,15 @@ const LESSON_JSON_SCHEMA_HASH = crypto
   .update(JsonSchemaString)
   .digest("hex");
 
-function getSnapshotHash(snapshot: Snapshot) {
-  const hash = crypto
-    .createHash("sha256")
-    .update(JSON.stringify(snapshot))
-    .digest("hex");
+function getSnapshotHash(snapshot: Snapshot, cacheKeyInput?: string) {
+  const hasher = crypto.createHash("sha256").update(JSON.stringify(snapshot));
 
-  return hash;
+  if (cacheKeyInput) {
+    hasher.update("\0");
+    hasher.update(cacheKeyInput);
+  }
+
+  return hasher.digest("hex");
 }
 
 /**
@@ -98,12 +100,20 @@ export class LessonSnapshots {
     messageId,
     snapshot,
     trigger,
+    cacheKeyInput,
   }: {
     userId: string;
     chatId: string;
     messageId: string;
     snapshot: Snapshot;
     trigger: LessonSnapshotTrigger;
+    /**
+     * Extra input folded into the lesson snapshot hash alongside the lesson
+     * content — e.g. the lesson-plan exporter mixes in active content guidance
+     * derived from moderations. Omit unless your artefact depends on more than
+     * lesson content.
+     */
+    cacheKeyInput?: string;
   }): Promise<LessonSnapshot> {
     /**
      * Prisma types complained when passing the JSON schema directly to the Prisma
@@ -127,7 +137,7 @@ export class LessonSnapshots {
       },
     });
 
-    const hash = getSnapshotHash(snapshot);
+    const hash = getSnapshotHash(snapshot, cacheKeyInput);
 
     // attempt to find existing snapshot
     const existingSnapshot = await this.prisma.lessonSnapshot.findFirst({

--- a/packages/core/src/models/lessonSnapshots.ts
+++ b/packages/core/src/models/lessonSnapshots.ts
@@ -20,7 +20,7 @@ const LESSON_JSON_SCHEMA_HASH = crypto
   .update(JsonSchemaString)
   .digest("hex");
 
-function getSnapshotHash(snapshot: Snapshot, cacheKeyInput?: string) {
+export function getSnapshotHash(snapshot: Snapshot, cacheKeyInput?: string) {
   const hasher = crypto.createHash("sha256").update(JSON.stringify(snapshot));
 
   if (cacheKeyInput) {


### PR DESCRIPTION
## Description

The fix removes regressions which introduced by PR #1010, raised on Sentry: [1](https://oak-national-academy.sentry.io/issues/114173238/events/b8ab5f6336494b31bc28ab78fc2ca96c?environment=production&project=4507089597300816&referrer=alert-rule-issue-list) [2](https://oak-national-academy.sentry.io/issues/114286617/events/cf330b13655f49bbab8da1981acdbe50?environment=production&project=4507089597300816&referrer=alert-rule-issue-list&seerDrawer=true)

PR #1010 wrote `expiredAt` on existing `lesson_exports` rows to invalidate the cache when content guidance changed. But `aila-download` filters `expiredAt IS NULL` because that column means "the Drive file has been deleted", breaking any download link a teacher already had loaded.

This PR introduces changes which ensure the lesson snapshot hash now folds in a string derived from active moderations. Existing rows are left untouched, so previously generated links continue to work until the daily cleanup cron retires them after 14 days.

These changes are only scoped to lesson plan exports. Slides, worksheets, quizzes, and additional materials don't render content guidance, so they are unaffected.

## Issue(s)

[AI-2159](https://www.notion.so/oaknationalacademy/Lesson-plan-export-cache-invalidation-bug-34b26cc4e1b180259f97cc5c7fa53570?v=c76315f391b74cf2bd6722b8bdcbc3e6&source=copy_link)

## How to test

Go to https://oak-ai-lesson-assistant-website-glbrddbm2.vercel.thenational.academy. 

### 1. Chat with no moderation should result in normal cache hit

1. Open a chat with a finished lesson, no active moderations.
2. Generate the lesson plan and click "Download lesson plan (.docx)", download the file and note the Drive URL (**URL-A**).
    - Right-click "Download lesson plan (.docx)" and copy the link address. Paste it somewhere this is URL-A. The important part is fileId=<…> in the URL; that's what changes when a fresh export is generated.
4. Click it again immediately, it should return the same URL-A download instantly (check the URL).

This demonstrates the same URL is present on both clicks and that the link works. Take note of URL-A.

### 2. Moderation presence should invalidate the cache and result in a fresh download link

1. Go back to the same chat, send a refinement message containing the magic string `oak-sen`. A content guidance banner should appear in the chat once Aila has finished.
2. Return to the download page (hard refresh by pressing Cmd+Shift+R.) and click "Download lesson plan (.docx)" > note the new URL (**URL-B**). It should differ from URL-A because the cache key now includes guidance.
3. Click it again, it should resolve instantly to URL-B (cache hit on the guidance-keyed snapshot).
5. Open URL-B in a fresh tab; it should download. The document should contain a content guidance section.

Demonstrates that URL-B is distinct from URL-A and repeat clicks return the same URL. Take note of URL-B.

### 3. Changing moderation does not break old links

This test is key as it shows that PR #1010's regression is fixed: changing moderation must NOT break old download links.

1. With URL-A and URL-B saved from the previous tests, send another refinement message containing `oak-sen` plus a request that meaningfully changes the lesson (e.g. *"Add a learning cycle on regional differences. oak-sen"*).
2. Wait for Aila to update the lesson, then return to the download page (hard refresh).
3. Click "Download lesson plan (.docx)" > note the new URL (**URL-C**). It should differ from both URL-A and URL-B.
4. **Critical:** open URL-B in a fresh browser tab. It must still download.
6. Open URL-A in a fresh browser tab. It must still download.

URL-A and URL-B should both still resolve after URL-C is generated.

> @mikeritson-oak URL-A and URL-B  are replaced by URL-C, but the underlying Drive files still exist so direct links will still keep working. FYI the job of this fix is to ensure the export reflects the current lesson plan based on lesson content and moderation state, not to revoke previously distributed links. Cleaning them up is the cron's job responsibility (which retires Drive files older than 14 days on a daily basis). 

### 4. Other exports are unaffected

1. In the chat from Test 3 (active moderations present), click "Download lesson slides" > note the URL (**URL-S**).
2. Send another `oak-sen` message to keep moderation active.
3. Return to the download page (hard refresh) and click "Download lesson slides" again, it should resolve to the same URL-S.

Demonstrates that the slides exporter ignores moderation changes. This is correct, because slides docs don't render content guidance.

## Screenshots

N/A, backend fix only. No UI changes.

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change