### PR TITLE
feat: check chat for unknown links -AI-2097

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/aila-start/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/aila-start/index.tsx
@@ -133,7 +133,7 @@ export function AilaStart() {
           $ph={["spacing-12", "spacing-12", "spacing-0"]}
           $justifyContent={"center"}
         >
-          <OakBox $mt="spacing-48">
+          <OakBox $mb={"spacing-24"} $mt="spacing-48">
             <ChatPanelDisclaimer size="sm" />
           </OakBox>
         </OakFlex>

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-panel-disclaimer.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-panel-disclaimer.tsx
@@ -4,14 +4,14 @@ const ChatPanelDisclaimer = ({
   readonly size: "sm" | "md" | "lg";
 }) => {
   return (
-    <p className={`my-12 text-${size}`}>
-      Aila can make mistakes. Check your lesson before use. See our{" "}
+    <p className={` text-${size}`}>
+      Aila can make mistakes. Check your lesson before use.{" "}
       <a
         href="https://www.thenational.academy/legal/terms-and-conditions"
         className="text-blue underline"
         target="_blank"
       >
-        terms and conditions
+        Oak terms and conditions
       </a>
       {"."}
     </p>

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-panel.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-panel.tsx
@@ -13,8 +13,6 @@ import {
 } from "@/stores/AilaStoresProvider";
 import { canAppendSelector } from "@/stores/chatStore/selectors";
 
-import ChatPanelDisclaimer from "./chat-panel-disclaimer";
-
 interface ChatPanelProps {
   isDemoLocked: boolean;
 }

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-panel.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-panel.tsx
@@ -72,9 +72,6 @@ export function ChatPanel({ isDemoLocked }: Readonly<ChatPanelProps>) {
           />
         )}
         {isDemoLocked && <LockedPromptForm />}
-        <span className="hidden w-full sm:block">
-          <ChatPanelDisclaimer size="sm" />
-        </span>
       </div>
     </div>
   );

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-start-form.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-start-form.tsx
@@ -44,10 +44,7 @@ export function ChatStartForm({
     if (e) {
       e.preventDefault();
     }
-    if (!input?.trim()) {
-      return;
-    }
-    if (formError) {
+    if (!input?.trim() || formError) {
       return;
     }
     submit(input);

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-start-form.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-start-form.tsx
@@ -1,15 +1,18 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import Textarea from "react-textarea-autosize";
+
+import { OakTertiaryButton } from "@oaknational/oak-components";
 
 import {
   Tooltip,
   TooltipContent,
   TooltipTrigger,
 } from "@/components/AppComponents/Chat/ui/tooltip";
-import { Icon } from "@/components/Icon";
-import LoadingWheel from "@/components/LoadingWheel";
 import { useClerkDemoMetadata } from "@/hooks/useClerkDemoMetadata";
 import { useEnterSubmit } from "@/lib/hooks/use-enter-submit";
+import { containsLink } from "@/utils/link-validation";
+
+import FormValidationWarning from "../FormValidationWarning";
 
 export function ChatStartForm({
   input,
@@ -24,11 +27,12 @@ export function ChatStartForm({
 }>) {
   const { formRef, onKeyDown } = useEnterSubmit();
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const [formError, setFormError] = useState<string | null>(null);
   // Disable submission until Clerk metadata has loaded. This prevents race
   // conditions (particularly in E2E tests) where submitting before metadata
   // loads would incorrectly show the demo interstitial modal to non-demo users.
   const clerkMetadata = useClerkDemoMetadata();
-  const isDisabled = isSubmitting || !clerkMetadata.isSet;
+  const isDisabled = isSubmitting || !clerkMetadata.isSet || formError !== null;
 
   useEffect(() => {
     if (inputRef.current) {
@@ -43,7 +47,20 @@ export function ChatStartForm({
     if (!input?.trim()) {
       return;
     }
+    if (formError) {
+      return;
+    }
     submit(input);
+  };
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = e.target.value;
+    setInput(newValue);
+    if (containsLink(newValue)) {
+      setFormError("Aila doesn't currently support links");
+    } else {
+      setFormError(null);
+    }
   };
 
   return (
@@ -57,7 +74,7 @@ export function ChatStartForm({
           onKeyDown={onKeyDown}
           rows={1}
           value={input}
-          onChange={(e) => setInput(e.target.value)}
+          onChange={handleInputChange}
           placeholder={"Subject, key stage and title"}
           spellCheck={false}
           className="min-h-[60px] w-full resize-none bg-transparent px-10 py-[1.3rem] text-lg focus-within:outline-none"
@@ -65,21 +82,27 @@ export function ChatStartForm({
         />
         <div className="absolute bottom-10 right-10 top-10 flex items-center justify-center">
           <Tooltip>
-            <LoadingWheel visible={isSubmitting} />
             <TooltipTrigger asChild>
-              <button
-                data-testid="send-message"
-                type="submit"
-                className={`${isSubmitting ? "hidden" : "inline-block"} rounded-full bg-black p-4`}
+              <OakTertiaryButton
                 disabled={isDisabled}
-              >
-                <Icon icon="chevron-right" color="white" size="sm" />
-              </button>
+                iconName="chevron-right"
+                isLoading={isSubmitting}
+                onClick={handleSubmit}
+                data-testid="send-message"
+              />
             </TooltipTrigger>
             <TooltipContent>Send message</TooltipContent>
           </Tooltip>
         </div>
       </div>
+
+      {formError && (
+        <FormValidationWarning
+          errorMessage={formError}
+          iconWidth="spacing-20"
+          $font="body-3"
+        />
+      )}
     </form>
   );
 }

--- a/apps/nextjs/src/components/AppComponents/Chat/prompt-form.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/prompt-form.tsx
@@ -7,7 +7,6 @@ import {
   TooltipContent,
   TooltipTrigger,
 } from "@/components/AppComponents/Chat/ui/tooltip";
-import { Icon } from "@/components/Icon";
 import { useEnterSubmit } from "@/lib/hooks/use-enter-submit";
 import { useChatStore } from "@/stores/AilaStoresProvider";
 import type { ChatAction } from "@/stores/chatStore";

--- a/apps/nextjs/src/components/AppComponents/Chat/prompt-form.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/prompt-form.tsx
@@ -1,4 +1,6 @@
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
+
+import { OakTertiaryButton } from "@oaknational/oak-components";
 
 import {
   Tooltip,
@@ -9,6 +11,9 @@ import { Icon } from "@/components/Icon";
 import { useEnterSubmit } from "@/lib/hooks/use-enter-submit";
 import { useChatStore } from "@/stores/AilaStoresProvider";
 import type { ChatAction } from "@/stores/chatStore";
+import { containsLink } from "@/utils/link-validation";
+
+import FormValidationWarning from "../FormValidationWarning";
 
 export interface PromptFormProps {
   input: string;
@@ -27,6 +32,7 @@ export function PromptForm({
 }: Readonly<PromptFormProps>) {
   const { formRef, onKeyDown } = useEnterSubmit();
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  const [formError, setFormError] = useState<string | null>(null);
   const queuedUserAction = useChatStore((state) => state.queuedUserAction);
 
   useEffect(() => {
@@ -35,17 +41,33 @@ export function PromptForm({
     }
   }, []);
 
+  const handleInputChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const newValue = e.target.value;
+    setInput(newValue);
+    if (containsLink(newValue)) {
+      setFormError("Aila doesn't currently support links");
+    } else {
+      setFormError(null);
+    }
+  };
+
+  const isSubmitDisabled = isDisabled || formError !== null;
+
+  const handleSubmit = (e?: React.FormEvent) => {
+    if (e) {
+      e.preventDefault();
+    }
+    if (!input?.trim()) {
+      return;
+    }
+    if (formError) {
+      return;
+    }
+    onSubmit(input);
+  };
+
   return (
-    <form
-      onSubmit={(e) => {
-        e.preventDefault();
-        if (!input?.trim()) {
-          return;
-        }
-        onSubmit(input);
-      }}
-      ref={formRef}
-    >
+    <form onSubmit={handleSubmit} ref={formRef}>
       <div
         className={`${isDisabled ? "block" : "hidden"} h-[60px] w-full rounded-md border-2 border-oakGrey3 sm:hidden`}
       />
@@ -60,7 +82,7 @@ export function PromptForm({
           onKeyDown={onKeyDown}
           rows={1}
           value={input}
-          onChange={(e) => setInput(e.target.value)}
+          onChange={handleInputChange}
           placeholder={handlePlaceholder(
             hasMessages,
             queuedUserAction ?? undefined,
@@ -71,19 +93,24 @@ export function PromptForm({
         <div className="absolute bottom-10 right-10 top-10 flex items-center justify-center">
           <Tooltip>
             <TooltipTrigger asChild>
-              <button
+              <OakTertiaryButton
+                disabled={isSubmitDisabled}
+                iconName="chevron-right"
+                onClick={handleSubmit}
                 data-testid="send-message"
-                type="submit"
-                className={`rounded-full bg-black p-4 ${isDisabled ? "cursor-not-allowed opacity-50" : ""}`}
-                disabled={isDisabled}
-              >
-                <Icon icon="chevron-right" color="white" size="sm" />
-              </button>
+              />
             </TooltipTrigger>
             <TooltipContent>Send message</TooltipContent>
           </Tooltip>
         </div>
       </div>
+      {formError && (
+        <FormValidationWarning
+          errorMessage={formError}
+          iconWidth="spacing-20"
+          $font="body-3"
+        />
+      )}
     </form>
   );
 }

--- a/apps/nextjs/src/components/AppComponents/Chat/prompt-form.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/prompt-form.tsx
@@ -56,10 +56,7 @@ export function PromptForm({
     if (e) {
       e.preventDefault();
     }
-    if (!input?.trim()) {
-      return;
-    }
-    if (formError) {
+    if (!input?.trim() || formError) {
       return;
     }
     onSubmit(input);

--- a/apps/nextjs/src/components/AppComponents/Chat/prompt-form.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/prompt-form.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 
-import { OakTertiaryButton } from "@oaknational/oak-components";
+import { OakBox, OakTertiaryButton } from "@oaknational/oak-components";
 
 import {
   Tooltip,
@@ -13,6 +13,7 @@ import type { ChatAction } from "@/stores/chatStore";
 import { containsLink } from "@/utils/link-validation";
 
 import FormValidationWarning from "../FormValidationWarning";
+import ChatPanelDisclaimer from "./chat-panel-disclaimer";
 
 export interface PromptFormProps {
   input: string;
@@ -107,6 +108,12 @@ export function PromptForm({
           $font="body-3"
         />
       )}
+      <OakBox
+        $mt={`${formError ? "spacing-0" : "spacing-24"}`}
+        $display={["none", "block"]}
+      >
+        <ChatPanelDisclaimer size="sm" />
+      </OakBox>
     </form>
   );
 }

--- a/apps/nextjs/src/components/AppComponents/FormValidationWarning.tsx
+++ b/apps/nextjs/src/components/AppComponents/FormValidationWarning.tsx
@@ -1,7 +1,7 @@
 import {
   type OakAllSpacingToken,
-  type OakBoxProps,
   OakFlex,
+  type OakFlexProps,
   type OakFontToken,
   OakIcon,
   OakSpan,
@@ -11,19 +11,22 @@ type FormValidationWarningProps = {
   errorMessage: string;
   iconWidth?: OakAllSpacingToken;
   $font?: OakFontToken;
-  $gap?: OakAllSpacingToken;
-  $mt?: OakBoxProps["$mt"];
+  containerProps?: OakFlexProps;
 };
 
 const FormValidationWarning = ({
   errorMessage,
   iconWidth = "spacing-40",
   $font = "body-2",
-  $gap = "spacing-4",
-  $mt,
+  containerProps,
 }: FormValidationWarningProps) => {
   return (
-    <OakFlex $flexDirection="row" $gap={$gap} $alignItems="center" $mt={$mt}>
+    <OakFlex
+      $flexDirection="row"
+      $gap="spacing-4"
+      $alignItems="center"
+      {...containerProps}
+    >
       <OakIcon
         iconName="warning"
         iconWidth={iconWidth}

--- a/apps/nextjs/src/components/AppComponents/FormValidationWarning.tsx
+++ b/apps/nextjs/src/components/AppComponents/FormValidationWarning.tsx
@@ -1,12 +1,37 @@
-import { OakFlex, OakIcon, OakP } from "@oaknational/oak-components";
+import {
+  type OakAllSpacingToken,
+  type OakBoxProps,
+  OakFlex,
+  type OakFontToken,
+  OakIcon,
+  OakSpan,
+} from "@oaknational/oak-components";
 
-const FormValidationWarning = ({ errorMessage }: { errorMessage: string }) => {
+type FormValidationWarningProps = {
+  errorMessage: string;
+  iconWidth?: OakAllSpacingToken;
+  $font?: OakFontToken;
+  $gap?: OakAllSpacingToken;
+  $mt?: OakBoxProps["$mt"];
+};
+
+const FormValidationWarning = ({
+  errorMessage,
+  iconWidth = "spacing-40",
+  $font = "body-2",
+  $gap = "spacing-4",
+  $mt,
+}: FormValidationWarningProps) => {
   return (
-    <OakFlex $flexDirection="row" $gap="spacing-4" $alignItems="center">
-      <OakIcon iconName="warning" iconWidth="spacing-40" $colorFilter="red" />
-      <OakP $font="body-2" $color="icon-error">
+    <OakFlex $flexDirection="row" $gap={$gap} $alignItems="center" $mt={$mt}>
+      <OakIcon
+        iconName="warning"
+        iconWidth={iconWidth}
+        $colorFilter="icon-error"
+      />
+      <OakSpan $font={$font} $color="text-error">
         {errorMessage}
-      </OakP>
+      </OakSpan>
     </OakFlex>
   );
 };

--- a/apps/nextjs/src/components/AppComponents/TeachingMaterials/StepLayouts/StepTwo.tsx
+++ b/apps/nextjs/src/components/AppComponents/TeachingMaterials/StepLayouts/StepTwo.tsx
@@ -9,7 +9,6 @@ import {
   useTeachingMaterialsActions,
   useTeachingMaterialsStore,
 } from "@/stores/TeachingMaterialsStoreProvider";
-import { containsLink } from "@/utils/link-validation";
 import {
   activeDropdownSelector,
   subjectSelector,

--- a/apps/nextjs/src/components/AppComponents/TeachingMaterials/StepLayouts/StepTwo.tsx
+++ b/apps/nextjs/src/components/AppComponents/TeachingMaterials/StepLayouts/StepTwo.tsx
@@ -9,6 +9,7 @@ import {
   useTeachingMaterialsActions,
   useTeachingMaterialsStore,
 } from "@/stores/TeachingMaterialsStoreProvider";
+import { containsLink } from "@/utils/link-validation";
 import {
   activeDropdownSelector,
   subjectSelector,

--- a/apps/nextjs/src/components/AppComponents/TeachingMaterials/StepLayouts/helpers.ts
+++ b/apps/nextjs/src/components/AppComponents/TeachingMaterials/StepLayouts/helpers.ts
@@ -1,5 +1,7 @@
 import type { Dispatch, SetStateAction } from "react";
 
+import { containsLink } from "@/utils/link-validation";
+
 import type { DialogTypes } from "../../Chat/Chat/types";
 
 export const handleDialogSelection = ({
@@ -51,6 +53,8 @@ export const getValidationError = (
     return `Please select a subject, so that Aila has the right context for your ${docTypeName}.`;
   } else if (!titleToCheck) {
     return `Please provide your lesson details, so that Aila has the right context for your ${docTypeName}.`;
+  } else if (containsLink(titleToCheck)) {
+    return "Aila doesn't currently support links";
   } else if (titleToCheck.length < 4) {
     return `Please provide a longer lesson title.`;
   }

--- a/apps/nextjs/src/utils/link-validation.test.ts
+++ b/apps/nextjs/src/utils/link-validation.test.ts
@@ -19,6 +19,14 @@ describe("containsLink", () => {
     expect(containsLink("Visit example.com")).toBe(false);
   });
 
+  it("detects www. URL without protocol", () => {
+    expect(containsLink("Visit www.example.com")).toBe(true);
+  });
+
+  it("does not match bare www. without a valid domain", () => {
+    expect(containsLink("www.")).toBe(false);
+  });
+
   it("returns false for empty or whitespace input", () => {
     expect(containsLink("")).toBe(false);
     expect(containsLink("   ")).toBe(false);

--- a/apps/nextjs/src/utils/link-validation.test.ts
+++ b/apps/nextjs/src/utils/link-validation.test.ts
@@ -1,0 +1,43 @@
+import { containsLink } from "./link-validation";
+
+describe("containsLink", () => {
+  it("detects HTTP URL", () => {
+    expect(containsLink("Visit http://example.com")).toBe(true);
+  });
+
+  it("detects HTTPS URL", () => {
+    expect(containsLink("Check this out https://example.com")).toBe(true);
+  });
+
+  it("detects URL with path, query params and fragment", () => {
+    expect(
+      containsLink("Link: https://example.com/path?foo=bar&baz=qux#top"),
+    ).toBe(true);
+  });
+
+  it("does not match bare domain without protocol", () => {
+    expect(containsLink("Visit example.com")).toBe(false);
+  });
+
+  it("returns false for empty or whitespace input", () => {
+    expect(containsLink("")).toBe(false);
+    expect(containsLink("   ")).toBe(false);
+    expect(containsLink("\n\n\n")).toBe(false);
+  });
+
+  it("returns false for lesson planning text without links", () => {
+    expect(
+      containsLink(
+        "Create a lesson plan for key stage 3 history about Roman Britain",
+      ),
+    ).toBe(false);
+  });
+
+  it("detects link in lesson planning context", () => {
+    expect(
+      containsLink(
+        "Create a lesson about https://www.example.com for key stage 2",
+      ),
+    ).toBe(true);
+  });
+});

--- a/apps/nextjs/src/utils/link-validation.ts
+++ b/apps/nextjs/src/utils/link-validation.ts
@@ -1,10 +1,10 @@
 export function containsLink(text: string): boolean {
-  const urlRegex = /(https?:\/\/[^\s]+)/g;
-  const urls = text.match(urlRegex) ?? [];
+  const urlRegex = /(https?:\/\/[^\s]+|www\.[^\s]+)/g;
+  const matches = text.match(urlRegex) ?? [];
 
-  return urls.some((url) => {
+  return matches.some((match) => {
     try {
-      new URL(url);
+      new URL(match.startsWith("www.") ? `https://${match}` : match);
       return true;
     } catch {
       return false;

--- a/apps/nextjs/src/utils/link-validation.ts
+++ b/apps/nextjs/src/utils/link-validation.ts
@@ -1,0 +1,13 @@
+export function containsLink(text: string): boolean {
+  const urlRegex = /(https?:\/\/[^\s]+)/g;
+  const urls = text.match(urlRegex) ?? [];
+
+  return urls.some((url) => {
+    try {
+      new URL(url);
+      return true;
+    } catch {
+      return false;
+    }
+  });
+}


### PR DESCRIPTION
## Description

[Figma](https://www.figma.com/design/I8Dulyd7bg2f0tEfbmSEpL/Aila-updates-2026?node-id=31-877&t=4C79bQ53vQ8NbehS-1)

- Validates user input for links and displays an error message (Aila lesson and Teaching materials)
Prevents users from submitting links in Aila by disabling the submit button. In Teaching materials, validation feedback appears on submit
- updates copy on disclaimer to match designs and moves into prompt form to match styling on error.

 ## Design notes
-Attempted to use the multi text component from the Oak library, but it does not support icons or children. Adapted the existing multi text input and refactored it to use the Oak button.

-The Oak error field component does not support styling props required to match designs, so a custom ai error component was edited to fit requirements.

Issue(s)

Fixes #

## How to test
Go to https://oak-ai-lesson-assistant-website-9307t08r5.vercel.thenational.academy/

Test chat messages and the initial lesson message in Aila. Validation should match designs and the submit button should be disabled when a link is present in the input box

Test step 2 input: validation message should appear on submit if a link exists in the textbox