### PR TITLE
chore: no-op QA preview branch for moderation v1

### DIFF
--- a/docs/qa-preview-moderation-v1.md
+++ b/docs/qa-preview-moderation-v1.md
@@ -1,0 +1,46 @@
+# QA preview — Oak Moderation Service as primary moderator
+
+This branch exists solely to provide a Vercel preview deployment that we can
+attach branch-scoped environment variables to. Its purpose is to validate the
+Oak AI Moderation Service running as Aila's **primary** chat moderator before
+any wider rollout.
+
+There are no behavioural code changes on this branch. Everything is driven by
+environment variables already supported by `AilaFeatureFactory`.
+
+## Required Vercel preview env vars (branch-scoped)
+
+Set these on the Aila Vercel project, scoped to the **Preview** environment and
+this branch (`test/moderation-v1-qa`):
+
+| Variable                       | Value                                                |
+| ------------------------------ | ---------------------------------------------------- |
+| `OAK_MODERATION_V1_PRIMARY`    | `true`                                               |
+| `MODERATION_API_URL`           | `https://moderation-api-preview.thenational.academy` |
+| `MODERATION_API_BYPASS_SECRET` | _(preview deployment protection bypass secret)_      |
+
+After setting the variables, redeploy this branch's preview — env var changes
+do not apply to existing builds.
+
+## Expected behaviour on this preview
+
+- Aila chat moderation calls `POST /v1/moderate` on the preview moderation
+  service.
+- Oak Moderation Service is the primary moderator and controls the moderation
+  result used by Aila.
+- The existing OpenAI moderation path runs only as the shadow moderator.
+- Shadow moderation errors remain non-fatal.
+- Aila product behaviour and admin workflows are unchanged apart from the
+  moderation backend being primary.
+- Preview moderation traces appear in Braintrust project
+  `Moderation - preview`.
+
+## Out of scope
+
+- Teaching materials moderation (`OAK_MODERATION_TEACHING_MATERIALS_V1_PRIMARY`)
+  is not touched by this preview. Only Aila chat moderation is being validated.
+
+## Lifecycle
+
+This PR should remain a draft. Once QA is complete, delete this file and close
+the PR — the branch-scoped env vars become inert when the branch is deleted.


### PR DESCRIPTION
## Description

- No-op PR. Exists solely to provide a stable Vercel preview deployment URL for QA of the Oak Moderation Service running as Aila's **primary** chat moderator.
- Adds `docs/qa-preview-moderation-v1.md` describing the purpose, the required branch-scoped Vercel preview env vars, expected behaviour, and lifecycle of this branch.
- No code or runtime behaviour changes — moderation routing is driven entirely by env vars already supported by `AilaFeatureFactory`.

## Issue(s)

Fixes #

## How to test

1. Set the following Vercel **Preview** env vars scoped to branch `test/moderation-v1-qa`:
   - `OAK_MODERATION_V1_PRIMARY=true`
   - `MODERATION_API_URL=https://moderation-api-preview.thenational.academy`
   - `MODERATION_API_BYPASS_SECRET=<preview deployment-protection bypass secret>`
2. Redeploy this branch's preview (env var changes do not apply to existing builds).
3. Open the preview URL and send an Aila chat message.
4. Confirm the `ai:aila` log line `Oak Moderation Service is primary moderator` appears (instead of `Shadow moderation enabled (Oak Moderation Service)`).
5. Confirm preview moderation traces appear in Braintrust project `Moderation - preview`.

## Screenshots

n/a — no UI changes.

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change

## Lifecycle

Keep this PR as a draft. Once QA is complete, delete `docs/qa-preview-moderation-v1.md` and close the PR — the branch-scoped env vars become inert when the branch is deleted.