### PR TITLE
feat: consistent lesson order in planning prompt -AI-2152

### DIFF
--- a/apps/nextjs/src/utils/serverSideFeatureFlag.ts
+++ b/apps/nextjs/src/utils/serverSideFeatureFlag.ts
@@ -6,6 +6,18 @@ import { kv } from "@vercel/kv";
 
 const log = aiLogger("feature-flags");
 
+function parseCachedFeatureFlagValue(value: unknown): boolean | null {
+  if (value === true || value === "true") {
+    return true;
+  }
+
+  if (value === false || value === "false") {
+    return false;
+  }
+
+  return null;
+}
+
 /**
  * Evaluate a feature flag server-side with full user context.
  *
@@ -19,15 +31,17 @@ export async function serverSideFeatureFlag(
   featureFlagId: string,
 ): Promise<boolean> {
   const { userId } = await auth();
+
   if (!userId) {
     return false;
   }
 
   const cacheKey = `feature_flag:${featureFlagId}:${userId}`;
   const cachedResult = await kv.get(cacheKey);
+  const parsedCachedResult = parseCachedFeatureFlagValue(cachedResult);
 
-  if (cachedResult !== null) {
-    return cachedResult === "true";
+  if (parsedCachedResult !== null) {
+    return parsedCachedResult;
   }
 
   try {
@@ -40,7 +54,7 @@ export async function serverSideFeatureFlag(
         personProperties: { ...(email && { email }) },
       })) ?? false;
 
-    await kv.set(cacheKey, isFeatureFlagEnabled.toString(), { ex: 60 });
+    await kv.set(cacheKey, isFeatureFlagEnabled, { ex: 60 });
 
     return isFeatureFlagEnabled;
   } catch (e) {

--- a/packages/aila/src/lib/agentic-system/agents/plannerAgent/__snapshots__/createPlannerAgent.test.ts.snap
+++ b/packages/aila/src/lib/agentic-system/agents/plannerAgent/__snapshots__/createPlannerAgent.test.ts.snap
@@ -44,12 +44,21 @@ You must respond with **exactly one of two decision types**:
 4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group** — never include sections from more than one group in a single plan, unless the user has explicitly named specific sections from different groups. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
 
 All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
 
+**Exception — explicit cross-group plans**: you may include sections from more than one group only if one of the following applies:
+1. The user's message explicitly names sections from different groups (e.g. "rewrite the \`keywords\` and make \`cycle2\` harder").
+2. The user explicitly asks to complete or generate the whole remaining lesson (e.g. "do everything", "complete the lesson", "fill in the rest"). In this case, plan all remaining incomplete sections.
+
+
+If none of these apply — including the default case where the user clicks "continue" or sends a vague positive intent — plan **only the next incomplete group**.
+
 #### cycle3
-Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 1 or 2 entries, do not include \`cycle3\`.
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 2 entries, do not include \`cycle3\`.
+
+
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
@@ -86,19 +95,20 @@ Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field c
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**:
-   - User asks to complete the full lesson
-   - Plan all remaining incomplete sections, one group at a time in group order, with each group's sections together in a single plan
+3. **Complete lesson request** (cross-group):
+   - User explicitly asks to complete or generate the whole lesson in one go (e.g. "do everything", "finish the lesson", "fill in the rest").
+   - Plan all remaining incomplete sections in logical order.
+   - This is the only "plan" case where multiple groups are included without the user naming specific sections.
 
-4. **Default progression**: 
-   - User provides general positive intent or wants to continue
-   - Plan the next logical incomplete sections
+4. **Default progression** (single group):
+   - User clicks "continue", or provides general positive intent without naming specific sections (e.g. "next", "ok", "go on", "looks good").
+   - Plan **only the next incomplete group**, following the SECTION GROUPS order.
 
 ---
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, plan all sections of the next incomplete group together in a single plan — never split a group across turns
+- **Process sections in their section groups**: Plan all sections of the next incomplete group together in a single plan — never split a group across turns, and never include sections from two or more groups unless the user has explicitly named sections from both.
 - **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
@@ -234,12 +244,21 @@ You must respond with **exactly one of two decision types**:
 4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group** — never include sections from more than one group in a single plan, unless the user has explicitly named specific sections from different groups. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
 
 All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
 
+**Exception — explicit cross-group plans**: you may include sections from more than one group only if one of the following applies:
+1. The user's message explicitly names sections from different groups (e.g. "rewrite the \`keywords\` and make \`cycle2\` harder").
+2. The user explicitly asks to complete or generate the whole remaining lesson (e.g. "do everything", "complete the lesson", "fill in the rest"). In this case, plan all remaining incomplete sections.
+
+
+If none of these apply — including the default case where the user clicks "continue" or sends a vague positive intent — plan **only the next incomplete group**.
+
 #### cycle3
-Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 1 or 2 entries, do not include \`cycle3\`.
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 2 entries, do not include \`cycle3\`.
+
+
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
@@ -276,19 +295,20 @@ Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field c
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**:
-   - User asks to complete the full lesson
-   - Plan all remaining incomplete sections, one group at a time in group order, with each group's sections together in a single plan
+3. **Complete lesson request** (cross-group):
+   - User explicitly asks to complete or generate the whole lesson in one go (e.g. "do everything", "finish the lesson", "fill in the rest").
+   - Plan all remaining incomplete sections in logical order.
+   - This is the only "plan" case where multiple groups are included without the user naming specific sections.
 
-4. **Default progression**: 
-   - User provides general positive intent or wants to continue
-   - Plan the next logical incomplete sections
+4. **Default progression** (single group):
+   - User clicks "continue", or provides general positive intent without naming specific sections (e.g. "next", "ok", "go on", "looks good").
+   - Plan **only the next incomplete group**, following the SECTION GROUPS order.
 
 ---
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, plan all sections of the next incomplete group together in a single plan — never split a group across turns
+- **Process sections in their section groups**: Plan all sections of the next incomplete group together in a single plan — never split a group across turns, and never include sections from two or more groups unless the user has explicitly named sections from both.
 - **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
@@ -415,12 +435,21 @@ You must respond with **exactly one of two decision types**:
 4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group** — never include sections from more than one group in a single plan, unless the user has explicitly named specific sections from different groups. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
 
 All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
 
+**Exception — explicit cross-group plans**: you may include sections from more than one group only if one of the following applies:
+1. The user's message explicitly names sections from different groups (e.g. "rewrite the \`keywords\` and make \`cycle2\` harder").
+2. The user explicitly asks to complete or generate the whole remaining lesson (e.g. "do everything", "complete the lesson", "fill in the rest"). In this case, plan all remaining incomplete sections.
+
+
+If none of these apply — including the default case where the user clicks "continue" or sends a vague positive intent — plan **only the next incomplete group**.
+
 #### cycle3
-Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 1 or 2 entries, do not include \`cycle3\`.
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 2 entries, do not include \`cycle3\`.
+
+
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
@@ -457,19 +486,20 @@ Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field c
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**:
-   - User asks to complete the full lesson
-   - Plan all remaining incomplete sections, one group at a time in group order, with each group's sections together in a single plan
+3. **Complete lesson request** (cross-group):
+   - User explicitly asks to complete or generate the whole lesson in one go (e.g. "do everything", "finish the lesson", "fill in the rest").
+   - Plan all remaining incomplete sections in logical order.
+   - This is the only "plan" case where multiple groups are included without the user naming specific sections.
 
-4. **Default progression**: 
-   - User provides general positive intent or wants to continue
-   - Plan the next logical incomplete sections
+4. **Default progression** (single group):
+   - User clicks "continue", or provides general positive intent without naming specific sections (e.g. "next", "ok", "go on", "looks good").
+   - Plan **only the next incomplete group**, following the SECTION GROUPS order.
 
 ---
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, plan all sections of the next incomplete group together in a single plan — never split a group across turns
+- **Process sections in their section groups**: Plan all sections of the next incomplete group together in a single plan — never split a group across turns, and never include sections from two or more groups unless the user has explicitly named sections from both.
 - **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
@@ -605,12 +635,21 @@ You must respond with **exactly one of two decision types**:
 4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group** — never include sections from more than one group in a single plan, unless the user has explicitly named specific sections from different groups. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
 
 All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
 
+**Exception — explicit cross-group plans**: you may include sections from more than one group only if one of the following applies:
+1. The user's message explicitly names sections from different groups (e.g. "rewrite the \`keywords\` and make \`cycle2\` harder").
+2. The user explicitly asks to complete or generate the whole remaining lesson (e.g. "do everything", "complete the lesson", "fill in the rest"). In this case, plan all remaining incomplete sections.
+
+
+If none of these apply — including the default case where the user clicks "continue" or sends a vague positive intent — plan **only the next incomplete group**.
+
 #### cycle3
-Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 1 or 2 entries, do not include \`cycle3\`.
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 2 entries, do not include \`cycle3\`.
+
+
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
@@ -647,19 +686,20 @@ Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field c
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**:
-   - User asks to complete the full lesson
-   - Plan all remaining incomplete sections, one group at a time in group order, with each group's sections together in a single plan
+3. **Complete lesson request** (cross-group):
+   - User explicitly asks to complete or generate the whole lesson in one go (e.g. "do everything", "finish the lesson", "fill in the rest").
+   - Plan all remaining incomplete sections in logical order.
+   - This is the only "plan" case where multiple groups are included without the user naming specific sections.
 
-4. **Default progression**: 
-   - User provides general positive intent or wants to continue
-   - Plan the next logical incomplete sections
+4. **Default progression** (single group):
+   - User clicks "continue", or provides general positive intent without naming specific sections (e.g. "next", "ok", "go on", "looks good").
+   - Plan **only the next incomplete group**, following the SECTION GROUPS order.
 
 ---
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, plan all sections of the next incomplete group together in a single plan — never split a group across turns
+- **Process sections in their section groups**: Plan all sections of the next incomplete group together in a single plan — never split a group across turns, and never include sections from two or more groups unless the user has explicitly named sections from both.
 - **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
@@ -784,12 +824,21 @@ You must respond with **exactly one of two decision types**:
 4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group** — never include sections from more than one group in a single plan, unless the user has explicitly named specific sections from different groups. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
 
 All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
 
+**Exception — explicit cross-group plans**: you may include sections from more than one group only if one of the following applies:
+1. The user's message explicitly names sections from different groups (e.g. "rewrite the \`keywords\` and make \`cycle2\` harder").
+2. The user explicitly asks to complete or generate the whole remaining lesson (e.g. "do everything", "complete the lesson", "fill in the rest"). In this case, plan all remaining incomplete sections.
+
+
+If none of these apply — including the default case where the user clicks "continue" or sends a vague positive intent — plan **only the next incomplete group**.
+
 #### cycle3
-Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 1 or 2 entries, do not include \`cycle3\`.
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 2 entries, do not include \`cycle3\`.
+
+
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
@@ -826,19 +875,20 @@ Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field c
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**:
-   - User asks to complete the full lesson
-   - Plan all remaining incomplete sections, one group at a time in group order, with each group's sections together in a single plan
+3. **Complete lesson request** (cross-group):
+   - User explicitly asks to complete or generate the whole lesson in one go (e.g. "do everything", "finish the lesson", "fill in the rest").
+   - Plan all remaining incomplete sections in logical order.
+   - This is the only "plan" case where multiple groups are included without the user naming specific sections.
 
-4. **Default progression**: 
-   - User provides general positive intent or wants to continue
-   - Plan the next logical incomplete sections
+4. **Default progression** (single group):
+   - User clicks "continue", or provides general positive intent without naming specific sections (e.g. "next", "ok", "go on", "looks good").
+   - Plan **only the next incomplete group**, following the SECTION GROUPS order.
 
 ---
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, plan all sections of the next incomplete group together in a single plan — never split a group across turns
+- **Process sections in their section groups**: Plan all sections of the next incomplete group together in a single plan — never split a group across turns, and never include sections from two or more groups unless the user has explicitly named sections from both.
 - **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
@@ -974,12 +1024,21 @@ You must respond with **exactly one of two decision types**:
 4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group** — never include sections from more than one group in a single plan, unless the user has explicitly named specific sections from different groups. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
 
 All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
 
+**Exception — explicit cross-group plans**: you may include sections from more than one group only if one of the following applies:
+1. The user's message explicitly names sections from different groups (e.g. "rewrite the \`keywords\` and make \`cycle2\` harder").
+2. The user explicitly asks to complete or generate the whole remaining lesson (e.g. "do everything", "complete the lesson", "fill in the rest"). In this case, plan all remaining incomplete sections.
+
+
+If none of these apply — including the default case where the user clicks "continue" or sends a vague positive intent — plan **only the next incomplete group**.
+
 #### cycle3
-Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 1 or 2 entries, do not include \`cycle3\`.
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 2 entries, do not include \`cycle3\`.
+
+
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
@@ -1016,19 +1075,20 @@ Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field c
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**:
-   - User asks to complete the full lesson
-   - Plan all remaining incomplete sections, one group at a time in group order, with each group's sections together in a single plan
+3. **Complete lesson request** (cross-group):
+   - User explicitly asks to complete or generate the whole lesson in one go (e.g. "do everything", "finish the lesson", "fill in the rest").
+   - Plan all remaining incomplete sections in logical order.
+   - This is the only "plan" case where multiple groups are included without the user naming specific sections.
 
-4. **Default progression**: 
-   - User provides general positive intent or wants to continue
-   - Plan the next logical incomplete sections
+4. **Default progression** (single group):
+   - User clicks "continue", or provides general positive intent without naming specific sections (e.g. "next", "ok", "go on", "looks good").
+   - Plan **only the next incomplete group**, following the SECTION GROUPS order.
 
 ---
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, plan all sections of the next incomplete group together in a single plan — never split a group across turns
+- **Process sections in their section groups**: Plan all sections of the next incomplete group together in a single plan — never split a group across turns, and never include sections from two or more groups unless the user has explicitly named sections from both.
 - **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 

--- a/packages/aila/src/lib/agentic-system/agents/plannerAgent/__snapshots__/createPlannerAgent.test.ts.snap
+++ b/packages/aila/src/lib/agentic-system/agents/plannerAgent/__snapshots__/createPlannerAgent.test.ts.snap
@@ -41,14 +41,19 @@ You must respond with **exactly one of two decision types**:
 1. \`title\`, \`keyStage\`, \`subject\`
 2. \`basedOn\` (optional), \`learningOutcome\`, \`learningCycles\`  
 3. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
-4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (optional), \`exitQuiz\`  
+4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+
+All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
+
+#### cycle3
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 1 or 2 entries, do not include \`cycle3\`.
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
-- You should only include \`basedOn\` in the 'plan' if the user has provided a clear and specific reference lesson to base it on when shown a list of relevant lessons. It should be clear from the Message History and User Message.
+- **NEVER include \`basedOn\` in the plan** unless ALL of the following are true: (1) the RELEVANT LESSONS section above lists at least one lesson title, AND (2) the user has explicitly selected or referenced one of those specific lessons in the Message History or User Message. If the RELEVANT LESSONS section says none were found or is empty, you must not include \`basedOn\`.
 
 ---
 
@@ -81,9 +86,9 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**: 
+3. **Complete lesson request**:
    - User asks to complete the full lesson
-   - Plan all remaining incomplete sections in logical order
+   - Plan all remaining incomplete sections, one group at a time in group order, with each group's sections together in a single plan
 
 4. **Default progression**: 
    - User provides general positive intent or wants to continue
@@ -93,8 +98,8 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, finish the next incomplete section group
-- **Only include 'basedOn' in the plan** if user has been shown a list of relevant lessons to choose from. If so, it will be abundantly clear from the MESSAGE HISTORY and USER MESSAGE sections.
+- **Process sections in their section groups**: Unless the user specifies otherwise, plan all sections of the next incomplete group together in a single plan — never split a group across turns
+- **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
 ### 🔹 SECTION INSTRUCTIONS
@@ -226,14 +231,19 @@ You must respond with **exactly one of two decision types**:
 1. \`title\`, \`keyStage\`, \`subject\`
 2. \`basedOn\` (optional), \`learningOutcome\`, \`learningCycles\`  
 3. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
-4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (optional), \`exitQuiz\`  
+4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+
+All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
+
+#### cycle3
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 1 or 2 entries, do not include \`cycle3\`.
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
-- You should only include \`basedOn\` in the 'plan' if the user has provided a clear and specific reference lesson to base it on when shown a list of relevant lessons. It should be clear from the Message History and User Message.
+- **NEVER include \`basedOn\` in the plan** unless ALL of the following are true: (1) the RELEVANT LESSONS section above lists at least one lesson title, AND (2) the user has explicitly selected or referenced one of those specific lessons in the Message History or User Message. If the RELEVANT LESSONS section says none were found or is empty, you must not include \`basedOn\`.
 
 ---
 
@@ -266,9 +276,9 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**: 
+3. **Complete lesson request**:
    - User asks to complete the full lesson
-   - Plan all remaining incomplete sections in logical order
+   - Plan all remaining incomplete sections, one group at a time in group order, with each group's sections together in a single plan
 
 4. **Default progression**: 
    - User provides general positive intent or wants to continue
@@ -278,8 +288,8 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, finish the next incomplete section group
-- **Only include 'basedOn' in the plan** if user has been shown a list of relevant lessons to choose from. If so, it will be abundantly clear from the MESSAGE HISTORY and USER MESSAGE sections.
+- **Process sections in their section groups**: Unless the user specifies otherwise, plan all sections of the next incomplete group together in a single plan — never split a group across turns
+- **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
 ### 🔹 SECTION INSTRUCTIONS
@@ -402,14 +412,19 @@ You must respond with **exactly one of two decision types**:
 1. \`title\`, \`keyStage\`, \`subject\`
 2. \`basedOn\` (optional), \`learningOutcome\`, \`learningCycles\`  
 3. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
-4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (optional), \`exitQuiz\`  
+4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+
+All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
+
+#### cycle3
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 1 or 2 entries, do not include \`cycle3\`.
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
-- You should only include \`basedOn\` in the 'plan' if the user has provided a clear and specific reference lesson to base it on when shown a list of relevant lessons. It should be clear from the Message History and User Message.
+- **NEVER include \`basedOn\` in the plan** unless ALL of the following are true: (1) the RELEVANT LESSONS section above lists at least one lesson title, AND (2) the user has explicitly selected or referenced one of those specific lessons in the Message History or User Message. If the RELEVANT LESSONS section says none were found or is empty, you must not include \`basedOn\`.
 
 ---
 
@@ -442,9 +457,9 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**: 
+3. **Complete lesson request**:
    - User asks to complete the full lesson
-   - Plan all remaining incomplete sections in logical order
+   - Plan all remaining incomplete sections, one group at a time in group order, with each group's sections together in a single plan
 
 4. **Default progression**: 
    - User provides general positive intent or wants to continue
@@ -454,8 +469,8 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, finish the next incomplete section group
-- **Only include 'basedOn' in the plan** if user has been shown a list of relevant lessons to choose from. If so, it will be abundantly clear from the MESSAGE HISTORY and USER MESSAGE sections.
+- **Process sections in their section groups**: Unless the user specifies otherwise, plan all sections of the next incomplete group together in a single plan — never split a group across turns
+- **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
 ### 🔹 SECTION INSTRUCTIONS
@@ -587,14 +602,19 @@ You must respond with **exactly one of two decision types**:
 1. \`title\`, \`keyStage\`, \`subject\`
 2. \`basedOn\` (optional), \`learningOutcome\`, \`learningCycles\`  
 3. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
-4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (optional), \`exitQuiz\`  
+4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+
+All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
+
+#### cycle3
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 1 or 2 entries, do not include \`cycle3\`.
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
-- You should only include \`basedOn\` in the 'plan' if the user has provided a clear and specific reference lesson to base it on when shown a list of relevant lessons. It should be clear from the Message History and User Message.
+- **NEVER include \`basedOn\` in the plan** unless ALL of the following are true: (1) the RELEVANT LESSONS section above lists at least one lesson title, AND (2) the user has explicitly selected or referenced one of those specific lessons in the Message History or User Message. If the RELEVANT LESSONS section says none were found or is empty, you must not include \`basedOn\`.
 
 ---
 
@@ -627,9 +647,9 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**: 
+3. **Complete lesson request**:
    - User asks to complete the full lesson
-   - Plan all remaining incomplete sections in logical order
+   - Plan all remaining incomplete sections, one group at a time in group order, with each group's sections together in a single plan
 
 4. **Default progression**: 
    - User provides general positive intent or wants to continue
@@ -639,8 +659,8 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, finish the next incomplete section group
-- **Only include 'basedOn' in the plan** if user has been shown a list of relevant lessons to choose from. If so, it will be abundantly clear from the MESSAGE HISTORY and USER MESSAGE sections.
+- **Process sections in their section groups**: Unless the user specifies otherwise, plan all sections of the next incomplete group together in a single plan — never split a group across turns
+- **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
 ### 🔹 SECTION INSTRUCTIONS
@@ -761,14 +781,19 @@ You must respond with **exactly one of two decision types**:
 1. \`title\`, \`keyStage\`, \`subject\`
 2. \`basedOn\` (optional), \`learningOutcome\`, \`learningCycles\`  
 3. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
-4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (optional), \`exitQuiz\`  
+4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+
+All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
+
+#### cycle3
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 1 or 2 entries, do not include \`cycle3\`.
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
-- You should only include \`basedOn\` in the 'plan' if the user has provided a clear and specific reference lesson to base it on when shown a list of relevant lessons. It should be clear from the Message History and User Message.
+- **NEVER include \`basedOn\` in the plan** unless ALL of the following are true: (1) the RELEVANT LESSONS section above lists at least one lesson title, AND (2) the user has explicitly selected or referenced one of those specific lessons in the Message History or User Message. If the RELEVANT LESSONS section says none were found or is empty, you must not include \`basedOn\`.
 
 ---
 
@@ -801,9 +826,9 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**: 
+3. **Complete lesson request**:
    - User asks to complete the full lesson
-   - Plan all remaining incomplete sections in logical order
+   - Plan all remaining incomplete sections, one group at a time in group order, with each group's sections together in a single plan
 
 4. **Default progression**: 
    - User provides general positive intent or wants to continue
@@ -813,8 +838,8 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, finish the next incomplete section group
-- **Only include 'basedOn' in the plan** if user has been shown a list of relevant lessons to choose from. If so, it will be abundantly clear from the MESSAGE HISTORY and USER MESSAGE sections.
+- **Process sections in their section groups**: Unless the user specifies otherwise, plan all sections of the next incomplete group together in a single plan — never split a group across turns
+- **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
 ### 🔹 SECTION INSTRUCTIONS
@@ -946,14 +971,19 @@ You must respond with **exactly one of two decision types**:
 1. \`title\`, \`keyStage\`, \`subject\`
 2. \`basedOn\` (optional), \`learningOutcome\`, \`learningCycles\`  
 3. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
-4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (optional), \`exitQuiz\`  
+4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+
+All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
+
+#### cycle3
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 1 or 2 entries, do not include \`cycle3\`.
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
-- You should only include \`basedOn\` in the 'plan' if the user has provided a clear and specific reference lesson to base it on when shown a list of relevant lessons. It should be clear from the Message History and User Message.
+- **NEVER include \`basedOn\` in the plan** unless ALL of the following are true: (1) the RELEVANT LESSONS section above lists at least one lesson title, AND (2) the user has explicitly selected or referenced one of those specific lessons in the Message History or User Message. If the RELEVANT LESSONS section says none were found or is empty, you must not include \`basedOn\`.
 
 ---
 
@@ -986,9 +1016,9 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**: 
+3. **Complete lesson request**:
    - User asks to complete the full lesson
-   - Plan all remaining incomplete sections in logical order
+   - Plan all remaining incomplete sections, one group at a time in group order, with each group's sections together in a single plan
 
 4. **Default progression**: 
    - User provides general positive intent or wants to continue
@@ -998,8 +1028,8 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, finish the next incomplete section group
-- **Only include 'basedOn' in the plan** if user has been shown a list of relevant lessons to choose from. If so, it will be abundantly clear from the MESSAGE HISTORY and USER MESSAGE sections.
+- **Process sections in their section groups**: Unless the user specifies otherwise, plan all sections of the next incomplete group together in a single plan — never split a group across turns
+- **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
 ### 🔹 SECTION INSTRUCTIONS

--- a/packages/aila/src/lib/agentic-system/agents/plannerAgent/plannerAgent.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/plannerAgent/plannerAgent.instructions.ts
@@ -36,14 +36,28 @@ You must respond with **exactly one of two decision types**:
 1. \`title\`, \`keyStage\`, \`subject\`
 2. \`basedOn\` (optional), \`learningOutcome\`, \`learningCycles\`  
 3. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
-4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (optional), \`exitQuiz\`  
+4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group** — never include sections from more than one group in a single plan, unless the user has explicitly named specific sections from different groups. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+
+All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
+
+**Exception — explicit cross-group plans**: you may include sections from more than one group only if one of the following applies:
+1. The user's message explicitly names sections from different groups (e.g. "rewrite the \`keywords\` and make \`cycle2\` harder").
+2. The user explicitly asks to complete or generate the whole remaining lesson (e.g. "do everything", "complete the lesson", "fill in the rest"). In this case, plan all remaining incomplete sections.
+
+
+If none of these apply — including the default case where the user clicks "continue" or sends a vague positive intent — plan **only the next incomplete group**.
+
+#### cycle3
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 2 entries, do not include \`cycle3\`.
+
+
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
-- You should only include \`basedOn\` in the 'plan' if the user has provided a clear and specific reference lesson to base it on when shown a list of relevant lessons. It should be clear from the Message History and User Message.
+- **NEVER include \`basedOn\` in the plan** unless ALL of the following are true: (1) the RELEVANT LESSONS section above lists at least one lesson title, AND (2) the user has explicitly selected or referenced one of those specific lessons in the Message History or User Message. If the RELEVANT LESSONS section says none were found or is empty, you must not include \`basedOn\`.
 
 ---
 
@@ -76,20 +90,21 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**: 
-   - User asks to complete the full lesson
-   - Plan all remaining incomplete sections in logical order
+3. **Complete lesson request** (cross-group):
+   - User explicitly asks to complete or generate the whole lesson in one go (e.g. "do everything", "finish the lesson", "fill in the rest").
+   - Plan all remaining incomplete sections in logical order.
+   - This is the only "plan" case where multiple groups are included without the user naming specific sections.
 
-4. **Default progression**: 
-   - User provides general positive intent or wants to continue
-   - Plan the next logical incomplete sections
+4. **Default progression** (single group):
+   - User clicks "continue", or provides general positive intent without naming specific sections (e.g. "next", "ok", "go on", "looks good").
+   - Plan **only the next incomplete group**, following the SECTION GROUPS order.
 
 ---
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, finish the next incomplete section group
-- **Only include 'basedOn' in the plan** if user has been shown a list of relevant lessons to choose from. If so, it will be abundantly clear from the MESSAGE HISTORY and USER MESSAGE sections.
+- **Process sections in their section groups**: Plan all sections of the next incomplete group together in a single plan — never split a group across turns, and never include sections from two or more groups unless the user has explicitly named sections from both.
+- **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
 ### 🔹 SECTION INSTRUCTIONS

--- a/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
@@ -106,22 +106,21 @@ const SCORERS: Scorer[] = [
         }
         const actual = po.plan.map((s) => s.sectionKey);
         const expected = EXPECTED_GROUPS[i];
-        if (!expected?.includes("cycle3")) {
-          // If cycle3 is not expected, remove it from actual if present, since it's optional in that case.
-          const cycle3Index = actual.indexOf("cycle3");
-          if (cycle3Index !== -1) {
-            actual.splice(cycle3Index, 1);
-          }
-        }
+        // cycle3 is optional in the actual output — strip it from expected
+        // only when both sides agree it's absent.
+        const expectedAdjusted =
+          expected && !actual.includes("cycle3")
+            ? expected.filter((s) => s !== "cycle3")
+            : expected;
         const match =
-          expected &&
-          actual.length === expected.length &&
-          actual.every((k, j) => k === expected[j]);
+          expectedAdjusted &&
+          actual.length === expectedAdjusted.length &&
+          actual.every((k, j) => k === expectedAdjusted[j]);
         const icon = match ? "✓" : "✗";
         if (!match) anyMismatch = true;
         lines.push(`Turn ${i + 1}: ${icon} [${actual.join(", ")}]`);
-        if (!match && expected) {
-          lines.push(`  expected: [${expected.join(", ")}]`);
+        if (!match && expectedAdjusted) {
+          lines.push(`  expected: [${expectedAdjusted.join(", ")}]`);
         }
       }
       lines.push(`Total: ${turnCount} turns`);

--- a/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
@@ -106,6 +106,13 @@ const SCORERS: Scorer[] = [
         }
         const actual = po.plan.map((s) => s.sectionKey);
         const expected = EXPECTED_GROUPS[i];
+        if (!expected?.includes("cycle3")) {
+          // If cycle3 is not expected, remove it from actual if present, since it's optional in that case.
+          const cycle3Index = actual.indexOf("cycle3");
+          if (cycle3Index !== -1) {
+            actual.splice(cycle3Index, 1);
+          }
+        }
         const match =
           expected &&
           actual.length === expected.length &&
@@ -343,9 +350,19 @@ async function runOnce(scenario: ScenarioConfig): Promise<RunCapture> {
       const callbacks: AilaTurnCallbacks = {
         onPlannerComplete: ({ sectionKeys }) => {
           turnPlannerSections = sectionKeys;
+          if (sectionKeys.length > 0) {
+            console.log(
+              `    [turn ${turnCount + 1}] planner → [${sectionKeys.join(", ")}]`,
+            );
+          } else {
+            console.log(`    [turn ${turnCount + 1}] planner → exit`);
+          }
         },
         onSectionComplete: (patches) => {
           turnPatches.push(...patches);
+          for (const p of patches) {
+            console.log(`    [turn ${turnCount + 1}] section done → ${p.path}`);
+          }
         },
         onTurnComplete: ({ document, ailaMessage }) => {
           turnDoc = document;

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
 codeHash: c829f5eeca94117fa2b0ebec8a7799c27c55158d70492520234f317533b0a7ff
-generated: 2026-04-30T11:54:50.548Z
+generated: 2026-04-30T13:37:43.991Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -10,8 +10,7 @@ summary:
     cycle-verbosity:
       pass: 3
     keyword-casing:
-      skip: 1
-      pass: 2
+      pass: 3
     title-no-gerund:
       pass: 3
     quiz-question-count:

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,14 +1,12 @@
-codeHash: 5499b3383906dd052cbc174e2a515face573d7cd591457cf8aaaf7546244dd19
-generated: 2026-02-24T12:45:22.745Z
+codeHash: 69f0a0041650003b9997077a6dc2c4b9f72965e69b5485a85066034114255ff2
+generated: 2026-04-30T10:51:51.990Z
 runsPerScenario: 3
 summary:
   full-lesson:
     plan-groupings:
-      flag: 2
-      pass: 1
+      pass: 3
     additional-materials-tone:
-      pass: 2
-      skip: 1
+      skip: 3
     cycle-verbosity:
       pass: 3
     keyword-casing:
@@ -19,7 +17,7 @@ summary:
       pass: 3
   no-rag-lesson:
     plan-groupings:
-      flag: 3
+      pass: 3
     additional-materials-tone:
       skip: 3
     cycle-verbosity:

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
-codeHash: 69f0a0041650003b9997077a6dc2c4b9f72965e69b5485a85066034114255ff2
-generated: 2026-04-30T10:51:51.990Z
+codeHash: 10c3ff50530cb9e048f2fa364b7a69cfd75a8f0c078af0211a2163369376cac3
+generated: 2026-04-30T11:35:25.147Z
 runsPerScenario: 3
 summary:
   full-lesson:

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
-codeHash: 10c3ff50530cb9e048f2fa364b7a69cfd75a8f0c078af0211a2163369376cac3
-generated: 2026-04-30T11:35:25.147Z
+codeHash: c829f5eeca94117fa2b0ebec8a7799c27c55158d70492520234f317533b0a7ff
+generated: 2026-04-30T11:54:50.548Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -10,7 +10,8 @@ summary:
     cycle-verbosity:
       pass: 3
     keyword-casing:
-      pass: 3
+      skip: 1
+      pass: 2
     title-no-gerund:
       pass: 3
     quiz-question-count:


### PR DESCRIPTION
## Description

- Change prompt to be more explicit about lesson section grouping 
- Adjust scoring harness to take into consideration optional cycle 3
- Added extra logs for harness


## How to test

Lesson sections should be completed in this order unless specified (e.g Complete all lesson sections at once)

1. learningOutcome, learningCycles
2. priorKnowledge, keyLearningPoints, misconceptions, keywords
3. starterQuiz, cycle1, cycle2, cycle3, exitQuiz
4. additionalMaterials

1. Go to https://oak-ai-lesson-assistant-website-i8vx79fdh.vercel.thenational.academy


## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
