### PR TITLE
fix: retry Oak Moderation Service once

### DIFF
--- a/packages/aila/src/features/moderation/moderators/OakModerationServiceModerator.test.ts
+++ b/packages/aila/src/features/moderation/moderators/OakModerationServiceModerator.test.ts
@@ -9,7 +9,7 @@ jest.mock("@oakai/core/src/utils/ailaModeration/oakModerationService", () => ({
 }));
 
 jest.mock("@oakai/logger", () => ({
-  aiLogger: () => ({ info: jest.fn(), error: jest.fn() }),
+  aiLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }),
 }));
 
 const mockedModerateWithOakService = jest.mocked(moderateWithOakService);

--- a/packages/aila/src/features/moderation/moderators/OakModerationServiceModerator.test.ts
+++ b/packages/aila/src/features/moderation/moderators/OakModerationServiceModerator.test.ts
@@ -1,0 +1,39 @@
+import type { ModerationResult } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
+import { moderateWithOakService } from "@oakai/core/src/utils/ailaModeration/oakModerationService";
+
+import { OakModerationServiceModerator } from "./OakModerationServiceModerator";
+
+jest.mock("@oakai/core/src/utils/ailaModeration/oakModerationService", () => ({
+  OakModerationServiceError: class OakModerationServiceError extends Error {},
+  moderateWithOakService: jest.fn(),
+}));
+
+jest.mock("@oakai/logger", () => ({
+  aiLogger: () => ({ info: jest.fn(), error: jest.fn() }),
+}));
+
+const mockedModerateWithOakService = jest.mocked(moderateWithOakService);
+
+describe("OakModerationServiceModerator", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("retries once when the Oak Moderation Service call fails", async () => {
+    const result: ModerationResult = {
+      categories: [],
+    };
+    mockedModerateWithOakService
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValueOnce(result);
+
+    const moderator = new OakModerationServiceModerator({
+      baseUrl: "https://moderation.test",
+      chatId: "chat-1",
+      userId: "user-1",
+    });
+
+    await expect(moderator.moderate("content")).resolves.toBe(result);
+    expect(mockedModerateWithOakService).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/aila/src/features/moderation/moderators/OakModerationServiceModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/OakModerationServiceModerator.ts
@@ -66,6 +66,7 @@ export class OakModerationServiceModerator extends AilaModerator {
       return await this._moderate(input, context);
     } catch (error) {
       log.error("Oak Moderation Service moderation error: ", error);
+      log.warn("Retrying Oak Moderation Service call");
       return await this._moderate(input, context);
     }
   }

--- a/packages/aila/src/features/moderation/moderators/OakModerationServiceModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/OakModerationServiceModerator.ts
@@ -33,14 +33,10 @@ export class OakModerationServiceModerator extends AilaModerator {
     this.config = config;
   }
 
-  async moderate(
+  private async _moderate(
     input: string,
     context?: AilaModeratorContext,
   ): Promise<ModerationResult> {
-    log.info("Calling Oak Moderation Service", {
-      contentLength: input.length,
-    });
-
     try {
       return await moderateWithOakService(input, {
         baseUrl: this.config.baseUrl,
@@ -55,6 +51,22 @@ export class OakModerationServiceModerator extends AilaModerator {
       throw new AilaModerationError("Oak Moderation Service failed", {
         cause: err,
       });
+    }
+  }
+
+  async moderate(
+    input: string,
+    context?: AilaModeratorContext,
+  ): Promise<ModerationResult> {
+    log.info("Calling Oak Moderation Service", {
+      contentLength: input.length,
+    });
+
+    try {
+      return await this._moderate(input, context);
+    } catch (error) {
+      log.error("Oak Moderation Service moderation error: ", error);
+      return await this._moderate(input, context);
     }
   }
 }


### PR DESCRIPTION
## Context

The intention behind this PR is to make the Oak Moderation Service safer to promote from shadow mode to the primary Aila moderator.

 The current primary inline OpenAI moderator already has a very lightweight resilience pattern: if the first moderation call throws, it logs the failure and tries once more. The Oak Moderation Service path did not have the equivalent protection, so a transient 5xx, timeout, or short-lived network failure would immediately fail the primary moderation step once we switch over.

This PR intentionally mirrors the existing inline moderator behaviour rather than introducing a broader retry framework. It keeps the change small and easy to reason about: call the Oak service once, log on failure, then retry once. If the second attempt also fails, the existing error handling still applies.

The goal is not to mask persistent moderation service failures, but to avoid user-facing failures for one-off transient errors during the primary moderator migration.


## Summary
- add a lightweight one-retry wrapper around Oak Moderation Service moderation calls
- keep Oak service error wrapping unchanged
- add a focused unit test covering retry after a transient failure

## Testing
- pnpm --filter @oakai/aila test -- --runTestsByPath src/features/moderation/moderators/OakModerationServiceModerator.test.ts
- pnpm --filter @oakai/aila type-check