### PR TITLE
fix: pass Aila moderation identifiers to Oak service

### DIFF
--- a/packages/aila/src/features/moderation/AilaModeration.ts
+++ b/packages/aila/src/features/moderation/AilaModeration.ts
@@ -115,6 +115,7 @@ export class AilaModeration implements AilaModerationFeature {
     const moderationResult: ModerationResult = await this.performModeration({
       messages,
       content,
+      messageId: lastAssistantMessage.id,
       retries: 3,
     });
 
@@ -187,10 +188,12 @@ export class AilaModeration implements AilaModerationFeature {
   public async performModeration({
     messages,
     content,
+    messageId,
     retries = 0,
   }: {
     messages: Message[];
     content: AilaDocumentContent;
+    messageId?: string;
     retries?: number;
   }): Promise<ModerationResult> {
     log.info("Performing moderation");
@@ -203,11 +206,15 @@ export class AilaModeration implements AilaModerationFeature {
     }
 
     const contentString = JSON.stringify(content);
+    const moderationContext = {
+      sessionId: this._aila.chatId,
+      messageId,
+    };
 
     // Fire off shadow moderation call (non-blocking, errors caught)
     if (this._shadowModerator) {
       const shadowPromise = this._shadowModerator
-        .moderate(contentString)
+        .moderate(contentString, moderationContext)
         .then((result) => {
           if (result) {
             log.info("Shadow moderation result", {
@@ -230,19 +237,25 @@ export class AilaModeration implements AilaModerationFeature {
     }
 
     // Production moderation call
-    const response = await this._moderator.moderate(contentString);
+    const response = await this._moderator.moderate(
+      contentString,
+      moderationContext,
+    );
     return (
-      response ?? (await this.retryModeration({ messages, content, retries }))
+      response ??
+      (await this.retryModeration({ messages, content, messageId, retries }))
     );
   }
 
   public async retryModeration({
     messages,
     content,
+    messageId,
     retries,
   }: {
     messages: Message[];
     content: AilaDocumentContent;
+    messageId?: string;
     retries: number;
   }): Promise<ModerationResult> {
     if (retries < 1) {
@@ -260,6 +273,7 @@ export class AilaModeration implements AilaModerationFeature {
     return this.performModeration({
       messages,
       content,
+      messageId,
       retries: retries - 1,
     });
   }

--- a/packages/aila/src/features/moderation/index.test.ts
+++ b/packages/aila/src/features/moderation/index.test.ts
@@ -6,11 +6,16 @@ import type { PrismaClientWithAccelerate } from "@oakai/db";
 import { AilaModeration } from ".";
 import { Aila } from "../../core/Aila";
 import type { Message } from "../../core/chat";
+import type { LLMService } from "../../core/llm/LLMService";
 import type { AilaPlugin } from "../../core/plugins";
 import type { AilaChatInitializationOptions } from "../../core/types";
 import type { PartialLessonPlan } from "../../protocol/schema";
 import type { AilaModerator } from "./moderators";
 import { MockModerator } from "./moderators/MockModerator";
+
+jest.mock("@oakai/db", () => ({
+  prisma: {},
+}));
 
 // Ensure that no tests start relying on prisma
 const prismaMock = {} as PrismaClientWithAccelerate;
@@ -38,9 +43,20 @@ const setUpModeration = ({
     document,
     chat,
     options: {
-      useModeration: true,
+      useModeration: false,
       usePersistence: false,
       useAnalytics: false,
+    },
+    services: {
+      chatLlmService: {
+        name: "mock-llm-service",
+        createChatCompletionStream: jest.fn(),
+        createChatCompletionObjectStream: jest.fn(),
+      } as unknown as LLMService,
+      chatCategoriser: {
+        categorise: jest.fn(),
+      },
+      oakModerator: moderator,
     },
     moderator,
     prisma: prismaMock,
@@ -101,6 +117,48 @@ describe("AilaModeration", () => {
         type: "moderation",
         categories: moderationResult.categories,
         id: undefined, // Because we are not persisting
+      });
+    });
+
+    it("passes session and assistant message identifiers to the moderator", async () => {
+      const moderationResult: ModerationResult = {
+        categories: [],
+      };
+      const moderator = new MockModerator([moderationResult]);
+      const moderateSpy = jest.spyOn(moderator, "moderate");
+
+      const messages: Message[] = [
+        { id: "user-message-1", role: "user", content: "test user message" },
+        {
+          id: "assistant-message-1",
+          role: "assistant",
+          content: "test assistant message",
+        },
+      ];
+      const chat = {
+        id: "session-1",
+        userId: "user-1",
+        messages,
+      };
+      const content = {};
+
+      const { ailaModeration, pluginContext } = setUpModeration({
+        document: {
+          content,
+        },
+        chat,
+        moderator,
+      });
+
+      await ailaModeration.moderate({
+        messages,
+        content,
+        pluginContext,
+      });
+
+      expect(moderateSpy).toHaveBeenCalledWith(JSON.stringify(content), {
+        sessionId: "session-1",
+        messageId: "assistant-message-1",
       });
     });
 

--- a/packages/aila/src/features/moderation/index.test.ts
+++ b/packages/aila/src/features/moderation/index.test.ts
@@ -43,7 +43,7 @@ const setUpModeration = ({
     document,
     chat,
     options: {
-      useModeration: false,
+      useModeration: true,
       usePersistence: false,
       useAnalytics: false,
     },

--- a/packages/aila/src/features/moderation/moderators/AilaModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/AilaModerator.ts
@@ -1,5 +1,10 @@
 import type { ModerationResult } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
 
+export type AilaModeratorContext = {
+  sessionId?: string;
+  messageId?: string;
+};
+
 export abstract class AilaModerator {
   protected _userId: string | undefined;
   protected _chatId: string | undefined;
@@ -8,7 +13,10 @@ export abstract class AilaModerator {
     this._userId = userId;
     this._chatId = chatId;
   }
-  abstract moderate(input: string): Promise<ModerationResult | undefined>;
+  abstract moderate(
+    input: string,
+    context?: AilaModeratorContext,
+  ): Promise<ModerationResult | undefined>;
 }
 
 export class AilaModerationError extends Error {

--- a/packages/aila/src/features/moderation/moderators/MockModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/MockModerator.ts
@@ -1,7 +1,11 @@
 import type { ModerationResult } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
 import { aiLogger } from "@oakai/logger";
 
-import { AilaModerationError, AilaModerator } from ".";
+import {
+  AilaModerationError,
+  AilaModerator,
+  type AilaModeratorContext,
+} from "./AilaModerator";
 
 const log = aiLogger("aila:testing");
 
@@ -13,7 +17,10 @@ export class MockModerator extends AilaModerator {
     this._mockedResults = results;
   }
 
-  async moderate(input: string, _context?: unknown): Promise<ModerationResult> {
+  async moderate(
+    input: string,
+    _context?: AilaModeratorContext,
+  ): Promise<ModerationResult> {
     const result = this._mockedResults.shift();
     log.info("Mock moderation: ", input, result);
 

--- a/packages/aila/src/features/moderation/moderators/MockModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/MockModerator.ts
@@ -13,7 +13,7 @@ export class MockModerator extends AilaModerator {
     this._mockedResults = results;
   }
 
-  async moderate(input: string): Promise<ModerationResult> {
+  async moderate(input: string, _context?: unknown): Promise<ModerationResult> {
     const result = this._mockedResults.shift();
     log.info("Mock moderation: ", input, result);
 

--- a/packages/aila/src/features/moderation/moderators/OakModerationServiceModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/OakModerationServiceModerator.ts
@@ -5,7 +5,11 @@ import {
 } from "@oakai/core/src/utils/ailaModeration/oakModerationService";
 import { aiLogger } from "@oakai/logger";
 
-import { AilaModerationError, AilaModerator } from "./AilaModerator";
+import {
+  AilaModerationError,
+  AilaModerator,
+  type AilaModeratorContext,
+} from "./AilaModerator";
 
 const log = aiLogger("aila:moderation");
 
@@ -29,7 +33,10 @@ export class OakModerationServiceModerator extends AilaModerator {
     this.config = config;
   }
 
-  async moderate(input: string): Promise<ModerationResult> {
+  async moderate(
+    input: string,
+    context?: AilaModeratorContext,
+  ): Promise<ModerationResult> {
     log.info("Calling Oak Moderation Service", {
       contentLength: input.length,
     });
@@ -39,6 +46,7 @@ export class OakModerationServiceModerator extends AilaModerator {
         baseUrl: this.config.baseUrl,
         timeoutMs: this.config.timeoutMs,
         protectionBypassSecret: this.config.protectionBypassSecret,
+        context,
       });
     } catch (err) {
       if (err instanceof OakModerationServiceError) {

--- a/packages/aila/src/features/moderation/moderators/OpenAiModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/OpenAiModerator.ts
@@ -12,15 +12,15 @@ import type {
 import zodToJsonSchema from "zod-to-json-schema";
 
 import {
-  AilaModerationError,
-  AilaModerator,
-  type AilaModeratorContext,
-} from "./AilaModerator";
-import {
   DEFAULT_MODERATION_MODEL,
   DEFAULT_MODERATION_TEMPERATURE,
 } from "../../../constants";
 import type { AilaServices } from "../../../core/AilaServices";
+import {
+  AilaModerationError,
+  AilaModerator,
+  type AilaModeratorContext,
+} from "./AilaModerator";
 
 const log = aiLogger("aila:moderation");
 

--- a/packages/aila/src/features/moderation/moderators/OpenAiModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/OpenAiModerator.ts
@@ -11,7 +11,11 @@ import type {
 } from "openai/resources/index.mjs";
 import zodToJsonSchema from "zod-to-json-schema";
 
-import { AilaModerationError, AilaModerator } from ".";
+import {
+  AilaModerationError,
+  AilaModerator,
+  type AilaModeratorContext,
+} from "./AilaModerator";
 import {
   DEFAULT_MODERATION_MODEL,
   DEFAULT_MODERATION_TEMPERATURE,
@@ -168,7 +172,10 @@ export class OpenAiModerator extends AilaModerator {
     };
   }
 
-  async moderate(input: string, _context?: unknown): Promise<ModerationResult> {
+  async moderate(
+    input: string,
+    _context?: AilaModeratorContext,
+  ): Promise<ModerationResult> {
     try {
       return await this._moderate(input, 0);
     } catch (error) {

--- a/packages/aila/src/features/moderation/moderators/OpenAiModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/OpenAiModerator.ts
@@ -168,7 +168,7 @@ export class OpenAiModerator extends AilaModerator {
     };
   }
 
-  async moderate(input: string): Promise<ModerationResult> {
+  async moderate(input: string, _context?: unknown): Promise<ModerationResult> {
     try {
       return await this._moderate(input, 0);
     } catch (error) {

--- a/packages/core/src/utils/ailaModeration/oakModerationService.test.ts
+++ b/packages/core/src/utils/ailaModeration/oakModerationService.test.ts
@@ -148,8 +148,15 @@ describe("moderateWithOakService", () => {
         },
       }),
     );
-    expect(mockPost.mock.calls[0]?.[1].body.context).not.toHaveProperty(
-      "user_id",
+    expect(mockPost).not.toHaveBeenCalledWith(
+      "/v1/moderate",
+      expect.objectContaining({
+        body: expect.objectContaining({
+          context: expect.objectContaining({
+            user_id: expect.anything(),
+          }),
+        }),
+      }),
     );
   });
 });

--- a/packages/core/src/utils/ailaModeration/oakModerationService.test.ts
+++ b/packages/core/src/utils/ailaModeration/oakModerationService.test.ts
@@ -115,4 +115,41 @@ describe("moderateWithOakService", () => {
 
     expect(mockPost).toHaveBeenCalledTimes(1);
   });
+
+  it("passes session and message identifiers without user identifiers", async () => {
+    mockPost.mockResolvedValue({
+      data: {
+        flagged_categories: [],
+        scores: {},
+        moderation_id: "mod-4",
+        prompt_version: "v1",
+      },
+      error: undefined,
+      response: { status: 200 },
+    });
+
+    await moderateWithOakService("test", {
+      ...baseConfig,
+      context: {
+        sessionId: "session-1",
+        messageId: "message-1",
+      },
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/v1/moderate",
+      expect.objectContaining({
+        body: {
+          content: "test",
+          context: {
+            session_id: "session-1",
+            message_id: "message-1",
+          },
+        },
+      }),
+    );
+    expect(mockPost.mock.calls[0]?.[1].body.context).not.toHaveProperty(
+      "user_id",
+    );
+  });
 });

--- a/packages/core/src/utils/ailaModeration/oakModerationService.ts
+++ b/packages/core/src/utils/ailaModeration/oakModerationService.ts
@@ -12,6 +12,10 @@ export interface OakModerationServiceConfig {
   baseUrl: string;
   timeoutMs?: number;
   protectionBypassSecret?: string;
+  context?: {
+    sessionId?: string;
+    messageId?: string;
+  };
 }
 
 export class OakModerationServiceError extends Error {
@@ -55,7 +59,7 @@ export async function moderateWithOakService(
 
   try {
     const { data, error, response } = await client.POST("/v1/moderate", {
-      body: { content },
+      body: createRequestBody(content, config.context),
       signal: controller.signal,
     });
 
@@ -92,4 +96,23 @@ export async function moderateWithOakService(
   } finally {
     clearTimeout(timeout);
   }
+}
+
+function createRequestBody(
+  content: string,
+  context: OakModerationServiceConfig["context"],
+) {
+  const requestContext = {
+    ...(context?.sessionId ? { session_id: context.sessionId } : {}),
+    ...(context?.messageId ? { message_id: context.messageId } : {}),
+  };
+
+  if (Object.keys(requestContext).length === 0) {
+    return { content };
+  }
+
+  return {
+    content,
+    context: requestContext,
+  };
 }


### PR DESCRIPTION
## Context

The underlying intent here is traceability across systems without introducing extra PII into the moderation service.

Aila already has its own chat/session records and message records, while the Oak Moderation Service creates its own moderation records.

The PR passes only the operational linkage identifiers the moderation service needs:

  - session_id: the Aila chat/session ID
  - message_id: the assistant message ID being moderated

It intentionally does not pass user_id, because that is PII and is not required for linking moderation records back to the Aila event/message context.

## Summary
- pass Aila chat/session and assistant message identifiers through moderation calls
- include only session_id and message_id in Oak Moderation Service context; user_id is intentionally not sent
- cover the Oak service request body and Aila moderator context propagation in tests

