### PR TITLE
fix: moderation modal padding and empty moderation modal - AI-2193

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Moderation/ContentGuidanceModalContent.tsx
+++ b/apps/nextjs/src/components/AppComponents/Moderation/ContentGuidanceModalContent.tsx
@@ -65,7 +65,10 @@ export function ContentGuidanceModal({
     <OakModalCenter
       isOpen={open}
       onClose={onClose}
-      modalInnerFlexProps={{ $ph: "spacing-80", $pb: "spacing-56" }}
+      modalInnerFlexProps={{
+        $ph: ["spacing-48", "spacing-80"],
+        $pb: ["spacing-32", "spacing-56"],
+      }}
     >
       <OakFlex
         $width="100%"

--- a/apps/nextjs/src/components/AppComponents/Moderation/ContentGuidanceModalContent.tsx
+++ b/apps/nextjs/src/components/AppComponents/Moderation/ContentGuidanceModalContent.tsx
@@ -63,6 +63,10 @@ export function ContentGuidanceModal({
 }: ContentGuidanceModalProps) {
   return (
     <OakModalCenter
+      modalFlexProps={{
+        $mt: ["spacing-72", "spacing-0"],
+        $mb: ["spacing-32", "spacing-0"],
+      }}
       isOpen={open}
       onClose={onClose}
       modalInnerFlexProps={{

--- a/apps/nextjs/src/components/AppComponents/TeachingMaterials/TeachingMaterialsModerationMessage.tsx
+++ b/apps/nextjs/src/components/AppComponents/TeachingMaterials/TeachingMaterialsModerationMessage.tsx
@@ -15,7 +15,7 @@ export function ModerationMessage({
   moderation,
   ...boxProps
 }: ModerationMessageProps) {
-  if (!moderation) {
+  if (!moderation?.categories.length) {
     return null;
   }
 


### PR DESCRIPTION
## Description

- Only show moderation banner in teaching materials when there are moderation categories.
- Add responsive padding props to moderation modals.

More info - https://oaknationalacademy.slack.com/archives/C0AENFW1FT4/p1778060081932519?thread_ts=1778059947.834909&cid=C0AENFW1FT4


## How to test

1. Go to https://oak-ai-lesson-assistant-website-6tf11e6cf.vercel.thenational.academy

Should be no moderation banner for these prompts

- 2025 German federal election quiz
- Positive representation of Muslim communities
- Mathematicians who changed the world
- KS2 water cycle/weather
- KS2 recycling/environment
- KS3 space and solar system


Mobiles match design

https://www.figma.com/design/N08ZrlKXfvFHXTOex5orUq/Moderation?node-id=824-5516&m=dev



## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
