### PR TITLE
build: release candidate

### DIFF
--- a/apps/nextjs/src/app/api/chat/chatHandler.ts
+++ b/apps/nextjs/src/app/api/chat/chatHandler.ts
@@ -196,7 +196,7 @@ function verifyChatOwnership(
   }
 }
 
-async function loadChatDataFromDatabase(
+async function loadGenerationContext(
   chatId: string,
   userId: string,
   prisma: PrismaClientWithAccelerate,
@@ -208,6 +208,7 @@ async function loadChatDataFromDatabase(
         id: true,
         userId: true,
         output: true,
+        threatDetections: { select: { messageId: true } },
       },
     });
 
@@ -225,7 +226,7 @@ async function loadChatDataFromDatabase(
 
     output.lessonPlan = output.lessonPlan ?? {};
 
-    const { messages, lessonPlan } = await migrateChatData(
+    const { messages: allMessages, lessonPlan } = await migrateChatData(
       output,
       async (upgradedData) => {
         await prisma.appSession.update({
@@ -236,9 +237,19 @@ async function loadChatDataFromDatabase(
       {
         id: chat.id,
         userId,
-        caller: "chatHandler.loadChatDataFromDatabase",
+        caller: "chatHandler.loadGenerationContext",
       },
     );
+
+    const threatenedMessageIds = new Set(
+      chat.threatDetections
+        .map((td) => td.messageId)
+        .filter((id): id is string => id !== null),
+    );
+    const messages =
+      threatenedMessageIds.size > 0
+        ? allMessages.filter((m) => !threatenedMessageIds.has(m.id))
+        : allMessages;
 
     log.info(
       `Loaded ${messages.length} messages and lesson plan for chat ${chatId}`,
@@ -248,7 +259,7 @@ async function loadChatDataFromDatabase(
     log.error(`Error loading chat data for chat ${chatId}`, error);
     captureException(error, {
       extra: { chatId, userId },
-      tags: { context: "loadChatDataFromDatabase" },
+      tags: { context: "loadGenerationContext" },
     });
     throw error;
   }
@@ -360,7 +371,7 @@ export async function handleChatPostRequest(
       span.setAttributes({ chat_id: chatId });
 
       const { messages: dbMessages, lessonPlan: dbLessonPlan } =
-        await loadChatDataFromDatabase(chatId, userId, config.prisma);
+        await loadGenerationContext(chatId, userId, config.prisma);
 
       const messages = prepareMessages(dbMessages, frontendMessages, chatId);
 

--- a/apps/nextjs/src/components/AppComponents/Moderation/ContentGuidanceModalContent.tsx
+++ b/apps/nextjs/src/components/AppComponents/Moderation/ContentGuidanceModalContent.tsx
@@ -63,9 +63,16 @@ export function ContentGuidanceModal({
 }: ContentGuidanceModalProps) {
   return (
     <OakModalCenter
+      modalFlexProps={{
+        $mt: ["spacing-72", "spacing-0"],
+        $mb: ["spacing-32", "spacing-0"],
+      }}
       isOpen={open}
       onClose={onClose}
-      modalInnerFlexProps={{ $ph: "spacing-80", $pb: "spacing-56" }}
+      modalInnerFlexProps={{
+        $ph: ["spacing-48", "spacing-80"],
+        $pb: ["spacing-32", "spacing-56"],
+      }}
     >
       <OakFlex
         $width="100%"

--- a/apps/nextjs/src/components/AppComponents/TeachingMaterials/TeachingMaterialsModerationMessage.tsx
+++ b/apps/nextjs/src/components/AppComponents/TeachingMaterials/TeachingMaterialsModerationMessage.tsx
@@ -15,7 +15,7 @@ export function ModerationMessage({
   moderation,
   ...boxProps
 }: ModerationMessageProps) {
-  if (!moderation) {
+  if (!moderation?.categories.length) {
     return null;
   }
 

--- a/packages/aila/src/features/moderation/AilaModeration.ts
+++ b/packages/aila/src/features/moderation/AilaModeration.ts
@@ -115,6 +115,7 @@ export class AilaModeration implements AilaModerationFeature {
     const moderationResult: ModerationResult = await this.performModeration({
       messages,
       content,
+      messageId: lastAssistantMessage.id,
       retries: 3,
     });
 
@@ -187,10 +188,12 @@ export class AilaModeration implements AilaModerationFeature {
   public async performModeration({
     messages,
     content,
+    messageId,
     retries = 0,
   }: {
     messages: Message[];
     content: AilaDocumentContent;
+    messageId?: string;
     retries?: number;
   }): Promise<ModerationResult> {
     log.info("Performing moderation");
@@ -203,11 +206,15 @@ export class AilaModeration implements AilaModerationFeature {
     }
 
     const contentString = JSON.stringify(content);
+    const moderationContext = {
+      sessionId: this._aila.chatId,
+      messageId,
+    };
 
     // Fire off shadow moderation call (non-blocking, errors caught)
     if (this._shadowModerator) {
       const shadowPromise = this._shadowModerator
-        .moderate(contentString)
+        .moderate(contentString, moderationContext)
         .then((result) => {
           if (result) {
             log.info("Shadow moderation result", {
@@ -230,19 +237,25 @@ export class AilaModeration implements AilaModerationFeature {
     }
 
     // Production moderation call
-    const response = await this._moderator.moderate(contentString);
+    const response = await this._moderator.moderate(
+      contentString,
+      moderationContext,
+    );
     return (
-      response ?? (await this.retryModeration({ messages, content, retries }))
+      response ??
+      (await this.retryModeration({ messages, content, messageId, retries }))
     );
   }
 
   public async retryModeration({
     messages,
     content,
+    messageId,
     retries,
   }: {
     messages: Message[];
     content: AilaDocumentContent;
+    messageId?: string;
     retries: number;
   }): Promise<ModerationResult> {
     if (retries < 1) {
@@ -260,6 +273,7 @@ export class AilaModeration implements AilaModerationFeature {
     return this.performModeration({
       messages,
       content,
+      messageId,
       retries: retries - 1,
     });
   }

--- a/packages/aila/src/features/moderation/index.test.ts
+++ b/packages/aila/src/features/moderation/index.test.ts
@@ -6,11 +6,16 @@ import type { PrismaClientWithAccelerate } from "@oakai/db";
 import { AilaModeration } from ".";
 import { Aila } from "../../core/Aila";
 import type { Message } from "../../core/chat";
+import type { LLMService } from "../../core/llm/LLMService";
 import type { AilaPlugin } from "../../core/plugins";
 import type { AilaChatInitializationOptions } from "../../core/types";
 import type { PartialLessonPlan } from "../../protocol/schema";
 import type { AilaModerator } from "./moderators";
 import { MockModerator } from "./moderators/MockModerator";
+
+jest.mock("@oakai/db", () => ({
+  prisma: {},
+}));
 
 // Ensure that no tests start relying on prisma
 const prismaMock = {} as PrismaClientWithAccelerate;
@@ -41,6 +46,17 @@ const setUpModeration = ({
       useModeration: true,
       usePersistence: false,
       useAnalytics: false,
+    },
+    services: {
+      chatLlmService: {
+        name: "mock-llm-service",
+        createChatCompletionStream: jest.fn(),
+        createChatCompletionObjectStream: jest.fn(),
+      } as unknown as LLMService,
+      chatCategoriser: {
+        categorise: jest.fn(),
+      },
+      oakModerator: moderator,
     },
     moderator,
     prisma: prismaMock,
@@ -101,6 +117,48 @@ describe("AilaModeration", () => {
         type: "moderation",
         categories: moderationResult.categories,
         id: undefined, // Because we are not persisting
+      });
+    });
+
+    it("passes session and assistant message identifiers to the moderator", async () => {
+      const moderationResult: ModerationResult = {
+        categories: [],
+      };
+      const moderator = new MockModerator([moderationResult]);
+      const moderateSpy = jest.spyOn(moderator, "moderate");
+
+      const messages: Message[] = [
+        { id: "user-message-1", role: "user", content: "test user message" },
+        {
+          id: "assistant-message-1",
+          role: "assistant",
+          content: "test assistant message",
+        },
+      ];
+      const chat = {
+        id: "session-1",
+        userId: "user-1",
+        messages,
+      };
+      const content = {};
+
+      const { ailaModeration, pluginContext } = setUpModeration({
+        document: {
+          content,
+        },
+        chat,
+        moderator,
+      });
+
+      await ailaModeration.moderate({
+        messages,
+        content,
+        pluginContext,
+      });
+
+      expect(moderateSpy).toHaveBeenCalledWith(JSON.stringify(content), {
+        sessionId: "session-1",
+        messageId: "assistant-message-1",
       });
     });
 

--- a/packages/aila/src/features/moderation/moderators/AilaModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/AilaModerator.ts
@@ -1,5 +1,10 @@
 import type { ModerationResult } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
 
+export type AilaModeratorContext = {
+  sessionId?: string;
+  messageId?: string;
+};
+
 export abstract class AilaModerator {
   protected _userId: string | undefined;
   protected _chatId: string | undefined;
@@ -8,7 +13,10 @@ export abstract class AilaModerator {
     this._userId = userId;
     this._chatId = chatId;
   }
-  abstract moderate(input: string): Promise<ModerationResult | undefined>;
+  abstract moderate(
+    input: string,
+    context?: AilaModeratorContext,
+  ): Promise<ModerationResult | undefined>;
 }
 
 export class AilaModerationError extends Error {

--- a/packages/aila/src/features/moderation/moderators/MockModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/MockModerator.ts
@@ -1,7 +1,11 @@
 import type { ModerationResult } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
 import { aiLogger } from "@oakai/logger";
 
-import { AilaModerationError, AilaModerator } from ".";
+import {
+  AilaModerationError,
+  AilaModerator,
+  type AilaModeratorContext,
+} from "./AilaModerator";
 
 const log = aiLogger("aila:testing");
 
@@ -13,7 +17,10 @@ export class MockModerator extends AilaModerator {
     this._mockedResults = results;
   }
 
-  async moderate(input: string): Promise<ModerationResult> {
+  async moderate(
+    input: string,
+    _context?: AilaModeratorContext,
+  ): Promise<ModerationResult> {
     const result = this._mockedResults.shift();
     log.info("Mock moderation: ", input, result);
 

--- a/packages/aila/src/features/moderation/moderators/OakModerationServiceModerator.test.ts
+++ b/packages/aila/src/features/moderation/moderators/OakModerationServiceModerator.test.ts
@@ -1,0 +1,39 @@
+import type { ModerationResult } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
+import { moderateWithOakService } from "@oakai/core/src/utils/ailaModeration/oakModerationService";
+
+import { OakModerationServiceModerator } from "./OakModerationServiceModerator";
+
+jest.mock("@oakai/core/src/utils/ailaModeration/oakModerationService", () => ({
+  OakModerationServiceError: class OakModerationServiceError extends Error {},
+  moderateWithOakService: jest.fn(),
+}));
+
+jest.mock("@oakai/logger", () => ({
+  aiLogger: () => ({ info: jest.fn(), warn: jest.fn(), error: jest.fn() }),
+}));
+
+const mockedModerateWithOakService = jest.mocked(moderateWithOakService);
+
+describe("OakModerationServiceModerator", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("retries once when the Oak Moderation Service call fails", async () => {
+    const result: ModerationResult = {
+      categories: [],
+    };
+    mockedModerateWithOakService
+      .mockRejectedValueOnce(new Error("temporary failure"))
+      .mockResolvedValueOnce(result);
+
+    const moderator = new OakModerationServiceModerator({
+      baseUrl: "https://moderation.test",
+      chatId: "chat-1",
+      userId: "user-1",
+    });
+
+    await expect(moderator.moderate("content")).resolves.toBe(result);
+    expect(mockedModerateWithOakService).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/aila/src/features/moderation/moderators/OakModerationServiceModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/OakModerationServiceModerator.ts
@@ -5,7 +5,11 @@ import {
 } from "@oakai/core/src/utils/ailaModeration/oakModerationService";
 import { aiLogger } from "@oakai/logger";
 
-import { AilaModerationError, AilaModerator } from "./AilaModerator";
+import {
+  AilaModerationError,
+  AilaModerator,
+  type AilaModeratorContext,
+} from "./AilaModerator";
 
 const log = aiLogger("aila:moderation");
 
@@ -29,7 +33,10 @@ export class OakModerationServiceModerator extends AilaModerator {
     this.config = config;
   }
 
-  async moderate(input: string): Promise<ModerationResult> {
+  async moderate(
+    input: string,
+    context?: AilaModeratorContext,
+  ): Promise<ModerationResult> {
     log.info("Calling Oak Moderation Service", {
       contentLength: input.length,
     });
@@ -39,6 +46,7 @@ export class OakModerationServiceModerator extends AilaModerator {
         baseUrl: this.config.baseUrl,
         timeoutMs: this.config.timeoutMs,
         protectionBypassSecret: this.config.protectionBypassSecret,
+        context,
       });
     } catch (err) {
       if (err instanceof OakModerationServiceError) {

--- a/packages/aila/src/features/moderation/moderators/OakModerationServiceModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/OakModerationServiceModerator.ts
@@ -33,14 +33,10 @@ export class OakModerationServiceModerator extends AilaModerator {
     this.config = config;
   }
 
-  async moderate(
+  private async _moderate(
     input: string,
     context?: AilaModeratorContext,
   ): Promise<ModerationResult> {
-    log.info("Calling Oak Moderation Service", {
-      contentLength: input.length,
-    });
-
     try {
       return await moderateWithOakService(input, {
         baseUrl: this.config.baseUrl,
@@ -55,6 +51,23 @@ export class OakModerationServiceModerator extends AilaModerator {
       throw new AilaModerationError("Oak Moderation Service failed", {
         cause: err,
       });
+    }
+  }
+
+  async moderate(
+    input: string,
+    context?: AilaModeratorContext,
+  ): Promise<ModerationResult> {
+    log.info("Calling Oak Moderation Service", {
+      contentLength: input.length,
+    });
+
+    try {
+      return await this._moderate(input, context);
+    } catch (error) {
+      log.error("Oak Moderation Service moderation error: ", error);
+      log.warn("Retrying Oak Moderation Service call");
+      return await this._moderate(input, context);
     }
   }
 }

--- a/packages/aila/src/features/moderation/moderators/OpenAiModerator.ts
+++ b/packages/aila/src/features/moderation/moderators/OpenAiModerator.ts
@@ -11,12 +11,16 @@ import type {
 } from "openai/resources/index.mjs";
 import zodToJsonSchema from "zod-to-json-schema";
 
-import { AilaModerationError, AilaModerator } from ".";
 import {
   DEFAULT_MODERATION_MODEL,
   DEFAULT_MODERATION_TEMPERATURE,
 } from "../../../constants";
 import type { AilaServices } from "../../../core/AilaServices";
+import {
+  AilaModerationError,
+  AilaModerator,
+  type AilaModeratorContext,
+} from "./AilaModerator";
 
 const log = aiLogger("aila:moderation");
 
@@ -168,7 +172,10 @@ export class OpenAiModerator extends AilaModerator {
     };
   }
 
-  async moderate(input: string): Promise<ModerationResult> {
+  async moderate(
+    input: string,
+    _context?: AilaModeratorContext,
+  ): Promise<ModerationResult> {
     try {
       return await this._moderate(input, 0);
     } catch (error) {

--- a/packages/aila/src/lib/agentic-system/agents/plannerAgent/__snapshots__/createPlannerAgent.test.ts.snap
+++ b/packages/aila/src/lib/agentic-system/agents/plannerAgent/__snapshots__/createPlannerAgent.test.ts.snap
@@ -41,14 +41,28 @@ You must respond with **exactly one of two decision types**:
 1. \`title\`, \`keyStage\`, \`subject\`
 2. \`basedOn\` (optional), \`learningOutcome\`, \`learningCycles\`  
 3. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
-4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (optional), \`exitQuiz\`  
+4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group** — never include sections from more than one group in a single plan, unless the user has explicitly named specific sections from different groups. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+
+All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
+
+**Exception — explicit cross-group plans**: you may include sections from more than one group only if one of the following applies:
+1. The user's message explicitly names sections from different groups (e.g. "rewrite the \`keywords\` and make \`cycle2\` harder").
+2. The user explicitly asks to complete or generate the whole remaining lesson (e.g. "do everything", "complete the lesson", "fill in the rest"). In this case, plan all remaining incomplete sections.
+
+
+If none of these apply — including the default case where the user clicks "continue" or sends a vague positive intent — plan **only the next incomplete group**.
+
+#### cycle3
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 2 entries, do not include \`cycle3\`.
+
+
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
-- You should only include \`basedOn\` in the 'plan' if the user has provided a clear and specific reference lesson to base it on when shown a list of relevant lessons. It should be clear from the Message History and User Message.
+- **NEVER include \`basedOn\` in the plan** unless ALL of the following are true: (1) the RELEVANT LESSONS section above lists at least one lesson title, AND (2) the user has explicitly selected or referenced one of those specific lessons in the Message History or User Message. If the RELEVANT LESSONS section says none were found or is empty, you must not include \`basedOn\`.
 
 ---
 
@@ -81,20 +95,21 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**: 
-   - User asks to complete the full lesson
-   - Plan all remaining incomplete sections in logical order
+3. **Complete lesson request** (cross-group):
+   - User explicitly asks to complete or generate the whole lesson in one go (e.g. "do everything", "finish the lesson", "fill in the rest").
+   - Plan all remaining incomplete sections in logical order.
+   - This is the only "plan" case where multiple groups are included without the user naming specific sections.
 
-4. **Default progression**: 
-   - User provides general positive intent or wants to continue
-   - Plan the next logical incomplete sections
+4. **Default progression** (single group):
+   - User clicks "continue", or provides general positive intent without naming specific sections (e.g. "next", "ok", "go on", "looks good").
+   - Plan **only the next incomplete group**, following the SECTION GROUPS order.
 
 ---
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, finish the next incomplete section group
-- **Only include 'basedOn' in the plan** if user has been shown a list of relevant lessons to choose from. If so, it will be abundantly clear from the MESSAGE HISTORY and USER MESSAGE sections.
+- **Process sections in their section groups**: Plan all sections of the next incomplete group together in a single plan — never split a group across turns, and never include sections from two or more groups unless the user has explicitly named sections from both.
+- **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
 ### 🔹 SECTION INSTRUCTIONS
@@ -226,14 +241,28 @@ You must respond with **exactly one of two decision types**:
 1. \`title\`, \`keyStage\`, \`subject\`
 2. \`basedOn\` (optional), \`learningOutcome\`, \`learningCycles\`  
 3. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
-4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (optional), \`exitQuiz\`  
+4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group** — never include sections from more than one group in a single plan, unless the user has explicitly named specific sections from different groups. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+
+All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
+
+**Exception — explicit cross-group plans**: you may include sections from more than one group only if one of the following applies:
+1. The user's message explicitly names sections from different groups (e.g. "rewrite the \`keywords\` and make \`cycle2\` harder").
+2. The user explicitly asks to complete or generate the whole remaining lesson (e.g. "do everything", "complete the lesson", "fill in the rest"). In this case, plan all remaining incomplete sections.
+
+
+If none of these apply — including the default case where the user clicks "continue" or sends a vague positive intent — plan **only the next incomplete group**.
+
+#### cycle3
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 2 entries, do not include \`cycle3\`.
+
+
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
-- You should only include \`basedOn\` in the 'plan' if the user has provided a clear and specific reference lesson to base it on when shown a list of relevant lessons. It should be clear from the Message History and User Message.
+- **NEVER include \`basedOn\` in the plan** unless ALL of the following are true: (1) the RELEVANT LESSONS section above lists at least one lesson title, AND (2) the user has explicitly selected or referenced one of those specific lessons in the Message History or User Message. If the RELEVANT LESSONS section says none were found or is empty, you must not include \`basedOn\`.
 
 ---
 
@@ -266,20 +295,21 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**: 
-   - User asks to complete the full lesson
-   - Plan all remaining incomplete sections in logical order
+3. **Complete lesson request** (cross-group):
+   - User explicitly asks to complete or generate the whole lesson in one go (e.g. "do everything", "finish the lesson", "fill in the rest").
+   - Plan all remaining incomplete sections in logical order.
+   - This is the only "plan" case where multiple groups are included without the user naming specific sections.
 
-4. **Default progression**: 
-   - User provides general positive intent or wants to continue
-   - Plan the next logical incomplete sections
+4. **Default progression** (single group):
+   - User clicks "continue", or provides general positive intent without naming specific sections (e.g. "next", "ok", "go on", "looks good").
+   - Plan **only the next incomplete group**, following the SECTION GROUPS order.
 
 ---
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, finish the next incomplete section group
-- **Only include 'basedOn' in the plan** if user has been shown a list of relevant lessons to choose from. If so, it will be abundantly clear from the MESSAGE HISTORY and USER MESSAGE sections.
+- **Process sections in their section groups**: Plan all sections of the next incomplete group together in a single plan — never split a group across turns, and never include sections from two or more groups unless the user has explicitly named sections from both.
+- **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
 ### 🔹 SECTION INSTRUCTIONS
@@ -402,14 +432,28 @@ You must respond with **exactly one of two decision types**:
 1. \`title\`, \`keyStage\`, \`subject\`
 2. \`basedOn\` (optional), \`learningOutcome\`, \`learningCycles\`  
 3. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
-4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (optional), \`exitQuiz\`  
+4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group** — never include sections from more than one group in a single plan, unless the user has explicitly named specific sections from different groups. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+
+All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
+
+**Exception — explicit cross-group plans**: you may include sections from more than one group only if one of the following applies:
+1. The user's message explicitly names sections from different groups (e.g. "rewrite the \`keywords\` and make \`cycle2\` harder").
+2. The user explicitly asks to complete or generate the whole remaining lesson (e.g. "do everything", "complete the lesson", "fill in the rest"). In this case, plan all remaining incomplete sections.
+
+
+If none of these apply — including the default case where the user clicks "continue" or sends a vague positive intent — plan **only the next incomplete group**.
+
+#### cycle3
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 2 entries, do not include \`cycle3\`.
+
+
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
-- You should only include \`basedOn\` in the 'plan' if the user has provided a clear and specific reference lesson to base it on when shown a list of relevant lessons. It should be clear from the Message History and User Message.
+- **NEVER include \`basedOn\` in the plan** unless ALL of the following are true: (1) the RELEVANT LESSONS section above lists at least one lesson title, AND (2) the user has explicitly selected or referenced one of those specific lessons in the Message History or User Message. If the RELEVANT LESSONS section says none were found or is empty, you must not include \`basedOn\`.
 
 ---
 
@@ -442,20 +486,21 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**: 
-   - User asks to complete the full lesson
-   - Plan all remaining incomplete sections in logical order
+3. **Complete lesson request** (cross-group):
+   - User explicitly asks to complete or generate the whole lesson in one go (e.g. "do everything", "finish the lesson", "fill in the rest").
+   - Plan all remaining incomplete sections in logical order.
+   - This is the only "plan" case where multiple groups are included without the user naming specific sections.
 
-4. **Default progression**: 
-   - User provides general positive intent or wants to continue
-   - Plan the next logical incomplete sections
+4. **Default progression** (single group):
+   - User clicks "continue", or provides general positive intent without naming specific sections (e.g. "next", "ok", "go on", "looks good").
+   - Plan **only the next incomplete group**, following the SECTION GROUPS order.
 
 ---
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, finish the next incomplete section group
-- **Only include 'basedOn' in the plan** if user has been shown a list of relevant lessons to choose from. If so, it will be abundantly clear from the MESSAGE HISTORY and USER MESSAGE sections.
+- **Process sections in their section groups**: Plan all sections of the next incomplete group together in a single plan — never split a group across turns, and never include sections from two or more groups unless the user has explicitly named sections from both.
+- **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
 ### 🔹 SECTION INSTRUCTIONS
@@ -587,14 +632,28 @@ You must respond with **exactly one of two decision types**:
 1. \`title\`, \`keyStage\`, \`subject\`
 2. \`basedOn\` (optional), \`learningOutcome\`, \`learningCycles\`  
 3. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
-4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (optional), \`exitQuiz\`  
+4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group** — never include sections from more than one group in a single plan, unless the user has explicitly named specific sections from different groups. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+
+All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
+
+**Exception — explicit cross-group plans**: you may include sections from more than one group only if one of the following applies:
+1. The user's message explicitly names sections from different groups (e.g. "rewrite the \`keywords\` and make \`cycle2\` harder").
+2. The user explicitly asks to complete or generate the whole remaining lesson (e.g. "do everything", "complete the lesson", "fill in the rest"). In this case, plan all remaining incomplete sections.
+
+
+If none of these apply — including the default case where the user clicks "continue" or sends a vague positive intent — plan **only the next incomplete group**.
+
+#### cycle3
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 2 entries, do not include \`cycle3\`.
+
+
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
-- You should only include \`basedOn\` in the 'plan' if the user has provided a clear and specific reference lesson to base it on when shown a list of relevant lessons. It should be clear from the Message History and User Message.
+- **NEVER include \`basedOn\` in the plan** unless ALL of the following are true: (1) the RELEVANT LESSONS section above lists at least one lesson title, AND (2) the user has explicitly selected or referenced one of those specific lessons in the Message History or User Message. If the RELEVANT LESSONS section says none were found or is empty, you must not include \`basedOn\`.
 
 ---
 
@@ -627,20 +686,21 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**: 
-   - User asks to complete the full lesson
-   - Plan all remaining incomplete sections in logical order
+3. **Complete lesson request** (cross-group):
+   - User explicitly asks to complete or generate the whole lesson in one go (e.g. "do everything", "finish the lesson", "fill in the rest").
+   - Plan all remaining incomplete sections in logical order.
+   - This is the only "plan" case where multiple groups are included without the user naming specific sections.
 
-4. **Default progression**: 
-   - User provides general positive intent or wants to continue
-   - Plan the next logical incomplete sections
+4. **Default progression** (single group):
+   - User clicks "continue", or provides general positive intent without naming specific sections (e.g. "next", "ok", "go on", "looks good").
+   - Plan **only the next incomplete group**, following the SECTION GROUPS order.
 
 ---
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, finish the next incomplete section group
-- **Only include 'basedOn' in the plan** if user has been shown a list of relevant lessons to choose from. If so, it will be abundantly clear from the MESSAGE HISTORY and USER MESSAGE sections.
+- **Process sections in their section groups**: Plan all sections of the next incomplete group together in a single plan — never split a group across turns, and never include sections from two or more groups unless the user has explicitly named sections from both.
+- **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
 ### 🔹 SECTION INSTRUCTIONS
@@ -761,14 +821,28 @@ You must respond with **exactly one of two decision types**:
 1. \`title\`, \`keyStage\`, \`subject\`
 2. \`basedOn\` (optional), \`learningOutcome\`, \`learningCycles\`  
 3. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
-4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (optional), \`exitQuiz\`  
+4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group** — never include sections from more than one group in a single plan, unless the user has explicitly named specific sections from different groups. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+
+All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
+
+**Exception — explicit cross-group plans**: you may include sections from more than one group only if one of the following applies:
+1. The user's message explicitly names sections from different groups (e.g. "rewrite the \`keywords\` and make \`cycle2\` harder").
+2. The user explicitly asks to complete or generate the whole remaining lesson (e.g. "do everything", "complete the lesson", "fill in the rest"). In this case, plan all remaining incomplete sections.
+
+
+If none of these apply — including the default case where the user clicks "continue" or sends a vague positive intent — plan **only the next incomplete group**.
+
+#### cycle3
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 2 entries, do not include \`cycle3\`.
+
+
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
-- You should only include \`basedOn\` in the 'plan' if the user has provided a clear and specific reference lesson to base it on when shown a list of relevant lessons. It should be clear from the Message History and User Message.
+- **NEVER include \`basedOn\` in the plan** unless ALL of the following are true: (1) the RELEVANT LESSONS section above lists at least one lesson title, AND (2) the user has explicitly selected or referenced one of those specific lessons in the Message History or User Message. If the RELEVANT LESSONS section says none were found or is empty, you must not include \`basedOn\`.
 
 ---
 
@@ -801,20 +875,21 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**: 
-   - User asks to complete the full lesson
-   - Plan all remaining incomplete sections in logical order
+3. **Complete lesson request** (cross-group):
+   - User explicitly asks to complete or generate the whole lesson in one go (e.g. "do everything", "finish the lesson", "fill in the rest").
+   - Plan all remaining incomplete sections in logical order.
+   - This is the only "plan" case where multiple groups are included without the user naming specific sections.
 
-4. **Default progression**: 
-   - User provides general positive intent or wants to continue
-   - Plan the next logical incomplete sections
+4. **Default progression** (single group):
+   - User clicks "continue", or provides general positive intent without naming specific sections (e.g. "next", "ok", "go on", "looks good").
+   - Plan **only the next incomplete group**, following the SECTION GROUPS order.
 
 ---
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, finish the next incomplete section group
-- **Only include 'basedOn' in the plan** if user has been shown a list of relevant lessons to choose from. If so, it will be abundantly clear from the MESSAGE HISTORY and USER MESSAGE sections.
+- **Process sections in their section groups**: Plan all sections of the next incomplete group together in a single plan — never split a group across turns, and never include sections from two or more groups unless the user has explicitly named sections from both.
+- **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
 ### 🔹 SECTION INSTRUCTIONS
@@ -946,14 +1021,28 @@ You must respond with **exactly one of two decision types**:
 1. \`title\`, \`keyStage\`, \`subject\`
 2. \`basedOn\` (optional), \`learningOutcome\`, \`learningCycles\`  
 3. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
-4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (optional), \`exitQuiz\`  
+4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group** — never include sections from more than one group in a single plan, unless the user has explicitly named specific sections from different groups. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+
+All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
+
+**Exception — explicit cross-group plans**: you may include sections from more than one group only if one of the following applies:
+1. The user's message explicitly names sections from different groups (e.g. "rewrite the \`keywords\` and make \`cycle2\` harder").
+2. The user explicitly asks to complete or generate the whole remaining lesson (e.g. "do everything", "complete the lesson", "fill in the rest"). In this case, plan all remaining incomplete sections.
+
+
+If none of these apply — including the default case where the user clicks "continue" or sends a vague positive intent — plan **only the next incomplete group**.
+
+#### cycle3
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 2 entries, do not include \`cycle3\`.
+
+
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
-- You should only include \`basedOn\` in the 'plan' if the user has provided a clear and specific reference lesson to base it on when shown a list of relevant lessons. It should be clear from the Message History and User Message.
+- **NEVER include \`basedOn\` in the plan** unless ALL of the following are true: (1) the RELEVANT LESSONS section above lists at least one lesson title, AND (2) the user has explicitly selected or referenced one of those specific lessons in the Message History or User Message. If the RELEVANT LESSONS section says none were found or is empty, you must not include \`basedOn\`.
 
 ---
 
@@ -986,20 +1075,21 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**: 
-   - User asks to complete the full lesson
-   - Plan all remaining incomplete sections in logical order
+3. **Complete lesson request** (cross-group):
+   - User explicitly asks to complete or generate the whole lesson in one go (e.g. "do everything", "finish the lesson", "fill in the rest").
+   - Plan all remaining incomplete sections in logical order.
+   - This is the only "plan" case where multiple groups are included without the user naming specific sections.
 
-4. **Default progression**: 
-   - User provides general positive intent or wants to continue
-   - Plan the next logical incomplete sections
+4. **Default progression** (single group):
+   - User clicks "continue", or provides general positive intent without naming specific sections (e.g. "next", "ok", "go on", "looks good").
+   - Plan **only the next incomplete group**, following the SECTION GROUPS order.
 
 ---
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, finish the next incomplete section group
-- **Only include 'basedOn' in the plan** if user has been shown a list of relevant lessons to choose from. If so, it will be abundantly clear from the MESSAGE HISTORY and USER MESSAGE sections.
+- **Process sections in their section groups**: Plan all sections of the next incomplete group together in a single plan — never split a group across turns, and never include sections from two or more groups unless the user has explicitly named sections from both.
+- **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
 ### 🔹 SECTION INSTRUCTIONS

--- a/packages/aila/src/lib/agentic-system/agents/plannerAgent/plannerAgent.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/plannerAgent/plannerAgent.instructions.ts
@@ -36,14 +36,28 @@ You must respond with **exactly one of two decision types**:
 1. \`title\`, \`keyStage\`, \`subject\`
 2. \`basedOn\` (optional), \`learningOutcome\`, \`learningCycles\`  
 3. \`priorKnowledge\`, \`keyLearningPoints\`, \`misconceptions\`, \`keywords\`  
-4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (optional), \`exitQuiz\`  
+4. \`starterQuiz\`, \`cycle1\`, \`cycle2\`, \`cycle3\` (conditional on \`learningCycles\`), \`exitQuiz\`
 5. \`additionalMaterials\` (optional)
 
-Only plan for sections in the **next incomplete group**, unless told otherwise. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+A group is **incomplete** if any of its mandatory (non-optional) sections are missing from the current lesson plan. Only plan for sections in the **next incomplete group** — never include sections from more than one group in a single plan, unless the user has explicitly named specific sections from different groups. So if a title exists, but not a key stage or subject, you would plan for the key stage and subject sections.
+
+All sections of a group must be included in a **single plan** for that turn — never split a group's sections across multiple turns.
+
+**Exception — explicit cross-group plans**: you may include sections from more than one group only if one of the following applies:
+1. The user's message explicitly names sections from different groups (e.g. "rewrite the \`keywords\` and make \`cycle2\` harder").
+2. The user explicitly asks to complete or generate the whole remaining lesson (e.g. "do everything", "complete the lesson", "fill in the rest"). In this case, plan all remaining incomplete sections.
+
+
+If none of these apply — including the default case where the user clicks "continue" or sends a vague positive intent — plan **only the next incomplete group**.
+
+#### cycle3
+Include \`cycle3\` in the plan **if and only if** the \`learningCycles\` field contains exactly 3 entries. If \`learningCycles\` has 2 entries, do not include \`cycle3\`.
+
+
 
 #### basedOn
 - \`basedOn\` is the outlier here. Once you go past this point, you shouldn't go back unless the user explicitly asks you to. So if learningOutcome and learningCycles are set, you would not go back to basedOn unless the user asks you to.
-- You should only include \`basedOn\` in the 'plan' if the user has provided a clear and specific reference lesson to base it on when shown a list of relevant lessons. It should be clear from the Message History and User Message.
+- **NEVER include \`basedOn\` in the plan** unless ALL of the following are true: (1) the RELEVANT LESSONS section above lists at least one lesson title, AND (2) the user has explicitly selected or referenced one of those specific lessons in the Message History or User Message. If the RELEVANT LESSONS section says none were found or is empty, you must not include \`basedOn\`.
 
 ---
 
@@ -76,20 +90,21 @@ Only plan for sections in the **next incomplete group**, unless told otherwise. 
    - User wants to delete a specific section
    - Use \`delete\` action for that section
 
-3. **Complete lesson request**: 
-   - User asks to complete the full lesson
-   - Plan all remaining incomplete sections in logical order
+3. **Complete lesson request** (cross-group):
+   - User explicitly asks to complete or generate the whole lesson in one go (e.g. "do everything", "finish the lesson", "fill in the rest").
+   - Plan all remaining incomplete sections in logical order.
+   - This is the only "plan" case where multiple groups are included without the user naming specific sections.
 
-4. **Default progression**: 
-   - User provides general positive intent or wants to continue
-   - Plan the next logical incomplete sections
+4. **Default progression** (single group):
+   - User clicks "continue", or provides general positive intent without naming specific sections (e.g. "next", "ok", "go on", "looks good").
+   - Plan **only the next incomplete group**, following the SECTION GROUPS order.
 
 ---
 
 ### 🔹 PLANNING GUIDELINES
 
-- **Process sections in their section groups**: Unless the user specifies otherwise, finish the next incomplete section group
-- **Only include 'basedOn' in the plan** if user has been shown a list of relevant lessons to choose from. If so, it will be abundantly clear from the MESSAGE HISTORY and USER MESSAGE sections.
+- **Process sections in their section groups**: Plan all sections of the next incomplete group together in a single plan — never split a group across turns, and never include sections from two or more groups unless the user has explicitly named sections from both.
+- **Never include 'basedOn' in the plan** unless RELEVANT LESSONS lists at least one lesson AND the user has explicitly selected one. An empty or absent RELEVANT LESSONS section means basedOn must be omitted.
 - **User intent**: Respect explicit user directions about specific sections
 
 ### 🔹 SECTION INSTRUCTIONS

--- a/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
@@ -106,15 +106,21 @@ const SCORERS: Scorer[] = [
         }
         const actual = po.plan.map((s) => s.sectionKey);
         const expected = EXPECTED_GROUPS[i];
+        // cycle3 is optional in the actual output — strip it from expected
+        // only when both sides agree it's absent.
+        const expectedAdjusted =
+          expected && !actual.includes("cycle3")
+            ? expected.filter((s) => s !== "cycle3")
+            : expected;
         const match =
-          expected &&
-          actual.length === expected.length &&
-          actual.every((k, j) => k === expected[j]);
+          expectedAdjusted &&
+          actual.length === expectedAdjusted.length &&
+          actual.every((k, j) => k === expectedAdjusted[j]);
         const icon = match ? "✓" : "✗";
         if (!match) anyMismatch = true;
         lines.push(`Turn ${i + 1}: ${icon} [${actual.join(", ")}]`);
-        if (!match && expected) {
-          lines.push(`  expected: [${expected.join(", ")}]`);
+        if (!match && expectedAdjusted) {
+          lines.push(`  expected: [${expectedAdjusted.join(", ")}]`);
         }
       }
       lines.push(`Total: ${turnCount} turns`);
@@ -343,9 +349,19 @@ async function runOnce(scenario: ScenarioConfig): Promise<RunCapture> {
       const callbacks: AilaTurnCallbacks = {
         onPlannerComplete: ({ sectionKeys }) => {
           turnPlannerSections = sectionKeys;
+          if (sectionKeys.length > 0) {
+            console.log(
+              `    [turn ${turnCount + 1}] planner → [${sectionKeys.join(", ")}]`,
+            );
+          } else {
+            console.log(`    [turn ${turnCount + 1}] planner → exit`);
+          }
         },
         onSectionComplete: (patches) => {
           turnPatches.push(...patches);
+          for (const p of patches) {
+            console.log(`    [turn ${turnCount + 1}] section done → ${p.path}`);
+          }
         },
         onTurnComplete: ({ document, ailaMessage }) => {
           turnDoc = document;

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,14 +1,12 @@
-codeHash: 1f4e1d2bbcc9baf26dee99550828b73422989b1a59dec54f0561bd460b7acc22
-generated: 2026-04-22T15:07:48.958Z
+codeHash: c829f5eeca94117fa2b0ebec8a7799c27c55158d70492520234f317533b0a7ff
+generated: 2026-04-30T13:37:43.991Z
 runsPerScenario: 3
 summary:
   full-lesson:
     plan-groupings:
-      flag: 2
-      pass: 1
+      pass: 3
     additional-materials-tone:
-      pass: 2
-      skip: 1
+      skip: 3
     cycle-verbosity:
       pass: 3
     keyword-casing:
@@ -19,8 +17,7 @@ summary:
       pass: 3
   no-rag-lesson:
     plan-groupings:
-      pass: 1
-      flag: 2
+      pass: 3
     additional-materials-tone:
       skip: 3
     cycle-verbosity:

--- a/packages/core/src/utils/ailaModeration/oakModerationService.test.ts
+++ b/packages/core/src/utils/ailaModeration/oakModerationService.test.ts
@@ -115,4 +115,48 @@ describe("moderateWithOakService", () => {
 
     expect(mockPost).toHaveBeenCalledTimes(1);
   });
+
+  it("passes session and message identifiers without user identifiers", async () => {
+    mockPost.mockResolvedValue({
+      data: {
+        flagged_categories: [],
+        scores: {},
+        moderation_id: "mod-4",
+        prompt_version: "v1",
+      },
+      error: undefined,
+      response: { status: 200 },
+    });
+
+    await moderateWithOakService("test", {
+      ...baseConfig,
+      context: {
+        sessionId: "session-1",
+        messageId: "message-1",
+      },
+    });
+
+    expect(mockPost).toHaveBeenCalledWith(
+      "/v1/moderate",
+      expect.objectContaining({
+        body: {
+          content: "test",
+          context: {
+            session_id: "session-1",
+            message_id: "message-1",
+          },
+        },
+      }),
+    );
+    expect(mockPost).not.toHaveBeenCalledWith(
+      "/v1/moderate",
+      expect.objectContaining({
+        body: expect.objectContaining({
+          context: expect.objectContaining({
+            user_id: expect.anything(),
+          }),
+        }),
+      }),
+    );
+  });
 });

--- a/packages/core/src/utils/ailaModeration/oakModerationService.ts
+++ b/packages/core/src/utils/ailaModeration/oakModerationService.ts
@@ -12,6 +12,10 @@ export interface OakModerationServiceConfig {
   baseUrl: string;
   timeoutMs?: number;
   protectionBypassSecret?: string;
+  context?: {
+    sessionId?: string;
+    messageId?: string;
+  };
 }
 
 export class OakModerationServiceError extends Error {
@@ -55,7 +59,7 @@ export async function moderateWithOakService(
 
   try {
     const { data, error, response } = await client.POST("/v1/moderate", {
-      body: { content },
+      body: createRequestBody(content, config.context),
       signal: controller.signal,
     });
 
@@ -92,4 +96,23 @@ export async function moderateWithOakService(
   } finally {
     clearTimeout(timeout);
   }
+}
+
+function createRequestBody(
+  content: string,
+  context: OakModerationServiceConfig["context"],
+) {
+  const requestContext = {
+    ...(context?.sessionId ? { session_id: context.sessionId } : {}),
+    ...(context?.messageId ? { message_id: context.messageId } : {}),
+  };
+
+  if (Object.keys(requestContext).length === 0) {
+    return { content };
+  }
+
+  return {
+    content,
+    context: requestContext,
+  };
 }


### PR DESCRIPTION
## Description
### Features
- **Keep lesson order consistent in planning prompts**: Ensures lessons are presented in a consistent order when generated. [#1033](https://github.com/oaknational/oak-ai-lesson-assistant/pull/1033)

### Fixes
- **Improve moderation modal layout**: Fixes padding issues and prevents an empty moderation modal state. [#1038](https://github.com/oaknational/oak-ai-lesson-assistant/pull/1038)
- **Exclude threat-detected messages from LLM context**: Prevents messages flagged as threats from being included in the LLM generation context. [#1037](https://github.com/oaknational/oak-ai-lesson-assistant/pull/1037)
- **Pass Aila moderation identifiers to Oak service**: Sends the required moderation identifiers through to the Oak moderation service. [#1036](https://github.com/oaknational/oak-ai-lesson-assistant/pull/1036)
- **Retry Oak Moderation Service once**: Adds a single retry for Oak Moderation Service requests to improve resilience. [#1035](https://github.com/oaknational/oak-ai-lesson-assistant/pull/1035)