### PR TITLE
fix: [AI-2146] improve diagnostics and resilience for AI provider, threat detection and Clerk errors

### DIFF
--- a/apps/nextjs/src/app/api/chat/errorHandling.test.ts
+++ b/apps/nextjs/src/app/api/chat/errorHandling.test.ts
@@ -6,6 +6,8 @@ import type { TracingSpan } from "@oakai/core/src/tracing";
 import { RateLimitExceededError } from "@oakai/core/src/utils/rateLimiting/errors";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 
+import * as Sentry from "@sentry/node";
+import { APICallError } from "ai";
 import invariant from "tiny-invariant";
 
 import {
@@ -21,6 +23,11 @@ jest.mock(
     handleThreatDetectionError: jest.fn(),
   }),
 );
+
+jest.mock("@sentry/node", () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
 
 describe("handleChatException", () => {
   describe("AilaThreatDetectionError", () => {
@@ -125,6 +132,52 @@ describe("handleChatException", () => {
         message: "An unexpected error occurred",
         value: "Sorry, an unexpected error occurred. Please try again later.",
       });
+    });
+  });
+
+  describe("upstream AI provider error", () => {
+    it("should return a temporary AI service message and capture a warning", async () => {
+      const providerError = new APICallError({
+        message:
+          "500 The server had an error while processing your request. Sorry about that!",
+        url: "https://oai.eu.hconeai.com/v1/chat/completions",
+        requestBodyValues: {},
+        statusCode: 500,
+      });
+      const error = new Error("Unexpected error in chat route", {
+        cause: providerError,
+      });
+      const prisma = {} as unknown as PrismaClientWithAccelerate;
+
+      const response = await handleChatException(error, "test-chat-id", prisma);
+
+      expect(response.status).toBe(200);
+
+      invariant(
+        response.body instanceof ReadableStream,
+        "Expected response.body to be a ReadableStream",
+      );
+
+      const consumed = await consumeStream(response.body);
+      const message = extractStreamMessage(consumed);
+
+      expect(message).toEqual({
+        type: "error",
+        message: "The AI service is temporarily unavailable",
+        value:
+          "The AI service is temporarily unavailable. Please try again shortly.",
+      });
+      expect(Sentry.captureMessage).toHaveBeenCalledWith(
+        "Upstream AI provider error",
+        expect.objectContaining({
+          level: "warning",
+          extra: expect.objectContaining({
+            statusCode: 500,
+            url: "https://oai.eu.hconeai.com/v1/chat/completions",
+          }),
+        }),
+      );
+      expect(Sentry.captureException).not.toHaveBeenCalled();
     });
   });
 

--- a/apps/nextjs/src/app/api/chat/errorHandling.ts
+++ b/apps/nextjs/src/app/api/chat/errorHandling.ts
@@ -11,6 +11,8 @@ import type { PrismaClientWithAccelerate } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
 
 import * as Sentry from "@sentry/node";
+import { APICallError } from "ai";
+import { APIError } from "openai";
 
 import { streamingJSON } from "./protocol";
 
@@ -71,6 +73,69 @@ async function handleGenericError(e: Error): Promise<Response> {
   );
 }
 
+type UpstreamAIProviderError = {
+  statusCode: number;
+  requestId?: string | null;
+  url?: string;
+};
+
+function getUpstreamAIProviderError(
+  error: unknown,
+): UpstreamAIProviderError | null {
+  let current: unknown = error;
+
+  while (current) {
+    if (
+      APICallError.isInstance(current) &&
+      current.statusCode !== undefined &&
+      current.statusCode >= 500
+    ) {
+      return {
+        statusCode: current.statusCode,
+        url: current.url,
+      };
+    }
+
+    if (
+      current instanceof APIError &&
+      current.status !== undefined &&
+      current.status >= 500
+    ) {
+      return {
+        statusCode: current.status,
+        requestId: current.request_id,
+      };
+    }
+
+    current =
+      current instanceof Error && "cause" in current ? current.cause : null;
+  }
+
+  return null;
+}
+
+async function handleUpstreamAIProviderError(
+  e: Error,
+  providerError: UpstreamAIProviderError,
+): Promise<Response> {
+  log.warn("Upstream AI provider error", providerError);
+  Sentry.captureMessage("Upstream AI provider error", {
+    level: "warning",
+    extra: {
+      ...providerError,
+      cause: e.message,
+    },
+  });
+
+  return Promise.resolve(
+    streamingJSON({
+      type: "error",
+      message: "The AI service is temporarily unavailable",
+      value: "The AI service is temporarily unavailable. Please try again shortly.",
+    } as ErrorDocument),
+  );
+}
+
 export async function handleChatException(
   e: unknown,
   chatId: string,
@@ -90,6 +155,13 @@ export async function handleChatException(
 
   if (e instanceof UserBannedError) {
     return handleUserBannedError();
+  }
+
+  if (e instanceof Error) {
+    const upstreamProviderError = getUpstreamAIProviderError(e);
+    if (upstreamProviderError) {
+      return handleUpstreamAIProviderError(e, upstreamProviderError);
+    }
   }
 
   Sentry.captureException(

--- a/apps/nextjs/src/app/api/chat/errorHandling.ts
+++ b/apps/nextjs/src/app/api/chat/errorHandling.ts
@@ -131,7 +131,8 @@ async function handleUpstreamAIProviderError(
     streamingJSON({
       type: "error",
       message: "The AI service is temporarily unavailable",
-      value: "The AI service is temporarily unavailable. Please try again shortly.",
+      value:
+        "The AI service is temporarily unavailable. Please try again shortly.",
     } as ErrorDocument),
   );
 }

--- a/packages/aila/src/core/chat/AilaStreamHandler.test.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.test.ts
@@ -1,4 +1,5 @@
 import { createOpenAIClient } from "@oakai/core/src/llm/openai";
+import type { ThreatDetectionResult } from "@oakai/core/src/threatDetection/types";
 import {
   getRagLessonPlansByIds,
   getRelevantLessonPlans,
@@ -8,11 +9,13 @@ import {
 
 import OpenAI from "openai";
 
+import { AilaThreatDetectionError } from "../../features/threatDetection";
 import { createOpenAIMessageToUserAgent } from "../../lib/agentic-system/agents/messageToUserAgent";
 import { createOpenAIPlannerAgent } from "../../lib/agentic-system/agents/plannerAgent";
 import { createSectionAgentRegistry as createSectionAgentRegistryFactory } from "../../lib/agentic-system/agents/sectionAgents/sectionAgentRegistry";
 import { ailaTurn } from "../../lib/agentic-system/ailaTurn";
 import type { SectionAgentRegistry } from "../../lib/agentic-system/types";
+import type { AilaPlugin } from "../plugins";
 import { AilaStreamHandler } from "./AilaStreamHandler";
 import type { Message } from "./types";
 
@@ -76,8 +79,15 @@ jest.mock(
   }),
 );
 
+type MockThreatDetector = {
+  detectThreat: jest.Mock;
+  isThreatError: jest.Mock;
+};
+
 type MockChatOptions = {
   useAgenticAila: boolean;
+  threatDetectors?: MockThreatDetector[];
+  plugins?: Partial<AilaPlugin>[];
 };
 
 const mockedAilaTurn = jest.mocked(ailaTurn);
@@ -105,7 +115,34 @@ function createObjectStreamReader(chunks: string[] = ["stream chunk"]) {
   }).getReader();
 }
 
-function createMockChat({ useAgenticAila }: MockChatOptions) {
+function createRejectingObjectStreamReader(error: unknown) {
+  return {
+    read: jest.fn().mockRejectedValue(error),
+  } as unknown as ReadableStreamDefaultReader<string>;
+}
+
+function createThreatDetector(
+  detectThreat: MockThreatDetector["detectThreat"],
+): MockThreatDetector {
+  return {
+    detectThreat,
+    isThreatError: jest.fn().mockReturnValue(false),
+  };
+}
+
+const noThreatDetection: ThreatDetectionResult = {
+  provider: "model_armor",
+  isThreat: false,
+  message: "No threats detected",
+  findings: [],
+  details: {},
+};
+
+function createMockChat({
+  useAgenticAila,
+  threatDetectors = [],
+  plugins = [],
+}: MockChatOptions) {
   const enqueue = jest.fn().mockResolvedValue(undefined);
   const complete = jest.fn().mockImplementation(async () => {
     await enqueue({
@@ -133,7 +170,7 @@ function createMockChat({ useAgenticAila }: MockChatOptions) {
         ) => await handler(),
       },
       threatDetection: {
-        detectors: [],
+        detectors: threatDetectors,
       },
       errorReporter: {
         reportError: jest.fn(),
@@ -141,7 +178,7 @@ function createMockChat({ useAgenticAila }: MockChatOptions) {
       document: {
         content: {},
       },
-      plugins: [],
+      plugins,
     },
     getPatchEnqueuer: () => ({
       setController: jest.fn(),
@@ -161,6 +198,15 @@ function createMockChat({ useAgenticAila }: MockChatOptions) {
       .fn()
       .mockResolvedValue(createObjectStreamReader()),
     persistChat: jest.fn().mockResolvedValue(undefined),
+    generationFailed: jest.fn().mockImplementation(async (error) => {
+      if (error instanceof AilaThreatDetectionError) {
+        await enqueue({
+          type: "error",
+          value: "Threat detected",
+          message: "Threat was detected",
+        });
+      }
+    }),
     complete,
     enqueue,
   };
@@ -205,6 +251,142 @@ describe("AilaStreamHandler", () => {
       type: "comment",
       value: "CHAT_COMPLETE",
     });
+  });
+
+  it("shows a retry error and skips generation when non-agentic threat detection fails", async () => {
+    const detectorError = new Error("Threat detector unavailable");
+    const threatDetector = createThreatDetector(
+      jest.fn().mockRejectedValue(detectorError),
+    );
+    const chat = createMockChat({
+      useAgenticAila: false,
+      threatDetectors: [threatDetector],
+    });
+    const handler = new AilaStreamHandler(chat as never);
+
+    await expect(consumeStream(handler.startStreaming())).resolves.toBe(
+      undefined,
+    );
+
+    expect(threatDetector.detectThreat).toHaveBeenCalledWith(chat.messages);
+    expect(chat.enqueue).toHaveBeenCalledWith({
+      type: "error",
+      value: "Threat detection failed",
+      message:
+        "I wasn't able to check your message for safety. Please try again in a moment.",
+    });
+    expect(chat.aila.errorReporter.reportError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "ThreatDetectionFailureError",
+      }),
+      "Threat detection failed",
+      "error",
+    );
+    expect(chat.createChatCompletionObjectStream).not.toHaveBeenCalled();
+    expect(chat.complete).not.toHaveBeenCalled();
+    expect(chat.generationFailed).not.toHaveBeenCalled();
+  });
+
+  it("shows a retry error and skips generation when agentic threat detection fails", async () => {
+    const detectorError = new Error("Threat detector unavailable");
+    const threatDetector = createThreatDetector(
+      jest.fn().mockRejectedValue(detectorError),
+    );
+    const chat = createMockChat({
+      useAgenticAila: true,
+      threatDetectors: [threatDetector],
+    });
+    const handler = new AilaStreamHandler(chat as never);
+
+    await expect(consumeStream(handler.startStreaming())).resolves.toBe(
+      undefined,
+    );
+
+    expect(threatDetector.detectThreat).toHaveBeenCalledWith(chat.messages);
+    expect(chat.enqueue).toHaveBeenCalledWith({
+      type: "error",
+      value: "Threat detection failed",
+      message:
+        "I wasn't able to check your message for safety. Please try again in a moment.",
+    });
+    expect(chat.aila.errorReporter.reportError).toHaveBeenCalledWith(
+      expect.objectContaining({
+        name: "ThreatDetectionFailureError",
+      }),
+      "Threat detection failed",
+      "error",
+    );
+    expect(mockedAilaTurn).not.toHaveBeenCalled();
+    expect(chat.complete).not.toHaveBeenCalled();
+    expect(chat.generationFailed).not.toHaveBeenCalled();
+  });
+
+  it("handles detected threats without erroring the stream", async () => {
+    const threatDetection: ThreatDetectionResult = {
+      provider: "model_armor",
+      isThreat: true,
+      message: "Threat detected",
+      severity: "high",
+      category: "prompt_injection",
+      findings: [],
+      details: {},
+    };
+    const threatDetector = createThreatDetector(
+      jest.fn().mockResolvedValue(threatDetection),
+    );
+    const chat = createMockChat({
+      useAgenticAila: false,
+      threatDetectors: [threatDetector],
+    });
+    const handler = new AilaStreamHandler(chat as never);
+
+    await expect(consumeStream(handler.startStreaming())).resolves.toBe(
+      undefined,
+    );
+
+    expect(chat.generationFailed).toHaveBeenCalledWith(
+      expect.any(AilaThreatDetectionError),
+    );
+    expect(chat.enqueue).toHaveBeenCalledWith({
+      type: "error",
+      value: "Threat detected",
+      message: "Threat was detected",
+    });
+    expect(chat.createChatCompletionObjectStream).not.toHaveBeenCalled();
+    expect(chat.complete).not.toHaveBeenCalled();
+  });
+
+  it("handles provider threat errors without erroring the stream", async () => {
+    const providerError = new Error("Prompt threat detected");
+    const threatDetector = createThreatDetector(
+      jest.fn().mockResolvedValue(noThreatDetection),
+    );
+    threatDetector.isThreatError.mockReturnValue(true);
+    const onStreamError = jest.fn().mockRejectedValue(providerError);
+    const chat = createMockChat({
+      useAgenticAila: false,
+      threatDetectors: [threatDetector],
+      plugins: [{ onStreamError }],
+    });
+    chat.createChatCompletionObjectStream.mockResolvedValue(
+      createRejectingObjectStreamReader(providerError),
+    );
+    const handler = new AilaStreamHandler(chat as never);
+
+    await expect(consumeStream(handler.startStreaming())).resolves.toBe(
+      undefined,
+    );
+
+    expect(chat.generationFailed).toHaveBeenCalledWith(
+      expect.any(AilaThreatDetectionError),
+    );
+    expect(chat.enqueue).toHaveBeenCalledWith({
+      type: "error",
+      value: "Threat detected",
+      message: "Threat was detected",
+    });
+    expect(onStreamError).not.toHaveBeenCalled();
+    expect(chat.complete).not.toHaveBeenCalled();
   });
 
   it("completes successful agentic turns", async () => {

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -1,5 +1,8 @@
 import { createOpenAIClient } from "@oakai/core/src/llm/openai";
-import type { ThreatDetectionMessage } from "@oakai/core/src/threatDetection/types";
+import type {
+  ThreatDetectionMessage,
+  ThreatDetectionResult,
+} from "@oakai/core/src/threatDetection/types";
 import { aiLogger } from "@oakai/logger";
 import {
   getRagLessonPlansByIds,
@@ -27,6 +30,16 @@ const log = aiLogger("aila:stream");
 
 function agenticTurnSucceeded(outcome: AilaTurnOutcome | null): boolean {
   return outcome?.status === "success";
+}
+
+class ThreatDetectionFailureError extends Error {
+  public readonly detectorName: string;
+
+  constructor(detectorName: string, options?: ErrorOptions) {
+    super(`Threat detection failed in ${detectorName}`, options);
+    this.name = "ThreatDetectionFailureError";
+    this.detectorName = detectorName;
+  }
 }
 
 export class AilaStreamHandler {
@@ -77,8 +90,15 @@ export class AilaStreamHandler {
 
     const detectors = this._chat.aila.threatDetection?.detectors ?? [];
     for (const detector of detectors) {
-      log.info("Running detector", { detector: detector.constructor.name });
-      const threatDetection = await detector.detectThreat(messagesToCheck);
+      const detectorName = detector.constructor.name;
+      log.info("Running detector", { detector: detectorName });
+      let threatDetection: ThreatDetectionResult;
+      try {
+        threatDetection = await detector.detectThreat(messagesToCheck);
+      } catch (error) {
+        log.error("Threat detector failed", { detector: detectorName, error });
+        throw new ThreatDetectionFailureError(detectorName, { cause: error });
+      }
       if (threatDetection.isThreat) {
         log.info("Threat detected", { threatDetection });
         throw new AilaThreatDetectionError(
@@ -98,6 +118,7 @@ export class AilaStreamHandler {
     log.info("Starting stream", { chatId: this._chat.id });
     this.setupController(controller);
     let agenticTurnOutcome: AilaTurnOutcome | null = null;
+    let skipCompletion = false;
     try {
       if (!this._chat.aila.options.useAgenticAila) {
         await this.span("set-up-generation", async () => {
@@ -152,13 +173,26 @@ export class AilaStreamHandler {
         type: e?.constructor?.name,
       });
       if (e instanceof AilaThreatDetectionError) {
-        log.info("Handling threat detection error");
-
-        await this._chat.generationFailed(e);
-        throw e;
+        await this.handleThreatDetected(e);
+        skipCompletion = true;
+        return;
       }
-      await this.handleStreamError(e);
-      log.info("Stream error", e, this._chat.iteration, this._chat.id);
+      if (e instanceof ThreatDetectionFailureError) {
+        await this.handleThreatDetectionFailure(e);
+        skipCompletion = true;
+        return;
+      }
+      try {
+        await this.handleStreamError(e);
+      } catch (streamError) {
+        if (streamError instanceof AilaThreatDetectionError) {
+          await this.handleThreatDetected(streamError);
+          skipCompletion = true;
+          return;
+        }
+
+        throw streamError;
+      }
     } finally {
       const status = this._chat.generation?.status;
       const shouldComplete = this._chat.aila.options.useAgenticAila
@@ -167,9 +201,10 @@ export class AilaStreamHandler {
       log.info("In finally block", {
         status,
         agenticTurnOutcome,
+        skipCompletion,
         chatId: this._chat.id,
       });
-      if (shouldComplete) {
+      if (shouldComplete && !skipCompletion) {
         try {
           await this.span("chat-completion", async () => {
             await this._chat.complete();
@@ -364,7 +399,48 @@ export class AilaStreamHandler {
     }
   }
 
+  private async handleThreatDetected(error: AilaThreatDetectionError) {
+    log.info("Handling threat detection error");
+    await this._chat.generationFailed(error);
+  }
+
+  private async handleThreatDetectionFailure(
+    error: ThreatDetectionFailureError,
+  ) {
+    this._chat.aila.errorReporter?.reportError(
+      error,
+      "Threat detection failed",
+      "error",
+    );
+    await this._chat.enqueue({
+      type: "error",
+      value: "Threat detection failed",
+      message:
+        "I wasn't able to check your message for safety. Please try again in a moment.",
+    });
+  }
+
+  private isThreatDetectionProviderError(error: Error): boolean {
+    const detectors = this._chat.aila.threatDetection?.detectors ?? [];
+    return detectors.some((detector) => detector.isThreatError(error));
+  }
+
   private async handleStreamError(error: unknown) {
+    if (error instanceof Error) {
+      if (error instanceof AilaThreatDetectionError) {
+        throw error;
+      }
+
+      if (this.isThreatDetectionProviderError(error)) {
+        throw new AilaThreatDetectionError(
+          this._chat.userId ?? "unknown",
+          "Threat detected",
+          undefined,
+          { cause: error },
+        );
+      }
+    }
+
     for (const plugin of this._chat.aila.plugins ?? []) {
       await plugin.onStreamError?.(error, {
         aila: this._chat.aila,
@@ -373,21 +449,6 @@ export class AilaStreamHandler {
     }
 
     if (error instanceof Error) {
-      if (error instanceof AilaThreatDetectionError) {
-        throw error;
-      }
-
-      const detectors = this._chat.aila.threatDetection?.detectors ?? [];
-      for (const detector of detectors) {
-        if (detector.isThreatError(error)) {
-          throw new AilaThreatDetectionError(
-            this._chat.userId ?? "unknown",
-            "Threat detected",
-            undefined,
-            { cause: error },
-          );
-        }
-      }
       this._chat.aila.errorReporter?.reportError(error);
       throw new AilaChatError(error.message, { cause: error });
     } else {

--- a/packages/aila/src/core/document/AilaDocument.test.ts
+++ b/packages/aila/src/core/document/AilaDocument.test.ts
@@ -1,0 +1,41 @@
+import type { AilaServices } from "../AilaServices";
+import type { Message } from "../chat";
+import { AilaDocument } from "./AilaDocument";
+
+describe("AilaDocument", () => {
+  describe("initialiseContentFromMessages", () => {
+    it("does not fail chat initialisation when categorisation fails", async () => {
+      const error = new Error("provider 500");
+      const reportError = jest.fn();
+      const categoriser = {
+        categorise: jest.fn().mockRejectedValue(error),
+      };
+      const document = new AilaDocument({
+        aila: {
+          errorReporter: { reportError },
+        } as unknown as AilaServices,
+        content: {},
+        categoriser,
+      });
+      const messages: Message[] = [
+        {
+          id: "message-id",
+          role: "user",
+          content: "Plan a lesson on plate tectonics",
+        },
+      ];
+
+      await expect(
+        document.initialiseContentFromMessages(messages),
+      ).resolves.toBeUndefined();
+
+      expect(document.content).toEqual({});
+      expect(document.hasInitialisedContentFromMessages).toBe(false);
+      expect(reportError).toHaveBeenCalledWith(
+        error,
+        "Failed to initialise content from messages",
+        "warning",
+      );
+    });
+  });
+});

--- a/packages/aila/src/core/document/AilaDocument.ts
+++ b/packages/aila/src/core/document/AilaDocument.ts
@@ -138,10 +138,18 @@ export class AilaDocument implements AilaDocumentService {
     // The initial lesson plan is blank, so we take the first messages
     // and attempt to deduce the lesson plan key stage, subject, title and topic
     if (shouldCategoriseBasedOnInitialMessages) {
-      const result = await this._categoriser.categorise(
-        messages,
-        this._content,
-      );
+      let result: AilaDocumentContent | undefined;
+      try {
+        result = await this._categoriser.categorise(messages, this._content);
+      } catch (error) {
+        log.error("Failed to initialise content from messages", { error });
+        this._aila.errorReporter?.reportError(
+          error,
+          "Failed to initialise content from messages",
+          "warning",
+        );
+        return;
+      }
 
       if (result) {
         this.initialise(result);

--- a/packages/api/src/router/auth.test.ts
+++ b/packages/api/src/router/auth.test.ts
@@ -1,0 +1,263 @@
+import { demoUsers } from "@oakai/core";
+import { posthogAiBetaServerClient } from "@oakai/core/src/analytics/posthogAiBetaServerClient";
+import { aiLogger } from "@oakai/logger";
+
+import { clerkClient } from "@clerk/nextjs/server";
+import * as Sentry from "@sentry/node";
+
+import { authRouter } from "./auth";
+
+jest.mock("@oakai/core", () => ({
+  demoUsers: {
+    isDemoStatusSet: jest.fn(),
+    getUserRegion: jest.fn(),
+  },
+}));
+
+jest.mock("@oakai/core/src/analytics/hubspotClient", () => ({
+  createHubspotCustomer: jest.fn(),
+}));
+
+jest.mock("@oakai/core/src/analytics/posthogAiBetaServerClient", () => ({
+  posthogAiBetaServerClient: {
+    identifyImmediate: jest.fn(),
+  },
+}));
+
+jest.mock("@oakai/logger", () => ({
+  aiLogger: jest.fn(() => ({
+    info: jest.fn(),
+    error: jest.fn(),
+  })),
+}));
+
+jest.mock("@clerk/nextjs/server", () => ({
+  clerkClient: jest.fn(),
+}));
+
+jest.mock("@clerk/shared", () => ({
+  isClerkAPIResponseError: jest.fn((error: unknown) => {
+    return (
+      typeof error === "object" &&
+      error !== null &&
+      "isClerkApiResponseError" in error
+    );
+  }),
+}));
+
+jest.mock("@sentry/node", () => ({
+  captureException: jest.fn(),
+  setContext: jest.fn(),
+  setTag: jest.fn(),
+  trpcMiddleware: jest.fn(
+    () =>
+      ({ next }: { next: () => unknown }) =>
+        next(),
+  ),
+}));
+
+jest.mock("../middleware/auth", () => {
+  const { publicProcedure } = jest.requireActual("../trpc");
+
+  return {
+    protectedProcedure: publicProcedure,
+  };
+});
+
+const mockedDemoUsers = jest.mocked(demoUsers);
+const mockedClerkClient = jest.mocked(clerkClient);
+const mockedPosthogClient = jest.mocked(posthogAiBetaServerClient);
+const mockedAiLogger = jest.mocked(aiLogger);
+const authLoggerIndex = mockedAiLogger.mock.calls.findIndex(
+  ([loggerName]) => loggerName === "auth",
+);
+const authLogger = mockedAiLogger.mock.results[authLoggerIndex]?.value as {
+  error: jest.Mock;
+};
+const authLoggerError = authLogger.error;
+
+const createCaller = () =>
+  authRouter.createCaller({
+    auth: { userId: "user_123" },
+    prisma: {},
+    req: {
+      url: "https://example.com/api/trpc/main/auth.setDemoStatus",
+      headers: new Headers({ "cf-ipcountry": "GB" }),
+    },
+  } as never);
+
+describe("authRouter.setDemoStatus", () => {
+  const getUser = jest.fn();
+  const updateUserMetadata = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockedClerkClient.mockResolvedValue({
+      users: {
+        getUser,
+        updateUserMetadata,
+      },
+    } as never);
+
+    getUser.mockResolvedValue({
+      publicMetadata: {
+        labs: {
+          isDemoUser: true,
+        },
+      },
+      privateMetadata: {},
+      emailAddresses: [],
+    });
+    updateUserMetadata.mockResolvedValue(undefined);
+    mockedDemoUsers.isDemoStatusSet.mockReturnValue(true);
+    mockedDemoUsers.getUserRegion.mockResolvedValue({
+      region: "GB",
+      isDemoRegion: false,
+    });
+    mockedPosthogClient.identifyImmediate.mockResolvedValue(undefined);
+  });
+
+  it("returns a boolean when demo status is already set", async () => {
+    const result = await createCaller().setDemoStatus();
+
+    expect(result).toEqual({ isDemoUser: true });
+    expect(updateUserMetadata).not.toHaveBeenCalled();
+    expect(mockedPosthogClient.identifyImmediate).not.toHaveBeenCalled();
+  });
+
+  it("sets demo metadata and identifies the user when demo status is missing", async () => {
+    mockedDemoUsers.isDemoStatusSet.mockReturnValue(false);
+
+    const result = await createCaller().setDemoStatus();
+
+    expect(mockedDemoUsers.getUserRegion).toHaveBeenCalledWith(
+      expect.objectContaining({
+        publicMetadata: {
+          labs: {
+            isDemoUser: true,
+          },
+        },
+      }),
+      "GB",
+    );
+    expect(updateUserMetadata).toHaveBeenCalledWith("user_123", {
+      publicMetadata: {
+        labs: {
+          isDemoUser: false,
+        },
+      },
+      privateMetadata: {
+        region: "GB",
+      },
+    });
+    expect(mockedPosthogClient.identifyImmediate).toHaveBeenCalledWith({
+      distinctId: "user_123",
+      properties: {
+        isDemoUser: false,
+      },
+    });
+    expect(result).toEqual({ isDemoUser: false });
+  });
+
+  it("records Clerk diagnostics and rethrows when getUser fails", async () => {
+    const clerkError = Object.assign(new Error("Clerk unavailable"), {
+      name: "ClerkAPIResponseError",
+      isClerkApiResponseError: true,
+      status: 503,
+      clerkTraceId: "trace_123",
+      retryAfter: 60,
+      errors: [
+        { code: "unexpected_error", message: "Service unavailable" },
+        { code: "extra_1", message: "Extra one" },
+        { code: "extra_2", message: "Extra two" },
+        { code: "extra_3", message: "Extra three" },
+      ],
+    });
+    getUser.mockRejectedValue(clerkError);
+
+    await expect(createCaller().setDemoStatus()).rejects.toMatchObject({
+      cause: clerkError,
+    });
+
+    expect(Sentry.setTag).toHaveBeenCalledWith(
+      "procedure",
+      "auth.setDemoStatus",
+    );
+    expect(Sentry.setTag).toHaveBeenCalledWith(
+      "clerk.operation",
+      "users.getUser",
+    );
+    expect(Sentry.setTag).toHaveBeenCalledWith("clerk.status", "503");
+    expect(Sentry.setContext).toHaveBeenCalledWith("clerk", {
+      procedure: "auth.setDemoStatus",
+      clerkOperation: "users.getUser",
+      userId: "user_123",
+      requestUrl: "https://example.com/api/trpc/main/auth.setDemoStatus",
+      cfIpCountry: "GB",
+      errorName: "ClerkAPIResponseError",
+      errorMessage: "Clerk unavailable",
+      status: 503,
+      clerkTraceId: "trace_123",
+      retryAfter: 60,
+      clerkErrors: [
+        { code: "unexpected_error", message: "Service unavailable" },
+        { code: "extra_1", message: "Extra one" },
+        { code: "extra_2", message: "Extra two" },
+      ],
+    });
+    expect(authLoggerError).toHaveBeenCalledWith(
+      "Clerk request failed in auth.setDemoStatus",
+      expect.objectContaining({
+        clerkOperation: "users.getUser",
+        status: 503,
+      }),
+    );
+  });
+
+  it("records Clerk diagnostics and rethrows when updateUserMetadata fails", async () => {
+    mockedDemoUsers.isDemoStatusSet.mockReturnValue(false);
+    const clerkError = Object.assign(new Error("Metadata write failed"), {
+      name: "ClerkAPIResponseError",
+      isClerkApiResponseError: true,
+      status: 429,
+      clerkTraceId: "trace_456",
+      retryAfter: 30,
+      errors: [{ code: "too_many_requests", message: "Rate limited" }],
+    });
+    updateUserMetadata.mockRejectedValue(clerkError);
+
+    await expect(createCaller().setDemoStatus()).rejects.toMatchObject({
+      cause: clerkError,
+    });
+
+    expect(Sentry.setTag).toHaveBeenCalledWith(
+      "clerk.operation",
+      "users.updateUserMetadata",
+    );
+    expect(Sentry.setTag).toHaveBeenCalledWith("clerk.status", "429");
+    expect(Sentry.setContext).toHaveBeenCalledWith(
+      "clerk",
+      expect.objectContaining({
+        procedure: "auth.setDemoStatus",
+        clerkOperation: "users.updateUserMetadata",
+        userId: "user_123",
+        requestUrl: "https://example.com/api/trpc/main/auth.setDemoStatus",
+        cfIpCountry: "GB",
+        errorName: "ClerkAPIResponseError",
+        errorMessage: "Metadata write failed",
+        status: 429,
+        clerkTraceId: "trace_456",
+        retryAfter: 30,
+        clerkErrors: [{ code: "too_many_requests", message: "Rate limited" }],
+      }),
+    );
+    expect(authLoggerError).toHaveBeenCalledWith(
+      "Clerk request failed in auth.setDemoStatus",
+      expect.objectContaining({
+        clerkOperation: "users.updateUserMetadata",
+        status: 429,
+      }),
+    );
+  });
+});

--- a/packages/api/src/router/auth.ts
+++ b/packages/api/src/router/auth.ts
@@ -7,6 +7,7 @@ import { z } from "zod";
 
 import { protectedProcedure } from "../middleware/auth";
 import { router } from "../trpc";
+import { withClerkDiagnostics } from "./helpers/clerkDiagnostics";
 
 export const authRouter = router({
   hasSeenWhatsNew: protectedProcedure
@@ -89,28 +90,48 @@ export const authRouter = router({
 
   setDemoStatus: protectedProcedure.mutation(async ({ ctx }) => {
     const { userId } = ctx.auth;
+    const cfIpCountry = ctx.req.headers.get("cf-ipcountry");
     const client = await clerkClient();
-    const user = await client.users.getUser(userId);
+    const requestContext = {
+      procedure: "auth.setDemoStatus",
+      userId,
+      requestUrl: ctx.req.url,
+      cfIpCountry,
+    };
+    const user = await withClerkDiagnostics(
+      {
+        ...requestContext,
+        clerkOperation: "users.getUser",
+      },
+      () => client.users.getUser(userId),
+    );
 
     if (demoUsers.isDemoStatusSet(user)) {
-      return { isDemoUser: user.publicMetadata.labs };
+      return { isDemoUser: Boolean(user.publicMetadata.labs.isDemoUser) };
     }
 
     const { region, isDemoRegion: isDemoUser } = await demoUsers.getUserRegion(
       user,
-      ctx.req.headers.get("cf-ipcountry"),
+      cfIpCountry,
     );
 
-    await client.users.updateUserMetadata(userId, {
-      publicMetadata: {
-        labs: {
-          isDemoUser,
-        },
+    await withClerkDiagnostics(
+      {
+        ...requestContext,
+        clerkOperation: "users.updateUserMetadata",
       },
-      privateMetadata: {
-        region,
-      },
-    });
+      () =>
+        client.users.updateUserMetadata(userId, {
+          publicMetadata: {
+            labs: {
+              isDemoUser,
+            },
+          },
+          privateMetadata: {
+            region,
+          },
+        }),
+    );
 
     await posthogAiBetaServerClient.identifyImmediate({
       distinctId: userId,

--- a/packages/api/src/router/helpers/clerkDiagnostics.ts
+++ b/packages/api/src/router/helpers/clerkDiagnostics.ts
@@ -1,0 +1,132 @@
+import { aiLogger } from "@oakai/logger";
+
+import { isClerkAPIResponseError } from "@clerk/shared";
+import * as Sentry from "@sentry/node";
+
+const log = aiLogger("auth");
+
+type ClerkOperation = "users.getUser" | "users.updateUserMetadata";
+
+type ClerkDiagnosticContext = {
+  procedure: string;
+  clerkOperation: ClerkOperation;
+  userId: string;
+  requestUrl: string;
+  cfIpCountry: string | null;
+};
+
+function getErrorName(error: unknown) {
+  return error instanceof Error ? error.name : typeof error;
+}
+
+function getErrorMessage(error: unknown) {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function isUnknownArray(value: unknown): value is unknown[] {
+  return Array.isArray(value);
+}
+
+function getNumberProperty(error: unknown, property: string) {
+  if (!isRecord(error)) {
+    return undefined;
+  }
+
+  return typeof error[property] === "number" ? error[property] : undefined;
+}
+
+function getStringProperty(error: unknown, property: string) {
+  if (!isRecord(error)) {
+    return undefined;
+  }
+
+  return typeof error[property] === "string" ? error[property] : undefined;
+}
+
+function getRawClerkErrors(error: unknown): unknown[] | undefined {
+  if (isClerkAPIResponseError(error)) {
+    const errors: unknown = error.errors;
+    return isUnknownArray(errors) ? errors : undefined;
+  }
+
+  if (isRecord(error) && isUnknownArray(error.errors)) {
+    return error.errors;
+  }
+}
+
+function getClerkErrors(error: unknown) {
+  const errors = getRawClerkErrors(error);
+  if (!errors) {
+    return undefined;
+  }
+
+  return errors.slice(0, 3).map((clerkError) => ({
+    code: isRecord(clerkError)
+      ? getStringProperty(clerkError, "code")
+      : undefined,
+    message: isRecord(clerkError)
+      ? getStringProperty(clerkError, "message")
+      : undefined,
+  }));
+}
+
+function getClerkStatus(error: unknown) {
+  return isClerkAPIResponseError(error)
+    ? error.status
+    : getNumberProperty(error, "status");
+}
+
+function getClerkTraceId(error: unknown) {
+  return isClerkAPIResponseError(error)
+    ? error.clerkTraceId
+    : getStringProperty(error, "clerkTraceId");
+}
+
+function getClerkRetryAfter(error: unknown) {
+  return isClerkAPIResponseError(error)
+    ? error.retryAfter
+    : getNumberProperty(error, "retryAfter");
+}
+
+function getClerkFailureDiagnostics(
+  error: unknown,
+  context: ClerkDiagnosticContext,
+) {
+  return {
+    ...context,
+    errorName: getErrorName(error),
+    errorMessage: getErrorMessage(error),
+    status: getClerkStatus(error),
+    clerkTraceId: getClerkTraceId(error),
+    retryAfter: getClerkRetryAfter(error),
+    clerkErrors: getClerkErrors(error),
+  };
+}
+
+function recordClerkFailure(
+  details: ReturnType<typeof getClerkFailureDiagnostics>,
+) {
+  Sentry.setTag("procedure", details.procedure);
+  Sentry.setTag("clerk.operation", details.clerkOperation);
+  if (typeof details.status !== "undefined") {
+    Sentry.setTag("clerk.status", String(details.status));
+  }
+  Sentry.setContext("clerk", details);
+  log.error(`Clerk request failed in ${details.procedure}`, details);
+}
+
+export async function withClerkDiagnostics<T>(
+  context: ClerkDiagnosticContext,
+  operation: () => Promise<T>,
+) {
+  try {
+    return await operation();
+  } catch (error) {
+    recordClerkFailure(getClerkFailureDiagnostics(error, context));
+    throw error;
+  }
+}


### PR DESCRIPTION
## Description

This PR improves logging and resilience for various errors which rarely occur with upstream AI providers, threat detection providers and Clerk.

## Issue(s)

Additionally, this PR fixes #AI-2146 where Aila would show a blank response if a threat detection provider call resulted in an error.

## How to test

Most changes rely on transient errors occurring in third party calls, which can't be manually verified.

To test the user-facing changes in this branch:

1. Go to {deployment_url}
2. Run Aila a couple of times through normal lesson generation 
3. Use a known trigger to verify threat detection behaves as expected
4. Sign in as a new user (or a user whose demo status hasn't been set) and check that the demo/non-demo experience is correct as usual