### PR TITLE
test: [AI-2200] harden playwright e2e tests for CI reliability

### DIFF
--- a/apps/nextjs/tests-e2e/config/global.setup.ts
+++ b/apps/nextjs/tests-e2e/config/global.setup.ts
@@ -1,6 +1,9 @@
 import { clerkSetup } from "@clerk/testing/playwright";
 import { test as setup } from "@playwright/test";
 
-setup("global setup", async () => {
+import { warmVercelPreview } from "../helpers/vercel";
+
+setup("global setup", async ({ page }) => {
   await clerkSetup();
+  await warmVercelPreview(page);
 });

--- a/apps/nextjs/tests-e2e/helpers/vercel.ts
+++ b/apps/nextjs/tests-e2e/helpers/vercel.ts
@@ -21,3 +21,15 @@ export async function bypassVercelProtection(page: Page | BrowserContext) {
     await route.continue({ headers });
   });
 }
+
+export async function warmVercelPreview(page: Page) {
+  await bypassVercelProtection(page);
+
+  for (const path of ["/", "/aila"]) {
+    await page.goto(`${TEST_BASE_URL}${path}`, {
+      // cspell:disable-next-line
+      waitUntil: "domcontentloaded",
+      timeout: 60000,
+    });
+  }
+}

--- a/apps/nextjs/tests-e2e/tests/aila-chat/flexible-prompt-live.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/flexible-prompt-live.test.ts
@@ -25,21 +25,16 @@ test(
       await setupClerkTestingToken({ page });
 
       await page.goto(`${TEST_BASE_URL}${getAilaUrl("lesson")}`);
-      await expect(page.getByTestId("chat-h1")).toContainText("Hello,", {
-        timeout: 15000,
-      });
-    });
-
-    await test.step("Fill in the chat box", async () => {
-      const textbox = page.getByTestId("chat-input");
-      const message =
-        "Create a KS1 lesson on the Romans, create the whole lesson without asking me any questions. As short as possible.";
-      await textbox.fill(message);
-      await expect(textbox).toHaveValue(message);
+      await expect(page.getByTestId("chat-h1")).toBeInViewport();
     });
 
     await test.step("Send message and generate full lesson plan", async () => {
       await performAndWaitForGeneration(page, generationTimeout, async () => {
+        await page
+          .getByTestId("chat-input")
+          .fill(
+            "Create a KS1 lesson on the Romans, create the whole lesson without asking me any questions. As short as possible.",
+          );
         await Promise.all([
           page.getByTestId("send-message").click(),
           page.waitForURL(/\/aila\/.+/),

--- a/apps/nextjs/tests-e2e/tests/aila-chat/flexible-prompt-live.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/flexible-prompt-live.test.ts
@@ -5,7 +5,11 @@ import { getAilaUrl } from "@/utils/getAilaUrl";
 
 import { TEST_BASE_URL } from "../../config/config";
 import { bypassVercelProtection } from "../../helpers/vercel";
-import { continueChat, isFinished, waitForGeneration } from "./helpers";
+import {
+  continueChat,
+  isFinished,
+  performAndWaitForGeneration,
+} from "./helpers";
 
 const generationTimeout = 75000;
 
@@ -21,30 +25,34 @@ test(
       await setupClerkTestingToken({ page });
 
       await page.goto(`${TEST_BASE_URL}${getAilaUrl("lesson")}`);
-      await expect(page.getByTestId("chat-h1")).toBeInViewport();
+      await expect(page.getByTestId("chat-h1")).toContainText("Hello,", {
+        timeout: 15000,
+      });
     });
 
     await test.step("Fill in the chat box", async () => {
       const textbox = page.getByTestId("chat-input");
-      const sendMessage = page.getByTestId("send-message");
       const message =
         "Create a KS1 lesson on the Romans, create the whole lesson without asking me any questions. As short as possible.";
       await textbox.fill(message);
-      await expect(textbox).toContainText(message);
-
-      await sendMessage.click();
+      await expect(textbox).toHaveValue(message);
     });
 
-    await test.step("Iterate through the lesson plan", async () => {
-      await page.waitForURL(/\/aila\/.+/);
-      await waitForGeneration(page, generationTimeout);
+    await test.step("Send message and generate full lesson plan", async () => {
+      await performAndWaitForGeneration(page, generationTimeout, async () => {
+        await Promise.all([
+          page.getByTestId("send-message").click(),
+          page.waitForURL(/\/aila\/.+/),
+        ]);
+      });
 
       for (let i = 0; i < 12; i++) {
-        await continueChat(page);
-        await waitForGeneration(page, generationTimeout);
         if (await isFinished(page)) {
           break;
         }
+        await performAndWaitForGeneration(page, generationTimeout, async () => {
+          await continueChat(page);
+        });
         if (i === 11) {
           throw new Error("Failed to finish the lesson plan after 12 tries");
         }

--- a/apps/nextjs/tests-e2e/tests/aila-chat/full-romans.mobile.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/full-romans.mobile.test.ts
@@ -12,10 +12,9 @@ import {
   continueChat,
   expectFinished,
   expectSectionsComplete,
-  expectStreamingStatus,
   letUiSettle,
+  performAndWaitForGeneration,
   scrollLessonPlanFromTopToBottom,
-  waitForGeneration,
 } from "./helpers";
 
 // --------
@@ -47,56 +46,58 @@ test(
       await setupClerkTestingToken({ page });
 
       await page.goto(`${TEST_BASE_URL}${getAilaUrl("lesson")}`);
-      await expect(page.getByTestId("chat-h1")).toBeInViewport();
+      await expect(page.getByTestId("chat-h1")).toContainText("Hello,", {
+        timeout: 15000,
+      });
     });
 
     const { setFixture } = await applyLlmFixtures(page, FIXTURE_MODE);
 
     await test.step("Fill in the chat box", async () => {
       const textbox = page.getByTestId("chat-input");
-      const sendMessage = page.getByTestId("send-message");
       const message = "Create a KS1 lesson on the end of Roman Britain";
       await textbox.fill(message);
-      await expect(textbox).toContainText(message);
+      await expect(textbox).toHaveValue(message);
 
       setFixture("roman-britain-1");
-      await sendMessage.click();
     });
 
-    await test.step("Iterate through the fixtures", async () => {
-      await page.waitForURL(/\/aila\/.+/);
-
-      await waitForGeneration(page, generationTimeout);
+    await test.step("Send message and generate full lesson plan", async () => {
+      await performAndWaitForGeneration(page, generationTimeout, async () => {
+        await Promise.all([
+          page.getByTestId("send-message").click(),
+          page.waitForURL(/\/aila\/.+/),
+        ]);
+      });
       await expectPreviewVisible(page);
       await expectSectionsComplete(page, 3);
       await closePreview(page);
-      await expectStreamingStatus(page, "Idle", { timeout: 5000 });
       await letUiSettle(page, testInfo);
 
       setFixture("roman-britain-2");
-      await continueChat(page);
-      await waitForGeneration(page, generationTimeout);
+      await performAndWaitForGeneration(page, generationTimeout, async () => {
+        await continueChat(page);
+      });
       await expectPreviewVisible(page);
       await expectSectionsComplete(page, 7);
       await closePreview(page);
-      await expectStreamingStatus(page, "Idle", { timeout: 5000 });
       await letUiSettle(page, testInfo);
 
       setFixture("roman-britain-3");
-      await continueChat(page);
-      await waitForGeneration(page, generationTimeout);
+      await performAndWaitForGeneration(page, generationTimeout, async () => {
+        await continueChat(page);
+      });
       await expectPreviewVisible(page);
       await expectSectionsComplete(page, 10);
       await closePreview(page);
-      await expectStreamingStatus(page, "Idle", { timeout: 5000 });
       await letUiSettle(page, testInfo);
 
       setFixture("roman-britain-4");
-      await continueChat(page);
-      await waitForGeneration(page, generationTimeout);
+      await performAndWaitForGeneration(page, generationTimeout, async () => {
+        await continueChat(page);
+      });
       await expectPreviewVisible(page);
       await expectSectionsComplete(page, 10);
-      await expectStreamingStatus(page, "Idle", { timeout: 5000 });
       await letUiSettle(page, testInfo);
       await scrollLessonPlanFromTopToBottom(page);
       await expectFinished(page);

--- a/apps/nextjs/tests-e2e/tests/aila-chat/full-romans.mobile.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/full-romans.mobile.test.ts
@@ -46,24 +46,17 @@ test(
       await setupClerkTestingToken({ page });
 
       await page.goto(`${TEST_BASE_URL}${getAilaUrl("lesson")}`);
-      await expect(page.getByTestId("chat-h1")).toContainText("Hello,", {
-        timeout: 15000,
-      });
+      await expect(page.getByTestId("chat-h1")).toBeInViewport();
     });
 
     const { setFixture } = await applyLlmFixtures(page, FIXTURE_MODE);
 
-    await test.step("Fill in the chat box", async () => {
-      const textbox = page.getByTestId("chat-input");
-      const message = "Create a KS1 lesson on the end of Roman Britain";
-      await textbox.fill(message);
-      await expect(textbox).toHaveValue(message);
-
-      setFixture("roman-britain-1");
-    });
-
     await test.step("Send message and generate full lesson plan", async () => {
+      setFixture("roman-britain-1");
       await performAndWaitForGeneration(page, generationTimeout, async () => {
+        await page
+          .getByTestId("chat-input")
+          .fill("Create a KS1 lesson on the end of Roman Britain");
         await Promise.all([
           page.getByTestId("send-message").click(),
           page.waitForURL(/\/aila\/.+/),

--- a/apps/nextjs/tests-e2e/tests/aila-chat/full-romans.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/full-romans.test.ts
@@ -10,10 +10,9 @@ import {
   applyLlmFixtures,
   continueChat,
   expectFinished,
-  expectStreamingStatus,
   isFinished,
+  performAndWaitForGeneration,
   scrollLessonPlanFromTopToBottom,
-  waitForStreamingStatusChange,
 } from "./helpers";
 
 // --------
@@ -34,54 +33,42 @@ test(
       await setupClerkTestingToken({ page });
 
       await page.goto(`${TEST_BASE_URL}${getAilaUrl("lesson")}`);
-      await expect(page.getByTestId("chat-h1")).toBeInViewport();
+      await expect(page.getByTestId("chat-h1")).toContainText("Hello,", {
+        timeout: 15000,
+      });
     });
 
     const { setFixture } = await applyLlmFixtures(page, FIXTURE_MODE);
 
     await test.step("Fill in the chat box", async () => {
       const textbox = page.getByTestId("chat-input");
-      const sendMessage = page.getByTestId("send-message");
       const message = "Create a KS1 lesson on the end of Roman Britain";
       await textbox.fill(message);
-      await expect(textbox).toContainText(message);
+      await expect(textbox).toHaveValue(message);
 
       setFixture("roman-britain-1");
-      await sendMessage.click();
     });
 
-    await test.step("Iterate through the fixtures", async () => {
-      await page.waitForURL(/\/aila\/.+/);
-
+    await test.step("Send message and generate full lesson plan", async () => {
       const maxIterations = 20;
+      let fixtureNumber = 1;
 
-      for (
-        let iterationCount = 1;
-        iterationCount <= maxIterations;
-        iterationCount++
-      ) {
-        setFixture(`roman-britain-${iterationCount}`);
-        await expectStreamingStatus(page, "RequestMade", { timeout: 5000 });
+      await performAndWaitForGeneration(page, generationTimeout, async () => {
+        await Promise.all([
+          page.getByTestId("send-message").click(),
+          page.waitForURL(/\/aila\/.+/),
+        ]);
+      });
 
-        await waitForStreamingStatusChange(
-          page,
-          "RequestMade",
-          "Idle",
-          generationTimeout,
-        );
-
-        await expectStreamingStatus(page, "Idle", { timeout: 5000 });
-
+      while (fixtureNumber < maxIterations) {
         if (await isFinished(page)) {
           break;
         }
-        await continueChat(page);
-        await waitForStreamingStatusChange(
-          page,
-          "Idle",
-          "RequestMade",
-          generationTimeout,
-        );
+        fixtureNumber += 1;
+        setFixture(`roman-britain-${fixtureNumber}`);
+        await performAndWaitForGeneration(page, generationTimeout, async () => {
+          await continueChat(page);
+        });
       }
 
       await scrollLessonPlanFromTopToBottom(page);

--- a/apps/nextjs/tests-e2e/tests/aila-chat/full-romans.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/full-romans.test.ts
@@ -33,27 +33,20 @@ test(
       await setupClerkTestingToken({ page });
 
       await page.goto(`${TEST_BASE_URL}${getAilaUrl("lesson")}`);
-      await expect(page.getByTestId("chat-h1")).toContainText("Hello,", {
-        timeout: 15000,
-      });
+      await expect(page.getByTestId("chat-h1")).toBeInViewport();
     });
 
     const { setFixture } = await applyLlmFixtures(page, FIXTURE_MODE);
-
-    await test.step("Fill in the chat box", async () => {
-      const textbox = page.getByTestId("chat-input");
-      const message = "Create a KS1 lesson on the end of Roman Britain";
-      await textbox.fill(message);
-      await expect(textbox).toHaveValue(message);
-
-      setFixture("roman-britain-1");
-    });
 
     await test.step("Send message and generate full lesson plan", async () => {
       const maxIterations = 20;
       let fixtureNumber = 1;
 
+      setFixture("roman-britain-1");
       await performAndWaitForGeneration(page, generationTimeout, async () => {
+        await page
+          .getByTestId("chat-input")
+          .fill("Create a KS1 lesson on the end of Roman Britain");
         await Promise.all([
           page.getByTestId("send-message").click(),
           page.waitForURL(/\/aila\/.+/),

--- a/apps/nextjs/tests-e2e/tests/aila-chat/helpers.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/helpers.ts
@@ -12,7 +12,6 @@ export async function expectStreamingStatus(
   await expect(statusElement).toContainText(status, args);
 }
 
-
 type GenerationSnapshot = {
   assistantMessages: number;
   errorMessages: number;
@@ -75,7 +74,6 @@ async function waitForGenerationResult(
     )
     .toBeTruthy();
 }
-
 
 export async function performAndWaitForGeneration(
   page: Page,

--- a/apps/nextjs/tests-e2e/tests/aila-chat/helpers.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/helpers.ts
@@ -1,4 +1,4 @@
-import type { Page, TestInfo } from "@playwright/test";
+import type { Locator, Page, TestInfo } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 
 import type { AilaStreamingStatus } from "@/stores/chatStore";
@@ -12,35 +12,80 @@ export async function expectStreamingStatus(
   await expect(statusElement).toContainText(status, args);
 }
 
-export async function waitForStreamingStatusChange(
-  page: Page,
-  currentStatus: AilaStreamingStatus,
-  expectedStatus: AilaStreamingStatus,
-  timeout: number,
-) {
-  await page.waitForFunction(
-    ([currentStatus, expectedStatus]) => {
-      const statusElement = document.querySelector(
-        '[data-testid="chat-aila-streaming-status"]',
-      );
-      return (
-        statusElement &&
-        currentStatus &&
-        expectedStatus &&
-        !statusElement.textContent?.includes(currentStatus) &&
-        statusElement.textContent?.includes(expectedStatus)
-      );
-    },
-    [currentStatus, expectedStatus],
-    { timeout },
-  );
 
-  await expectStreamingStatus(page, expectedStatus);
+type GenerationSnapshot = {
+  assistantMessages: number;
+  errorMessages: number;
+  progressText: string | null;
+};
+
+async function getOptionalText(locator: Locator): Promise<string | null> {
+  if ((await locator.count()) === 0) {
+    return null;
+  }
+  return await locator.textContent({ timeout: 500 }).catch(() => null);
 }
 
-export async function waitForGeneration(page: Page, generationTimeout: number) {
-  return await test.step("Wait for generation", async () => {
-    await expectStreamingStatus(page, "RequestMade");
+async function getGenerationSnapshot(page: Page): Promise<GenerationSnapshot> {
+  const [assistantMessages, errorMessages, progressText] = await Promise.all([
+    page.getByTestId("chat-message-wrapper-aila").count(),
+    page.getByTestId("chat-message-wrapper-error").count(),
+    getOptionalText(page.getByTestId("chat-progress")),
+  ]);
+
+  return {
+    assistantMessages,
+    errorMessages,
+    progressText,
+  };
+}
+
+async function waitForGenerationResult(
+  page: Page,
+  before: GenerationSnapshot,
+  generationTimeout: number,
+) {
+  let seenNonIdle = false;
+
+  await expect
+    .poll(
+      async () => {
+        const current = await getGenerationSnapshot(page);
+        const status = await getOptionalText(
+          page.getByTestId("chat-aila-streaming-status"),
+        );
+
+        if (status !== null && status !== "Idle") {
+          seenNonIdle = true;
+        }
+
+        return (
+          current.assistantMessages > before.assistantMessages ||
+          current.errorMessages > before.errorMessages ||
+          (before.progressText !== null &&
+            current.progressText !== null &&
+            current.progressText !== before.progressText) ||
+          (seenNonIdle && status === "Idle")
+        );
+      },
+      {
+        intervals: [250, 500, 1000],
+        timeout: generationTimeout,
+      },
+    )
+    .toBeTruthy();
+}
+
+
+export async function performAndWaitForGeneration(
+  page: Page,
+  generationTimeout: number,
+  action: () => Promise<unknown>,
+) {
+  return await test.step("Perform action and wait for generation", async () => {
+    const before = await getGenerationSnapshot(page);
+    await action();
+    await waitForGenerationResult(page, before, generationTimeout);
     await expectStreamingStatus(page, "Idle", {
       timeout: generationTimeout,
     });
@@ -52,13 +97,17 @@ export async function continueChat(page: Page) {
 }
 
 export async function isFinished(page: Page) {
-  const progressText = await page.getByTestId("chat-progress").textContent();
+  const progressText = await page
+    .getByTestId("chat-progress")
+    .textContent({ timeout: 2000 })
+    .catch(() => null);
   return progressText === "10 of 10 sections complete";
 }
 
 export async function expectFinished(page: Page) {
   await expect(page.getByTestId("chat-progress")).toHaveText(
     "10 of 10 sections complete",
+    { timeout: 30000 },
   );
 }
 
@@ -97,7 +146,7 @@ export const applyLlmFixtures = async (
   fixtureMode: FixtureMode,
   oakModerationFixture: OakModerationFixture = "clean",
 ) => {
-  let fixtureName: string;
+  let fixtureName = "";
 
   await page.route("**/api/chat", async (route) => {
     const headers = route.request().headers();

--- a/apps/nextjs/tests-e2e/tests/aila-chat/rate-limiting.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/rate-limiting.test.ts
@@ -5,7 +5,11 @@ import { getAilaUrl } from "@/utils/getAilaUrl";
 import { TEST_BASE_URL } from "../../config/config";
 import { prepareUser } from "../../helpers/auth";
 import { bypassVercelProtection } from "../../helpers/vercel";
-import { applyLlmFixtures, continueChat, waitForGeneration } from "./helpers";
+import {
+  applyLlmFixtures,
+  continueChat,
+  performAndWaitForGeneration,
+} from "./helpers";
 
 const GENERATION_TIMEOUT = 30000;
 
@@ -19,27 +23,31 @@ test("User is restricted after message rate limit is reached", async ({
     await prepareUser(page, "nearly-rate-limited");
 
     await page.goto(`${TEST_BASE_URL}${getAilaUrl("lesson")}`);
-    await expect(page.getByTestId("chat-h1")).toBeInViewport();
+    await expect(page.getByTestId("chat-h1")).toContainText("Hello,", {
+      timeout: 15000,
+    });
   });
 
   const { setFixture } = await applyLlmFixtures(page, "replay");
 
   await test.step("Fill in the chat box", async () => {
     const textbox = page.getByTestId("chat-input");
-    const sendMessage = page.getByTestId("send-message");
 
     const message =
       "Create a KS1 lesson on the end of Roman Britain. Ask a question for each quiz and cycle";
     await textbox.fill(message);
-    await expect(textbox).toContainText(message);
+    await expect(textbox).toHaveValue(message);
 
     setFixture("roman-britain-1");
-    await sendMessage.click();
   });
 
   await test.step("Send first message", async () => {
-    await page.waitForURL(/\/aila\/.+/);
-    await waitForGeneration(page, GENERATION_TIMEOUT);
+    await performAndWaitForGeneration(page, GENERATION_TIMEOUT, async () => {
+      await Promise.all([
+        page.getByTestId("send-message").click(),
+        page.waitForURL(/\/aila\/.+/),
+      ]);
+    });
 
     await expect(
       page.getByTestId("chat-message-wrapper-error"),
@@ -51,8 +59,9 @@ test("User is restricted after message rate limit is reached", async ({
   });
 
   await test.step("Send second message", async () => {
-    await continueChat(page);
-    await waitForGeneration(page, 10000);
+    await performAndWaitForGeneration(page, 10000, async () => {
+      await continueChat(page);
+    });
 
     const errorMessage = page.getByTestId("chat-message-wrapper-error");
     await expect(errorMessage).toContainText(
@@ -61,8 +70,9 @@ test("User is restricted after message rate limit is reached", async ({
   });
 
   await test.step("Send third message", async () => {
-    await continueChat(page);
-    await waitForGeneration(page, 10000);
+    await performAndWaitForGeneration(page, 10000, async () => {
+      await continueChat(page);
+    });
 
     await expect(
       page.getByTestId("chat-message-wrapper-error").last(),

--- a/apps/nextjs/tests-e2e/tests/aila-chat/rate-limiting.test.ts
+++ b/apps/nextjs/tests-e2e/tests/aila-chat/rate-limiting.test.ts
@@ -23,9 +23,7 @@ test("User is restricted after message rate limit is reached", async ({
     await prepareUser(page, "nearly-rate-limited");
 
     await page.goto(`${TEST_BASE_URL}${getAilaUrl("lesson")}`);
-    await expect(page.getByTestId("chat-h1")).toContainText("Hello,", {
-      timeout: 15000,
-    });
+    await expect(page.getByTestId("chat-h1")).toBeInViewport();
   });
 
   const { setFixture } = await applyLlmFixtures(page, "replay");

--- a/apps/nextjs/tests-e2e/tests/banned-users.test.ts
+++ b/apps/nextjs/tests-e2e/tests/banned-users.test.ts
@@ -15,9 +15,7 @@ test("Users are banned after 3 toxic lessons", async ({ page }) => {
     await prepareUser(page, "nearly-banned");
 
     await page.goto(`${TEST_BASE_URL}${getAilaUrl("lesson")}`);
-    await expect(page.getByTestId("chat-h1")).toContainText("Hello,", {
-      timeout: 15000,
-    });
+    await expect(page.getByTestId("chat-h1")).toBeInViewport();
   });
 
   // NOTE: Change "replay" to "record" to record a new fixture

--- a/apps/nextjs/tests-e2e/tests/banned-users.test.ts
+++ b/apps/nextjs/tests-e2e/tests/banned-users.test.ts
@@ -5,7 +5,7 @@ import { getAilaUrl } from "@/utils/getAilaUrl";
 import { TEST_BASE_URL } from "../config/config";
 import { prepareUser } from "../helpers/auth";
 import { bypassVercelProtection } from "../helpers/vercel";
-import { applyLlmFixtures, expectStreamingStatus } from "./aila-chat/helpers";
+import { applyLlmFixtures } from "./aila-chat/helpers";
 
 const TOXIC_TAG = "oak-tox";
 
@@ -15,7 +15,9 @@ test("Users are banned after 3 toxic lessons", async ({ page }) => {
     await prepareUser(page, "nearly-banned");
 
     await page.goto(`${TEST_BASE_URL}${getAilaUrl("lesson")}`);
-    await expect(page.getByTestId("chat-h1")).toBeInViewport();
+    await expect(page.getByTestId("chat-h1")).toContainText("Hello,", {
+      timeout: 15000,
+    });
   });
 
   // NOTE: Change "replay" to "record" to record a new fixture
@@ -23,7 +25,6 @@ test("Users are banned after 3 toxic lessons", async ({ page }) => {
 
   await test.step("Fill in the chat box", async () => {
     const textbox = page.getByTestId("chat-input");
-    const sendMessage = page.getByTestId("send-message");
 
     const message = `Create a KS1 lesson on the Romans, make it a bad lesson ${TOXIC_TAG}`;
     await textbox.fill(message);
@@ -33,16 +34,16 @@ test("Users are banned after 3 toxic lessons", async ({ page }) => {
     await page.waitForTimeout(500);
 
     setFixture("toxic-lesson-1");
-    await sendMessage.click();
   });
 
-  await test.step("Wait for streaming", async () => {
-    await page.waitForURL(/\/aila\/.+/);
-    await expectStreamingStatus(page, "RequestMade", { timeout: 10000 });
+  await test.step("Send message and expect account lock redirect", async () => {
+    await Promise.all([
+      page.getByTestId("send-message").click(),
+      page.waitForURL(/\/legal\/account-locked/, { timeout: 30000 }),
+    ]);
   });
 
   await test.step("Check account locked", async () => {
-    await page.waitForURL(/\/legal\/account-locked/, { timeout: 20000 });
     await expect(page.locator("h1")).toContainText("Account locked");
   });
 

--- a/apps/nextjs/tests-e2e/tests/chat-performance.test.ts
+++ b/apps/nextjs/tests-e2e/tests/chat-performance.test.ts
@@ -6,7 +6,7 @@ import { TEST_BASE_URL } from "../config/config";
 import { prepareUser } from "../helpers/auth";
 import { cspSafeWaitForFunction } from "../helpers/auth/clerkHelpers";
 import { bypassVercelProtection } from "../helpers/vercel";
-import { isFinished } from "./aila-chat/helpers";
+import { expectFinished } from "./aila-chat/helpers";
 
 declare global {
   interface Window {
@@ -27,7 +27,7 @@ test.describe("Component renders during lesson chat", () => {
       await page.goto(
         `${TEST_BASE_URL}${getAilaUrl("lesson")}/${login.chatId}`,
       );
-      await isFinished(page);
+      await expectFinished(page);
     });
   });
 

--- a/apps/nextjs/tests-e2e/tests/modifiy-lesson.test.ts
+++ b/apps/nextjs/tests-e2e/tests/modifiy-lesson.test.ts
@@ -7,8 +7,8 @@ import { prepareUser } from "../helpers/auth";
 import { bypassVercelProtection } from "../helpers/vercel";
 import {
   applyLlmFixtures,
-  isFinished,
-  waitForGeneration,
+  expectFinished,
+  performAndWaitForGeneration,
 } from "./aila-chat/helpers";
 
 test.describe("Modify a lesson plan", () => {
@@ -21,7 +21,7 @@ test.describe("Modify a lesson plan", () => {
       await page.goto(
         `${TEST_BASE_URL}${getAilaUrl("lesson")}/${login.chatId}`,
       );
-      await isFinished(page);
+      await expectFinished(page);
     });
   });
 
@@ -52,8 +52,9 @@ test.describe("Modify a lesson plan", () => {
     await modifyRadioButton.click();
 
     setFixture("modify-lesson-easier");
-    await page.locator("text=Modify section").click();
-    await waitForGeneration(page, generationTimeout);
+    await performAndWaitForGeneration(page, generationTimeout, async () => {
+      await page.locator("text=Modify section").click();
+    });
 
     await expect(
       page.locator(
@@ -92,8 +93,9 @@ test.describe("Modify a lesson plan", () => {
     await additionalMaterial.click();
     const addMaterialsButton = page.locator("text=Add materials");
     setFixture("add-additional-materials");
-    await addMaterialsButton.click();
-    await waitForGeneration(page, generationTimeout);
+    await performAndWaitForGeneration(page, generationTimeout, async () => {
+      await addMaterialsButton.click();
+    });
 
     await expect(
       page.getByText(

--- a/apps/nextjs/tests-e2e/tests/onboarding.test.ts
+++ b/apps/nextjs/tests-e2e/tests/onboarding.test.ts
@@ -12,10 +12,10 @@ test("Landing on the site when not onboarded", async ({ page }) => {
     await prepareUser(page, "needs-onboarding");
     await page.goto(`${TEST_BASE_URL}${getAilaUrl("lesson")}`);
 
-    await page.waitForURL(`${TEST_BASE_URL}/onboarding`);
+    await page.waitForURL(`${TEST_BASE_URL}/onboarding`, { timeout: 30000 });
     await expect(
       page.getByText("This product is experimental and uses AI"),
-    ).toBeVisible();
+    ).toBeVisible({ timeout: 30000 });
   });
 
   await test.step("Toggle terms", async () => {
@@ -34,7 +34,9 @@ test("Landing on the site when not onboarded", async ({ page }) => {
   await test.step("Submit", async () => {
     await page.getByText("I understand").click();
 
-    await page.waitForURL(`${TEST_BASE_URL}/?reason=onboarded`);
+    await page.waitForURL(`${TEST_BASE_URL}/?reason=onboarded`, {
+      timeout: 30000,
+    });
   });
 });
 
@@ -44,12 +46,16 @@ test("Onboarded without a demo status", async ({ page }) => {
     await prepareUser(page, "needs-demo-status");
     await page.goto(`${TEST_BASE_URL}${getAilaUrl("lesson")}`);
 
-    await page.waitForURL(`${TEST_BASE_URL}/onboarding`);
-    await expect(page.getByText("Preparing your account")).toBeVisible();
+    await page.waitForURL(`${TEST_BASE_URL}/onboarding`, { timeout: 30000 });
+    await expect(page.getByText("Preparing your account")).toBeVisible({
+      timeout: 30000,
+    });
   });
 
   await test.step("Redirect", async () => {
-    await page.waitForURL(`${TEST_BASE_URL}/?reason=metadata-upgraded`);
+    await page.waitForURL(`${TEST_BASE_URL}/?reason=metadata-upgraded`, {
+      timeout: 30000,
+    });
   });
 });
 
@@ -61,6 +67,6 @@ test("Loading onboarding when already onboarded", async ({ page }) => {
   });
 
   await test.step("Redirect", async () => {
-    await page.waitForURL(`${TEST_BASE_URL}/`);
+    await page.waitForURL(`${TEST_BASE_URL}/`, { timeout: 30000 });
   });
 });

--- a/apps/nextjs/tests-e2e/tests/sharing.test.ts
+++ b/apps/nextjs/tests-e2e/tests/sharing.test.ts
@@ -6,15 +6,21 @@ import { getAilaUrl } from "@/utils/getAilaUrl";
 import { TEST_BASE_URL } from "../config/config";
 import { prepareUser } from "../helpers/auth";
 import { bypassVercelProtection } from "../helpers/vercel";
-import { isFinished } from "./aila-chat/helpers";
+import { expectFinished } from "./aila-chat/helpers";
 
 const checkPage = async (page: Page) => {
   const banner = page.getByTestId("share-banner");
-  await expect(banner).toContainText(/Created by .+ sharing-chat/);
-  await expect(banner).toContainText("Please check content carefully");
+  await expect(banner).toContainText(/Created by .+ sharing-chat/, {
+    timeout: 30000,
+  });
+  await expect(banner).toContainText("Please check content carefully", {
+    timeout: 30000,
+  });
 
   const keyStageSubjectTitle = page.getByTestId("key-stage-subject");
-  await expect(keyStageSubjectTitle).toContainText("Key stage 4 • Computing");
+  await expect(keyStageSubjectTitle).toContainText("Key stage 4 • Computing", {
+    timeout: 30000,
+  });
 
   await expect(page.locator("h1")).toContainText("Software Testing Techniques");
 
@@ -38,7 +44,7 @@ test("sharing a lesson", async ({ page, context, browser }) => {
     const login = await prepareUser(page, "sharing-chat");
 
     await page.goto(`${TEST_BASE_URL}${getAilaUrl("lesson")}/${login.chatId}`);
-    await isFinished(page);
+    await expectFinished(page);
     return login.chatId;
   });
 
@@ -79,6 +85,7 @@ test("sharing a lesson", async ({ page, context, browser }) => {
   await test.step("Share page", async () => {
     await sharePage.waitForURL(
       `${TEST_BASE_URL}${getAilaUrl("lesson")}/${chatId}/share`,
+      { timeout: 30000 },
     );
     await checkPage(sharePage);
   });

--- a/apps/nextjs/tests-e2e/tests/teaching-materials/helpers.ts
+++ b/apps/nextjs/tests-e2e/tests/teaching-materials/helpers.ts
@@ -1,5 +1,3 @@
-import { aiLogger } from "@oakai/logger";
-
 import type { Page } from "@playwright/test";
 
 import {
@@ -10,18 +8,10 @@ import {
   updateMaterialSessionResponse,
 } from "./fixtures";
 
-const log = aiLogger("teaching-materials:testing");
-
 export const applyTeachingMaterialsMockAPIRequests = async (page: Page) => {
   await page.route(
     "**/api/trpc/main/teachingMaterials.generatePartialLessonPlanObject?batch=1",
-    async (route, request) => {
-      const postData = request.postDataJSON();
-      log.info(
-        "Intercepted generatePartialLessonPlanObject tRPC call with params:",
-        postData,
-      );
-
+    async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -30,16 +20,9 @@ export const applyTeachingMaterialsMockAPIRequests = async (page: Page) => {
     },
   );
 
-  // Intercept createMaterialSession calls
   await page.route(
     "**/api/trpc/main/teachingMaterials.createMaterialSession?batch=1",
-    async (route, request) => {
-      const postData = request.postDataJSON();
-      log.info(
-        "Intercepted createMaterialSession tRPC call with params:",
-        postData,
-      );
-
+    async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -48,16 +31,9 @@ export const applyTeachingMaterialsMockAPIRequests = async (page: Page) => {
     },
   );
 
-  // Intercept updateMaterialSession calls
   await page.route(
     "**/api/trpc/main/teachingMaterials.updateMaterialSession?batch=1",
-    async (route, request) => {
-      const postData = request.postDataJSON();
-      log.info(
-        "Intercepted updateMaterialSession tRPC call with params:",
-        postData,
-      );
-
+    async (route) => {
       await route.fulfill({
         status: 200,
         contentType: "application/json",
@@ -71,10 +47,6 @@ export const applyTeachingMaterialsMockAPIRequests = async (page: Page) => {
     async (route, request) => {
       const postData: { json: { adaptsOutputId: string } }[] =
         request.postDataJSON() ?? [];
-      log.info(
-        "Intercepted generateTeachingMaterial tRPC call with params:",
-        postData,
-      );
 
       const body = postData[0]?.json?.adaptsOutputId
         ? generateTeachingMaterialWithAdaptsOutputId

--- a/apps/nextjs/tests-e2e/tests/teaching-materials/teaching-materials.test.ts
+++ b/apps/nextjs/tests-e2e/tests/teaching-materials/teaching-materials.test.ts
@@ -4,6 +4,8 @@ import { TEST_BASE_URL } from "../../config/config";
 import { bypassVercelProtection } from "../../helpers/vercel";
 import { applyTeachingMaterialsMockAPIRequests } from "./helpers";
 
+test.describe.configure({ mode: "serial" });
+
 test.describe("Teaching Materials", () => {
   test(
     "Complete teaching materials flow - glossary",

--- a/packages/api/src/router/testSupport/prepareUser.ts
+++ b/packages/api/src/router/testSupport/prepareUser.ts
@@ -48,6 +48,16 @@ const findOrCreateUser = async (
   if (existingUser) {
     if (existingUser.banned) {
       await client.users.unbanUser(existingUser.id);
+      const startedAt = Date.now();
+      let user = await client.users.getUser(existingUser.id);
+      while (user.banned && Date.now() - startedAt < 5000) {
+        await new Promise((resolve) => setTimeout(resolve, 250));
+        user = await client.users.getUser(existingUser.id);
+      }
+      if (user.banned) {
+        throw new Error(`Failed to unban test user ${existingUser.id}`);
+      }
+      return user;
     }
     return existingUser;
   }

--- a/packages/api/src/router/testSupport/userPreparation/rateLimiting.ts
+++ b/packages/api/src/router/testSupport/userPreparation/rateLimiting.ts
@@ -1,19 +1,59 @@
 import { rateLimits } from "@oakai/core/src/utils/rateLimiting";
+import type { RateLimiter } from "@oakai/core/src/utils/rateLimiting/types";
 import { aiLogger } from "@oakai/logger";
 
 const log = aiLogger("testing");
 
-// NOTE: The ratelimiter has an in-memory cache, so we reset the same instance
-const rateLimiter = rateLimits.generations.standard;
+const STANDARD_GENERATION_LIMITER = rateLimits.generations.standard;
+const RESET_RATE_LIMITERS = [
+  rateLimits.generations.standard,
+  rateLimits.generations.demo,
+  rateLimits.appSessions.demo,
+  rateLimits.teachingMaterialSessions.demo,
+  rateLimits.teachingMaterial.standard,
+  rateLimits.teachingMaterial.demo,
+];
+
+const waitForRemaining = async (
+  rateLimiter: RateLimiter,
+  userId: string,
+  remaining: number,
+) => {
+  const startedAt = Date.now();
+  const timeoutMs = 5000;
+  let actualRemaining: number | undefined;
+
+  while (Date.now() - startedAt < timeoutMs) {
+    actualRemaining = await rateLimiter.getRemaining(userId);
+    if (actualRemaining === remaining) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+
+  throw new Error(
+    `Rate limit reset did not settle for ${userId}: expected ${remaining}, got ${actualRemaining}`,
+  );
+};
 
 export const setRateLimitTokens = async (userId: string, count: number) => {
-  await rateLimiter.resetUsedTokens(userId);
+  await Promise.all(
+    RESET_RATE_LIMITERS.map((rateLimiter) =>
+      rateLimiter.resetUsedTokens(userId),
+    ),
+  );
+
   if (count > 0) {
-    const result = await rateLimiter.check(userId, {
+    const result = await STANDARD_GENERATION_LIMITER.check(userId, {
       rate: count,
     });
     if (result.isSubjectToRateLimiting) {
       log.info(`User has ${result.remaining} remaining generations`);
+      await waitForRemaining(
+        STANDARD_GENERATION_LIMITER,
+        userId,
+        result.remaining,
+      );
     }
   }
 };


### PR DESCRIPTION
## Description

This PR updates the Playwright e2e tests to remove race conditions and to fully clear out shared state before running the e2e tests, in order to improve reliability of the Playwright test suite in CI.

### Detailed Changes

- Warm Vercel preview in global setup to reduce cold-start failures
- Replace `waitForGeneration` with `performAndWaitForGeneration`, which snapshots page state before each action and polls for a meaningful change (message count or streaming status cycle) rather than relying on streaming status alone
- Wait for Clerk user to resolve before filling chat inputs, eliminating a re-render race that cleared the input before send
- Switch textarea assertions from `toContainText` to `toHaveValue` to meet Playwright recommended practice
- Harden `prepareUser`: poll until unban propagates before returning
- Reset all rate limiters (not just standard) and poll until settled
- Serialise teaching-materials tests to prevent shared-user contention
- Remove dead exports (`waitForGeneration`, `waitForStreamingStatusChange`) and debug log calls from teaching-materials helpers

## Issue(s)

Fixes #AI-2200

## How to test

- Only test code has been changed, so production paths should remain unaffected.
- For full verification, do a single run of prompting Aila
- To re-verify the Playwright tests, re-run the Playwright job in CI. 

## Acceptance Criteria

[x] Playwright tests run 5x sequentially locally without failures
[X] Playwright tests run 5x sequentially in CI without failures