### PR TITLE
fix: [AI-2162] stop empty moderation requests and fix stream completion edge cases

### DIFF
--- a/packages/aila/src/core/chat/AilaStreamHandler.test.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.test.ts
@@ -245,6 +245,21 @@ describe("AilaStreamHandler", () => {
     });
   });
 
+  it("enqueues an error message when ailaTurn throws (agentic)", async () => {
+    mockedAilaTurn.mockRejectedValue(new Error("ailaTurn threw unexpectedly"));
+
+    const chat = createMockChat({ useAgenticAila: true });
+    const handler = new AilaStreamHandler(chat as never);
+
+    await consumeStream(handler.startStreaming());
+
+    expect(chat.complete).not.toHaveBeenCalled();
+    expect(chat.enqueue).toHaveBeenCalledWith({
+      type: "error",
+      value: "Something went wrong. Please try sending your message again.",
+    });
+  });
+
   it("shows a retry error and skips generation when non-agentic threat detection fails", async () => {
     const detectorError = new Error("Threat detector unavailable");
     const threatDetector = createThreatDetector(
@@ -537,6 +552,43 @@ describe("AilaStreamHandler", () => {
     });
   });
 
+  it("calls generationFailed and skips complete when non-agentic stream errors", async () => {
+    const chat = createMockChat({ useAgenticAila: false });
+    // Override: stream throws immediately
+    chat.createChatCompletionObjectStream = jest
+      .fn()
+      .mockRejectedValue(new Error("LLM stream failed"));
+    // Override: generationFailed must update status so shouldComplete becomes false
+    chat.generationFailed = jest.fn().mockImplementation(() => {
+      if (chat.generation) {
+        (chat.generation as { status: string }).status = "FAILED";
+      }
+      return Promise.resolve();
+    });
+
+    const handler = new AilaStreamHandler(chat as never);
+    await consumeStream(handler.startStreaming());
+
+    expect(chat.generationFailed).toHaveBeenCalledTimes(1);
+    expect(chat.complete).not.toHaveBeenCalled();
+  });
+
+  it("skips complete when generationFailed rejects", async () => {
+    const chat = createMockChat({ useAgenticAila: false });
+    chat.createChatCompletionObjectStream = jest
+      .fn()
+      .mockRejectedValue(new Error("LLM stream failed"));
+    chat.generationFailed = jest
+      .fn()
+      .mockRejectedValue(new Error("generationFailed failed"));
+
+    const handler = new AilaStreamHandler(chat as never);
+    await consumeStream(handler.startStreaming());
+
+    expect(chat.generationFailed).toHaveBeenCalledTimes(1);
+    expect(chat.complete).not.toHaveBeenCalled();
+  });
+
   it("keeps non-agentic completion behavior unchanged", async () => {
     const chat = createMockChat({ useAgenticAila: false });
     const handler = new AilaStreamHandler(chat as never);
@@ -551,5 +603,17 @@ describe("AilaStreamHandler", () => {
       type: "comment",
       value: "CHAT_COMPLETE",
     });
+  });
+
+  it("skips completion when the abort controller is signalled (client disconnect)", async () => {
+    const abortController = new AbortController();
+    const chat = createMockChat({ useAgenticAila: false });
+    // Abort before streaming starts so readFromStream exits immediately
+    abortController.abort();
+
+    const handler = new AilaStreamHandler(chat as never);
+    await consumeStream(handler.startStreaming(abortController));
+
+    expect(chat.complete).not.toHaveBeenCalled();
   });
 });

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -64,7 +64,20 @@ export class AilaStreamHandler {
       start: (controller) => {
         this.stream(controller, abortController).catch((error) => {
           log.error("Error in stream:", error);
-          controller.error(error);
+          try {
+            controller.error(error);
+          } catch (e) {
+            if (
+              e instanceof TypeError &&
+              (e as NodeJS.ErrnoException).code === "ERR_INVALID_STATE"
+            ) {
+              log.info(
+                "Controller already terminated before error could be signalled",
+              );
+            } else {
+              throw e;
+            }
+          }
         });
       },
     });
@@ -186,6 +199,9 @@ export class AilaStreamHandler {
         await this.span("read-from-stream", async () => {
           await this.readFromStream(abortController);
         });
+        if (abortController?.signal.aborted) {
+          skipCompletion = true;
+        }
       }
 
       log.info(
@@ -196,6 +212,16 @@ export class AilaStreamHandler {
     } catch (e) {
       if (this._chat.aila.options.useAgenticAila) {
         agenticTurnOutcome = { status: "failed" };
+        // ailaTurn threw rather than returning; its internal failure path never
+        // completed, so the client has not received an error message.
+        await this._chat.enqueue({
+          type: "error",
+          value: "Something went wrong. Please try sending your message again.",
+        });
+      } else if (this._chat.generation) {
+        // Sets status → FAILED so the finally block skips complete() (and moderation).
+        skipCompletion = true;
+        await this._chat.generationFailed(e);
       }
       log.info("Caught error in stream", {
         error: e,

--- a/packages/aila/src/features/moderation/AilaModeration.ts
+++ b/packages/aila/src/features/moderation/AilaModeration.ts
@@ -206,6 +206,11 @@ export class AilaModeration implements AilaModerationFeature {
     }
 
     const contentString = JSON.stringify(content);
+    if (!contentString || contentString === "{}") {
+      log.info("Skipping moderation - document content is empty");
+      return { categories: [] };
+    }
+
     const moderationContext = {
       sessionId: this._aila.chatId,
       messageId,

--- a/packages/aila/src/features/moderation/index.test.ts
+++ b/packages/aila/src/features/moderation/index.test.ts
@@ -97,7 +97,7 @@ describe("AilaModeration", () => {
         userId: "456",
         messages,
       };
-      const content = {};
+      const content = { title: "Test Lesson" };
 
       const { ailaModeration, pluginContext } = setUpModeration({
         document: {
@@ -140,7 +140,7 @@ describe("AilaModeration", () => {
         userId: "user-1",
         messages,
       };
-      const content = {};
+      const content = { title: "Test Lesson" };
 
       const { ailaModeration, pluginContext } = setUpModeration({
         document: {
@@ -160,6 +160,41 @@ describe("AilaModeration", () => {
         sessionId: "session-1",
         messageId: "assistant-message-1",
       });
+    });
+
+    it("should skip moderation call when document content is empty", async () => {
+      const moderationResult: ModerationResult = {
+        categories: ["l/strong-language"],
+        justification: "Test justification",
+      };
+      const moderator = new MockModerator([moderationResult]);
+      const moderateSpy = jest.spyOn(moderator, "moderate");
+
+      const messages: Message[] = [
+        { id: "1", role: "user", content: "test user message" },
+        { id: "2", role: "assistant", content: "test assistant message" },
+      ];
+      const chat = {
+        id: "123",
+        userId: "456",
+        messages,
+      };
+      const content = {};
+
+      const { ailaModeration, pluginContext } = setUpModeration({
+        document: { content },
+        chat,
+        moderator,
+      });
+
+      const result = await ailaModeration.moderate({
+        messages,
+        content,
+        pluginContext,
+      });
+
+      expect(moderateSpy).not.toHaveBeenCalled();
+      expect(result).toEqual({ type: "moderation", categories: [] });
     });
 
     it("should skip moderation when there are no user messages", async () => {
@@ -285,7 +320,7 @@ describe("AilaModeration", () => {
         onToxicModeration: jest.fn(() => {}),
       } as unknown as AilaPlugin;
 
-      const document = { content: {} };
+      const document = { content: { title: "Test Lesson" } };
       const { ailaModeration, pluginContext } = setUpModeration({
         document,
         chat,
@@ -333,7 +368,7 @@ describe("AilaModeration", () => {
         onHighlySensitiveModeration: jest.fn(() => {}),
       } as unknown as AilaPlugin;
 
-      const document = { content: {} };
+      const document = { content: { title: "Test Lesson" } };
       const { ailaModeration, pluginContext } = setUpModeration({
         document,
         chat,
@@ -382,7 +417,7 @@ describe("AilaModeration", () => {
         onToxicModeration: jest.fn(() => {}),
       } as unknown as AilaPlugin;
 
-      const document = { content: {} };
+      const document = { content: { title: "Test Lesson" } };
       const { ailaModeration, pluginContext } = setUpModeration({
         document,
         chat,


### PR DESCRIPTION
## Description

- **Prevents empty moderation requests**: `performModeration()` now skips the moderation service call when `document.content` is `{}`. The service was receiving empty requests and responding invalidly. Mock override codes (`oak-hs`, `oak-tox`) are unaffected as they are checked before this guard.

- **Prevents non-agentic stream errors calling `complete()`**: `generationFailed()` is now called from the error path, ensuring `complete()` (and moderation) don't run after a stream failure

- **Stops client abort being persisted as `SUCCESS`**: `readFromStream` now sets `skipCompletion = true` immediately after a client aborts (e.g. by closing a tab during a stream), preventing an empty document from being persisted

- **Prevents unhandled `controller.error()` rejection**: The `.catch()` in `startStreaming` could throw`ERR_INVALID_STATE` if the controller was already closed by the `finally` block - added a try/catch to prevent this behaviour.

- **Agentic silent failure**: When `ailaTurn` throws (rather than returning `{ status: "failed" }`), the client received no error message. Now one is enqueued explicitly.

## Automated test plan

- [X] `pnpm --filter @oakai/aila test -- --testPathPatterns="AilaStreamHandler|moderation/index"` — 23 tests pass

## Issue(s)

Fixes #AI-2162

## How to test

1. No manual test plan for the specific changes. All fixes cover rare error paths that are not reproducible through the UI. Verification is via the unit test suite (23 tests) and code review. 
2. We should verify the happy path is unaffected - Aila lesson generation should operate as usual for typical scenarios. 