### PR TITLE
refactor: deduplicate agentic scoring harnesses and maths quiz handlers

### DIFF
--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -301,7 +301,6 @@ export class AilaStreamHandler {
       (
         quizType: "/starterQuiz" | "/exitQuiz",
         quizNoun: string,
-        article: string,
       ): SectionAgent<LatestQuiz>["handler"] =>
       async (ctx) => {
         try {
@@ -329,7 +328,7 @@ export class AilaStreamHandler {
           log.error(`Error generating ${quizNoun}`, { error });
           return {
             error: {
-              message: `Failed to generate ${article} ${quizNoun} with maths quiz engine`,
+              message: `Failed to generate a ${quizNoun} with maths quiz engine`,
             },
           };
         }
@@ -366,13 +365,8 @@ export class AilaStreamHandler {
             "starterQuiz--maths": buildMathsQuizHandler(
               "/starterQuiz",
               "starter quiz",
-              "a",
             ),
-            "exitQuiz--maths": buildMathsQuizHandler(
-              "/exitQuiz",
-              "exit quiz",
-              "an",
-            ),
+            "exitQuiz--maths": buildMathsQuizHandler("/exitQuiz", "exit quiz"),
           },
         }),
         messageToUserAgent: createOpenAIMessageToUserAgent(openai),

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -14,7 +14,11 @@ import { createSectionAgentRegistry } from "../../lib/agentic-system/agents/sect
 import { ailaTurn } from "../../lib/agentic-system/ailaTurn";
 import { createAilaTurnCallbacks } from "../../lib/agentic-system/compatibility/ailaTurnCallbacks";
 import { deriveQuizBuildMode } from "../../lib/agentic-system/quizOperations/deriveQuizBuildMode";
-import type { AilaTurnOutcome } from "../../lib/agentic-system/types";
+import type {
+  AilaTurnOutcome,
+  SectionAgent,
+} from "../../lib/agentic-system/types";
+import type { LatestQuiz } from "../../protocol/schema";
 import { extractPromptTextFromMessages } from "../../utils/extractPromptTextFromMessages";
 import { handleThreatDetectionResult } from "../../utils/threatDetection/threatDetectionHandling";
 import { AilaChatError } from "../AilaError";
@@ -284,6 +288,46 @@ export class AilaStreamHandler {
       controller: this._controller!,
     });
 
+    // starterQuiz and exitQuiz only differ by quiz path and the words used in
+    // their messages; everything else is the same maths-engine build flow.
+    const buildMathsQuizHandler =
+      (
+        quizType: "/starterQuiz" | "/exitQuiz",
+        quizNoun: string,
+        article: string,
+      ): SectionAgent<LatestQuiz>["handler"] =>
+      async (ctx) => {
+        try {
+          const userInstructions =
+            ctx.currentTurn.currentStep?.sectionInstructions;
+          const mode = deriveQuizBuildMode(ctx.currentTurn.currentStep);
+          const tracker = createQuizTracker();
+          const { quiz, note } = await tracker.run(async (task, reportId) => {
+            const result = await this._chat.quizService.buildQuiz(
+              quizType,
+              ctx.currentTurn.document,
+              this._chat.relevantLessons ?? [],
+              task,
+              reportId,
+              mode,
+              userInstructions,
+            );
+            task.addData({ quiz: result.quiz, mode, userInstructions });
+            return result;
+          });
+          await ReportStorage.store(tracker.getReport());
+
+          return { error: null, data: quiz, note };
+        } catch (error) {
+          log.error(`Error generating ${quizNoun}`, { error });
+          return {
+            error: {
+              message: `Failed to generate ${article} ${quizNoun} with maths quiz engine`,
+            },
+          };
+        }
+      };
+
     let relevantLessonsPopulated: Awaited<
       ReturnType<typeof getRagLessonPlansByIds>
     > = [];
@@ -312,82 +356,16 @@ export class AilaStreamHandler {
         sectionAgents: createSectionAgentRegistry({
           openai,
           customAgentHandlers: {
-            "starterQuiz--maths": async (ctx) => {
-              try {
-                const userInstructions =
-                  ctx.currentTurn.currentStep?.sectionInstructions;
-                const mode = deriveQuizBuildMode(ctx.currentTurn.currentStep);
-                const tracker = createQuizTracker();
-                const { quiz, note } = await tracker.run(
-                  async (task, reportId) => {
-                    const result = await this._chat.quizService.buildQuiz(
-                      "/starterQuiz",
-                      ctx.currentTurn.document,
-                      this._chat.relevantLessons ?? [],
-                      task,
-                      reportId,
-                      mode,
-                      userInstructions,
-                    );
-                    task.addData({
-                      quiz: result.quiz,
-                      mode,
-                      userInstructions,
-                    });
-                    return result;
-                  },
-                );
-                await ReportStorage.store(tracker.getReport());
-
-                return { error: null, data: quiz, note };
-              } catch (error) {
-                log.error("Error generating starter quiz", { error });
-                return {
-                  error: {
-                    message:
-                      "Failed to generate a starter quiz with maths quiz engine",
-                  },
-                };
-              }
-            },
-            "exitQuiz--maths": async (ctx) => {
-              try {
-                const userInstructions =
-                  ctx.currentTurn.currentStep?.sectionInstructions;
-                const mode = deriveQuizBuildMode(ctx.currentTurn.currentStep);
-                const tracker = createQuizTracker();
-                const { quiz, note } = await tracker.run(
-                  async (task, reportId) => {
-                    const result = await this._chat.quizService.buildQuiz(
-                      "/exitQuiz",
-                      ctx.currentTurn.document,
-                      this._chat.relevantLessons ?? [],
-                      task,
-                      reportId,
-                      mode,
-                      userInstructions,
-                    );
-                    task.addData({
-                      quiz: result.quiz,
-                      mode,
-                      userInstructions,
-                    });
-                    return result;
-                  },
-                );
-                await ReportStorage.store(tracker.getReport());
-
-                return { error: null, data: quiz, note };
-              } catch (error) {
-                log.error("Error generating exit quiz", { error });
-                return {
-                  error: {
-                    message:
-                      "Failed to generate an exit quiz with maths quiz engine",
-                  },
-                };
-              }
-            },
+            "starterQuiz--maths": buildMathsQuizHandler(
+              "/starterQuiz",
+              "starter quiz",
+              "a",
+            ),
+            "exitQuiz--maths": buildMathsQuizHandler(
+              "/exitQuiz",
+              "exit quiz",
+              "an",
+            ),
           },
         }),
         messageToUserAgent: createOpenAIMessageToUserAgent(openai),

--- a/packages/aila/src/lib/agentic-system/scoring/evalHarness.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/evalHarness.ts
@@ -1,0 +1,126 @@
+/* eslint-disable no-console */
+
+/**
+ * Shared scaffolding for the scoring eval harnesses (scoreMathsComposer,
+ * scorePlannerQuizIntent). Each harness supplies its own cells, per-run scorer
+ * and formatters; the run loop, markdown report and YAML output are the same.
+ */
+import fs from "fs";
+import path from "path";
+import YAML from "yaml";
+
+/** Minimum shape every scored run shares. */
+export type ScoredRun = {
+  pass: boolean;
+  reasons: string[];
+};
+
+/** Minimum shape every eval cell shares. */
+export type EvalCellBase = {
+  id: string;
+  description: string;
+  passThreshold: number;
+};
+
+export type ScoredCell<TRun extends ScoredRun> = {
+  cellId: string;
+  description: string;
+  passThreshold: number;
+  passRate: number;
+  runs: TRun[];
+};
+
+/** Run every cell `runsPerCell` times, logging progress and computing pass rates. */
+export async function runEvalCells<
+  TCell extends EvalCellBase,
+  TRun extends ScoredRun,
+>(
+  cells: TCell[],
+  runsPerCell: number,
+  runOnce: (cell: TCell) => Promise<TRun>,
+  formatConsole: (run: TRun) => string,
+): Promise<ScoredCell<TRun>[]> {
+  const results: ScoredCell<TRun>[] = [];
+  for (const cell of cells) {
+    console.log(`\n--- ${cell.id} (${runsPerCell} runs) ---`);
+    const runs: TRun[] = [];
+    for (let i = 0; i < runsPerCell; i++) {
+      const run = await runOnce(cell);
+      console.log(
+        `  Run ${i + 1} ${run.pass ? "✓" : "🚩"} ${formatConsole(run)}`,
+      );
+      runs.push(run);
+    }
+    const passRate = runs.filter((r) => r.pass).length / runs.length;
+    results.push({
+      cellId: cell.id,
+      description: cell.description,
+      passThreshold: cell.passThreshold,
+      passRate,
+      runs,
+    });
+  }
+  return results;
+}
+
+/** Build the markdown report: a summary table plus per-cell run details. */
+export function generateReport<TRun extends ScoredRun>(
+  title: string,
+  results: ScoredCell<TRun>[],
+  runsPerCell: number,
+  formatActual: (run: TRun) => string,
+): string {
+  const lines: string[] = [];
+  lines.push(`# ${title}`);
+  lines.push("");
+  lines.push(`Generated: ${new Date().toISOString()}`);
+  lines.push(`Runs per cell: ${runsPerCell}`);
+  lines.push("");
+  lines.push("| Cell | Threshold | Pass rate | Status |");
+  lines.push("|------|-----------|-----------|--------|");
+  for (const r of results) {
+    const meets = r.passRate >= r.passThreshold;
+    const status = r.passThreshold === 0 ? "📊 baseline" : meets ? "✓" : "🚩";
+    lines.push(
+      `| ${r.cellId} | ${(r.passThreshold * 100).toFixed(0)}% | ${(r.passRate * 100).toFixed(0)}% | ${status} |`,
+    );
+  }
+  lines.push("");
+  for (const r of results) {
+    lines.push(`### ${r.cellId} — ${r.description}`);
+    lines.push("");
+    for (let i = 0; i < r.runs.length; i++) {
+      const run = r.runs[i]!;
+      const icon = run.pass ? "✓" : "🚩";
+      const reasonStr = run.reasons.length
+        ? ` — ${run.reasons.join("; ")}`
+        : "";
+      lines.push(`- Run ${i + 1} ${icon} ${formatActual(run)}${reasonStr}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/** Serialise results to the scores YAML file, delegating per-run shape to the caller. */
+export function writeScores<TRun extends ScoredRun>(
+  outputFile: string,
+  results: ScoredCell<TRun>[],
+  runsPerCell: number,
+  serializeRun: (run: TRun) => unknown,
+): void {
+  const yamlData = {
+    generated: new Date().toISOString(),
+    runsPerCell,
+    cells: results.map((r) => ({
+      id: r.cellId,
+      description: r.description,
+      passThreshold: r.passThreshold,
+      passRate: r.passRate,
+      runs: r.runs.map(serializeRun),
+    })),
+  };
+  fs.mkdirSync(path.dirname(outputFile), { recursive: true });
+  fs.writeFileSync(outputFile, YAML.stringify(yamlData));
+  console.log(`\nReport written to: ${outputFile}`);
+}

--- a/packages/aila/src/lib/agentic-system/scoring/evalHarness.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/evalHarness.ts
@@ -5,8 +5,8 @@
  * scorePlannerQuizIntent). Each harness supplies its own cells, per-run scorer
  * and formatters; the run loop, markdown report and YAML output are the same.
  */
-import fs from "fs";
-import path from "path";
+import fs from "node:fs";
+import path from "node:path";
 import YAML from "yaml";
 
 /** Minimum shape every scored run shares. */
@@ -71,24 +71,29 @@ export function generateReport<TRun extends ScoredRun>(
   formatActual: (run: TRun) => string,
 ): string {
   const lines: string[] = [];
-  lines.push(`# ${title}`);
-  lines.push("");
-  lines.push(`Generated: ${new Date().toISOString()}`);
-  lines.push(`Runs per cell: ${runsPerCell}`);
-  lines.push("");
-  lines.push("| Cell | Threshold | Pass rate | Status |");
-  lines.push("|------|-----------|-----------|--------|");
+  lines.push(
+    `# ${title}`,
+    "",
+    `Generated: ${new Date().toISOString()}`,
+    `Runs per cell: ${runsPerCell}`,
+    "",
+    "| Cell | Threshold | Pass rate | Status |",
+    "|------|-----------|-----------|--------|",
+  );
   for (const r of results) {
-    const meets = r.passRate >= r.passThreshold;
-    const status = r.passThreshold === 0 ? "📊 baseline" : meets ? "✓" : "🚩";
+    let status: string;
+    if (r.passThreshold === 0) {
+      status = "📊 baseline";
+    } else {
+      status = r.passRate >= r.passThreshold ? "✓" : "🚩";
+    }
     lines.push(
       `| ${r.cellId} | ${(r.passThreshold * 100).toFixed(0)}% | ${(r.passRate * 100).toFixed(0)}% | ${status} |`,
     );
   }
   lines.push("");
   for (const r of results) {
-    lines.push(`### ${r.cellId} — ${r.description}`);
-    lines.push("");
+    lines.push(`### ${r.cellId} — ${r.description}`, "");
     for (let i = 0; i < r.runs.length; i++) {
       const run = r.runs[i]!;
       const icon = run.pass ? "✓" : "🚩";

--- a/packages/aila/src/lib/agentic-system/scoring/scoreMathsComposer.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/scoreMathsComposer.ts
@@ -18,9 +18,7 @@
  *
  * Output: packages/aila/src/lib/agentic-system/scoring/scores-maths-composer.yaml
  */
-import fs from "fs";
 import path from "path";
-import YAML from "yaml";
 
 import { LLMComposer } from "../../../core/quiz/composers/LLMQuizComposer";
 import type {
@@ -31,6 +29,12 @@ import type {
 } from "../../../core/quiz/interfaces";
 import { createMockTask } from "../../../core/quiz/reporting/testing";
 import type { PartialLessonPlan, QuizPath } from "../../../protocol/schema";
+import {
+  type ScoredCell,
+  generateReport,
+  runEvalCells,
+  writeScores,
+} from "./evalHarness";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -267,14 +271,6 @@ type CellRun = {
   error?: string;
 };
 
-type CellResult = {
-  cellId: string;
-  description: string;
-  passThreshold: number;
-  passRate: number;
-  runs: CellRun[];
-};
-
 function scoreRun(cell: ComposerEvalCell, result: ComposerResult): CellRun {
   const reasons: string[] = [];
 
@@ -357,42 +353,10 @@ async function runCellOnce(cell: ComposerEvalCell): Promise<CellRun> {
 // Report
 // ---------------------------------------------------------------------------
 
-function generateReport(results: CellResult[], runsPerCell: number): string {
-  const lines: string[] = [];
-  lines.push("# Maths Composer Eval Report");
-  lines.push("");
-  lines.push(`Generated: ${new Date().toISOString()}`);
-  lines.push(`Runs per cell: ${runsPerCell}`);
-  lines.push("");
-  lines.push("| Cell | Threshold | Pass rate | Status |");
-  lines.push("|------|-----------|-----------|--------|");
-  for (const r of results) {
-    const meets = r.passRate >= r.passThreshold;
-    const status = r.passThreshold === 0 ? "📊 baseline" : meets ? "✓" : "🚩";
-    lines.push(
-      `| ${r.cellId} | ${(r.passThreshold * 100).toFixed(0)}% | ${(r.passRate * 100).toFixed(0)}% | ${status} |`,
-    );
-  }
-  lines.push("");
-  for (const r of results) {
-    lines.push(`### ${r.cellId} — ${r.description}`);
-    lines.push("");
-    for (let i = 0; i < r.runs.length; i++) {
-      const run = r.runs[i]!;
-      const icon = run.pass ? "✓" : "🚩";
-      const actual =
-        run.status === "success"
-          ? `status=success count=${run.selectedCount} uids=[${run.selectedUids.join(", ")}]`
-          : `status=bail reason="${run.bailReason ?? ""}"`;
-      const reasonStr = run.reasons.length
-        ? ` — ${run.reasons.join("; ")}`
-        : "";
-      lines.push(`- Run ${i + 1} ${icon} ${actual}${reasonStr}`);
-    }
-    lines.push("");
-  }
-  return lines.join("\n");
-}
+const formatActual = (run: CellRun): string =>
+  run.status === "success"
+    ? `status=success count=${run.selectedCount} uids=[${run.selectedUids.join(", ")}]`
+    : `status=bail reason="${run.bailReason ?? ""}"`;
 
 const OUTPUT_FILE = path.join(__dirname, "scores-maths-composer.yaml");
 const SCORE_RUNS = parseInt(process.env.SCORE_RUNS ?? "3", 10);
@@ -403,56 +367,34 @@ const SCORE_RUNS = parseInt(process.env.SCORE_RUNS ?? "3", 10);
 
 describe("Maths Composer Eval", () => {
   test(`score all cells (${SCORE_RUNS} runs each)`, async () => {
-    const results: CellResult[] = [];
+    const results: ScoredCell<CellRun>[] = await runEvalCells(
+      CELLS,
+      SCORE_RUNS,
+      runCellOnce,
+      (run) =>
+        run.status === "success"
+          ? `success count=${run.selectedCount} uids=[${run.selectedUids.join(", ")}]`
+          : `bail reason="${run.bailReason ?? run.error ?? ""}"`,
+    );
 
-    for (const cell of CELLS) {
-      console.log(`\n--- ${cell.id} (${SCORE_RUNS} runs) ---`);
-      const runs: CellRun[] = [];
-      for (let i = 0; i < SCORE_RUNS; i++) {
-        const run = await runCellOnce(cell);
-        const icon = run.pass ? "✓" : "🚩";
-        const actual =
-          run.status === "success"
-            ? `success count=${run.selectedCount} uids=[${run.selectedUids.join(", ")}]`
-            : `bail reason="${run.bailReason ?? run.error ?? ""}"`;
-        console.log(`  Run ${i + 1} ${icon} ${actual}`);
-        runs.push(run);
-      }
-      const passCount = runs.filter((r) => r.pass).length;
-      const passRate = passCount / runs.length;
-      results.push({
-        cellId: cell.id,
-        description: cell.description,
-        passThreshold: cell.passThreshold,
-        passRate,
-        runs,
-      });
-    }
+    console.log(
+      "\n" +
+        generateReport(
+          "Maths Composer Eval Report",
+          results,
+          SCORE_RUNS,
+          formatActual,
+        ),
+    );
 
-    const report = generateReport(results, SCORE_RUNS);
-    console.log("\n" + report);
-
-    const yamlData = {
-      generated: new Date().toISOString(),
-      runsPerCell: SCORE_RUNS,
-      cells: results.map((r) => ({
-        id: r.cellId,
-        description: r.description,
-        passThreshold: r.passThreshold,
-        passRate: r.passRate,
-        runs: r.runs.map((run) => ({
-          pass: run.pass,
-          reasons: run.reasons,
-          status: run.status,
-          selectedCount: run.selectedCount,
-          selectedUids: run.selectedUids,
-          ...(run.bailReason ? { bailReason: run.bailReason } : {}),
-          ...(run.error ? { error: run.error } : {}),
-        })),
-      })),
-    };
-    fs.mkdirSync(path.dirname(OUTPUT_FILE), { recursive: true });
-    fs.writeFileSync(OUTPUT_FILE, YAML.stringify(yamlData));
-    console.log(`\nReport written to: ${OUTPUT_FILE}`);
+    writeScores(OUTPUT_FILE, results, SCORE_RUNS, (run) => ({
+      pass: run.pass,
+      reasons: run.reasons,
+      status: run.status,
+      selectedCount: run.selectedCount,
+      selectedUids: run.selectedUids,
+      ...(run.bailReason ? { bailReason: run.bailReason } : {}),
+      ...(run.error ? { error: run.error } : {}),
+    }));
   }, 600_000);
 });

--- a/packages/aila/src/lib/agentic-system/scoring/scorePlannerQuizIntent.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/scorePlannerQuizIntent.ts
@@ -15,10 +15,8 @@
  *
  * Output: packages/aila/src/lib/agentic-system/scoring/scores-planner-quiz-intent.yaml
  */
-import fs from "fs";
 import OpenAI from "openai";
 import path from "path";
-import YAML from "yaml";
 
 import type {
   LatestQuiz,
@@ -28,6 +26,12 @@ import type {
 import { createOpenAIPlannerAgent } from "../agents/plannerAgent";
 import type { PlannerOutput, QuizIntent } from "../schema";
 import type { ChatMessage } from "../types";
+import {
+  type ScoredCell,
+  generateReport,
+  runEvalCells,
+  writeScores,
+} from "./evalHarness";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -263,14 +267,6 @@ type CellRun = {
   error?: string;
 };
 
-type CellResult = {
-  cellId: string;
-  description: string;
-  passThreshold: number;
-  passRate: number;
-  runs: CellRun[];
-};
-
 function findQuizStep(
   planner: PlannerOutput,
   sectionKey: "starterQuiz" | "exitQuiz",
@@ -368,43 +364,12 @@ async function runCellOnce(cell: EvalCell, openai: OpenAI): Promise<CellRun> {
 // Report
 // ---------------------------------------------------------------------------
 
-function generateReport(results: CellResult[], runsPerCell: number): string {
-  const lines: string[] = [];
-  lines.push("# Planner Quiz-Intent Eval Report");
-  lines.push("");
-  lines.push(`Generated: ${new Date().toISOString()}`);
-  lines.push(`Runs per cell: ${runsPerCell}`);
-  lines.push("");
-  lines.push("| Cell | Threshold | Pass rate | Status |");
-  lines.push("|------|-----------|-----------|--------|");
-  for (const r of results) {
-    const meets = r.passRate >= r.passThreshold;
-    const status = r.passThreshold === 0 ? "📊 baseline" : meets ? "✓" : "🚩";
-    lines.push(
-      `| ${r.cellId} | ${(r.passThreshold * 100).toFixed(0)}% | ${(r.passRate * 100).toFixed(0)}% | ${status} |`,
-    );
-  }
-  lines.push("");
-  for (const r of results) {
-    lines.push(`### ${r.cellId} — ${r.description}`);
-    lines.push("");
-    for (let i = 0; i < r.runs.length; i++) {
-      const run = r.runs[i]!;
-      const icon = run.pass ? "✓" : "🚩";
-      const actual = run.actual
-        ? `action=${run.actual.action} position=${run.actual.position}`
-        : run.error
-          ? `error=${run.error}`
-          : `decision=${run.decision}`;
-      const reasonStr = run.reasons.length
-        ? ` — ${run.reasons.join("; ")}`
-        : "";
-      lines.push(`- Run ${i + 1} ${icon} ${actual}${reasonStr}`);
-    }
-    lines.push("");
-  }
-  return lines.join("\n");
-}
+const formatActual = (run: CellRun): string =>
+  run.actual
+    ? `action=${run.actual.action} position=${run.actual.position}`
+    : run.error
+      ? `error=${run.error}`
+      : `decision=${run.decision}`;
 
 const OUTPUT_FILE = path.join(__dirname, "scores-planner-quiz-intent.yaml");
 const SCORE_RUNS = parseInt(process.env.SCORE_RUNS ?? "5", 10);
@@ -416,54 +381,34 @@ const SCORE_RUNS = parseInt(process.env.SCORE_RUNS ?? "5", 10);
 describe("Planner Quiz-Intent Eval", () => {
   test(`score all cells (${SCORE_RUNS} runs each)`, async () => {
     const openai = new OpenAI();
-    const results: CellResult[] = [];
 
-    for (const cell of CELLS) {
-      console.log(`\n--- ${cell.id} (${SCORE_RUNS} runs) ---`);
-      const runs: CellRun[] = [];
-      for (let i = 0; i < SCORE_RUNS; i++) {
-        const run = await runCellOnce(cell, openai);
-        const icon = run.pass ? "✓" : "🚩";
-        const actual = run.actual
+    const results: ScoredCell<CellRun>[] = await runEvalCells(
+      CELLS,
+      SCORE_RUNS,
+      (cell) => runCellOnce(cell, openai),
+      (run) =>
+        run.actual
           ? `${run.actual.action} pos=${run.actual.position}`
           : run.error
             ? `error: ${run.error}`
-            : `decision: ${run.decision}`;
-        console.log(`  Run ${i + 1} ${icon} ${actual}`);
-        runs.push(run);
-      }
-      const passCount = runs.filter((r) => r.pass).length;
-      const passRate = passCount / runs.length;
-      results.push({
-        cellId: cell.id,
-        description: cell.description,
-        passThreshold: cell.passThreshold,
-        passRate,
-        runs,
-      });
-    }
+            : `decision: ${run.decision}`,
+    );
 
-    const report = generateReport(results, SCORE_RUNS);
-    console.log("\n" + report);
+    console.log(
+      "\n" +
+        generateReport(
+          "Planner Quiz-Intent Eval Report",
+          results,
+          SCORE_RUNS,
+          formatActual,
+        ),
+    );
 
-    const yamlData = {
-      generated: new Date().toISOString(),
-      runsPerCell: SCORE_RUNS,
-      cells: results.map((r) => ({
-        id: r.cellId,
-        description: r.description,
-        passThreshold: r.passThreshold,
-        passRate: r.passRate,
-        runs: r.runs.map((run) => ({
-          pass: run.pass,
-          reasons: run.reasons,
-          actual: run.actual,
-          ...(run.error ? { error: run.error } : {}),
-        })),
-      })),
-    };
-    fs.mkdirSync(path.dirname(OUTPUT_FILE), { recursive: true });
-    fs.writeFileSync(OUTPUT_FILE, YAML.stringify(yamlData));
-    console.log(`\nReport written to: ${OUTPUT_FILE}`);
+    writeScores(OUTPUT_FILE, results, SCORE_RUNS, (run) => ({
+      pass: run.pass,
+      reasons: run.reasons,
+      actual: run.actual,
+      ...(run.error ? { error: run.error } : {}),
+    }));
   }, 600_000);
 });


### PR DESCRIPTION
## Description

Clears the SonarCloud duplication issue (was 4.8%, limit is 3%) that failed on release candidate #1062. This PR removes it by extracting the shared code, with no change to behaviour.

- `AilaStreamHandler.ts`: Extracted the near-identical `starterQuiz--maths` and `exitQuiz--maths` handlers into one `buildMathsQuizHandler` factory, with the quiz path and message wording passed as parameters.
- `scoreMathsComposer.ts` / `scorePlannerQuizIntent.ts`: Moved the shared `CellResult` type, report, run loop and YAML-writing block into a new `scoring/evalHarness.ts`. Each harness now supplies only its own cells and formatters.

## Issue(s)

Fixes the duplication introduced in #1053.

## How to test

1. `cd packages/aila && pnpm type-check` passes
2. `pnpm exec jest src/core/chat/AilaStreamHandler.test.ts` passes (15 tests)
3. `pnpm lint` on the changed files is clean
4. On the PR, confirm SonarCloud Duplication on New Code is under 3% and the quality gate passes

## Screenshots

n/a, no UI changes.

## Checklist

- [ ] ~~Manually tested across browsers / devices~~ (no runtime behaviour change)
- [ ] ~~Considered impact on accessibility~~
- [ ] ~~Does this PR update a package with a breaking change~~
