### PR TITLE
feat: direct link to teaching materials - AI-2217

### DIFF
--- a/apps/nextjs/src/app/aila/teaching-materials/page.tsx
+++ b/apps/nextjs/src/app/aila/teaching-materials/page.tsx
@@ -36,6 +36,15 @@ export default async function TeachingMaterialsPage({
       },
     };
   }
+  if (docType) {
+    pageProps = {
+      source: "aila",
+      initialStep: 1,
+      queryParams: {
+        docType,
+      },
+    };
+  }
 
   return <TeachingMaterialsView {...pageProps} />;
 }

--- a/apps/nextjs/src/app/aila/teaching-materials/teachingMaterialsView.tsx
+++ b/apps/nextjs/src/app/aila/teaching-materials/teachingMaterialsView.tsx
@@ -42,7 +42,7 @@ export type TeachingMaterialsPageProps = {
   error?: Error;
   lessonId?: string;
   queryParams?: {
-    lessonSlug: string;
+    lessonSlug?: string;
     programmeSlug?: string;
     docType: string;
   };

--- a/apps/nextjs/src/components/AppComponents/Chat/aila-start/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/aila-start/index.tsx
@@ -16,7 +16,6 @@ import {
   OakUL,
 } from "@oaknational/oak-components";
 import Link from "next/link";
-import styled from "styled-components";
 
 import useAnalytics from "@/lib/analytics/useAnalytics";
 import { getAilaUrl } from "@/utils/getAilaUrl";

--- a/apps/nextjs/src/components/AppComponents/Chat/aila-start/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/aila-start/index.tsx
@@ -26,22 +26,30 @@ import EmptyScreenAccordion from "../empty-screen-accordion";
 
 const teachingMaterialsList: {
   label: string;
+  ariaLabel: string;
   docType: TeachingMaterialType;
 }[] = [
-  { label: "Glossaries", docType: "additional-glossary" },
   {
-    label: "Comprehension tasks",
+    label: "Glossary",
+    ariaLabel: "Create a glossary teaching material",
+    docType: "additional-glossary",
+  },
+  {
+    label: "Comprehension task",
+    ariaLabel: "Create a comprehension tasks teaching material",
     docType: "additional-comprehension",
   },
-  { label: "Starter quiz", docType: "additional-starter-quiz" },
-  { label: "Exit quiz", docType: "additional-exit-quiz" },
+  {
+    label: "Starter quiz",
+    ariaLabel: "Create a starter quiz teaching material",
+    docType: "additional-starter-quiz",
+  },
+  {
+    label: "Exit quiz",
+    ariaLabel: "Create an exit quiz teaching material",
+    docType: "additional-exit-quiz",
+  },
 ];
-
-const StyledUL = styled(OakUL)`
-  list-style-type: disc;
-
-  padding-left: 20px;
-`;
 
 export function AilaStart() {
   const { track } = useAnalytics();
@@ -126,6 +134,7 @@ export function AilaStart() {
                       element="a"
                       href={`${getAilaUrl("teaching-materials")}?docType=${item.docType}`}
                       iconName="chevron-right"
+                      aria-label={item.ariaLabel}
                       onClick={() => {
                         track.createTeachingMaterialsInitiated({
                           platform: "aila-beta",

--- a/apps/nextjs/src/components/AppComponents/Chat/aila-start/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/aila-start/index.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import type { TeachingMaterialType } from "@oakai/teaching-materials/src/documents/teachingMaterials/configSchema";
+
 import { useUser } from "@clerk/nextjs";
 import {
   OakBox,
@@ -7,10 +9,10 @@ import {
   OakGrid,
   OakGridArea,
   OakHeading,
-  OakLI,
   OakMaxWidth,
   OakP,
   OakPrimaryButton,
+  OakTertiaryButton,
   OakUL,
 } from "@oaknational/oak-components";
 import Link from "next/link";
@@ -21,6 +23,19 @@ import { getAilaUrl } from "@/utils/getAilaUrl";
 
 import ChatPanelDisclaimer from "../chat-panel-disclaimer";
 import EmptyScreenAccordion from "../empty-screen-accordion";
+
+const teachingMaterialsList: {
+  label: string;
+  docType: TeachingMaterialType;
+}[] = [
+  { label: "Glossaries", docType: "additional-glossary" },
+  {
+    label: "Comprehension tasks",
+    docType: "additional-comprehension",
+  },
+  { label: "Starter quiz", docType: "additional-starter-quiz" },
+  { label: "Exit quiz", docType: "additional-exit-quiz" },
+];
 
 const StyledUL = styled(OakUL)`
   list-style-type: disc;
@@ -56,7 +71,7 @@ export function AilaStart() {
           <OakGridArea $alignContent={"center"} $colSpan={[12, 6, 7]}>
             <OakBox
               $background="bg-primary"
-              $pa="spacing-32"
+              $pa="spacing-24"
               $borderRadius="border-radius-s"
               $position={"relative"}
             >
@@ -84,47 +99,49 @@ export function AilaStart() {
               </OakFlex>
             </OakBox>
           </OakGridArea>
-          <OakGridArea $colSpan={[12, 6, 5]}>
+          <OakGridArea $colSpan={[12, 6, 4]}>
             <OakBox
               $background="bg-primary"
-              $pa="spacing-32"
+              $pa="spacing-24"
               $borderRadius="border-radius-s"
             >
-              <OakFlex $flexDirection="column">
-                {/* Heading, description, and list */}
-                <OakHeading $mb="spacing-12" $font="heading-5" tag="h2">
-                  Create teaching materials with AI
+              <OakFlex $gap="spacing-24" $flexDirection="column">
+                <OakHeading $font="heading-5" tag="h2">
+                  Create teaching materials
                 </OakHeading>
-                <OakP $mb="spacing-12" $font="body-2">
-                  Enhance lessons with a range of teaching materials, including:
+                <OakP $font="body-2">
+                  Enhance your own lessons with editable resources:
                 </OakP>
-                <StyledUL>
-                  <OakLI $mv="spacing-12">Glossaries</OakLI>
-                  <OakLI $mv="spacing-12">Comprehension tasks</OakLI>
-                  <OakLI $mt="spacing-12">Quizzes</OakLI>
-                </StyledUL>
-                <OakBox $mt="spacing-24">
-                  <OakPrimaryButton
-                    element={Link}
-                    href={getAilaUrl("teaching-materials")}
-                    data-testid={"create-teaching-materials-button"}
-                    iconName="arrow-right"
-                    isTrailingIcon={true}
-                    onClick={() => {
-                      track.createTeachingMaterialsInitiated({
-                        platform: "aila-beta",
-                        product: "ai lesson assistant",
-                        engagementIntent: "explore",
-                        componentType: "create_additional_materials_button",
-                        eventVersion: "2.0.0",
-                        analyticsUseCase: "Teacher",
-                        isLoggedIn: Boolean(user),
-                      });
-                    }}
-                  >
-                    Create teaching materials
-                  </OakPrimaryButton>
-                </OakBox>
+                <OakBox
+                  $color={"border-neutral"}
+                  $bb={"border-solid-s"}
+                  $pa="spacing-0"
+                />
+
+                <OakFlex $flexDirection={"column"} $gap="spacing-12">
+                  {teachingMaterialsList.map((item) => (
+                    <OakTertiaryButton
+                      key={item.docType}
+                      data-testid={`create-teaching-materials-button-${item.docType}`}
+                      element="a"
+                      href={`${getAilaUrl("teaching-materials")}?docType=${item.docType}`}
+                      iconName="chevron-right"
+                      onClick={() => {
+                        track.createTeachingMaterialsInitiated({
+                          platform: "aila-beta",
+                          product: "ai lesson assistant",
+                          engagementIntent: "explore",
+                          componentType: "create_additional_materials_button",
+                          eventVersion: "2.0.0",
+                          analyticsUseCase: "Teacher",
+                          isLoggedIn: Boolean(user),
+                        });
+                      }}
+                    >
+                      {item.label}
+                    </OakTertiaryButton>
+                  ))}
+                </OakFlex>
               </OakFlex>
             </OakBox>
           </OakGridArea>

--- a/apps/nextjs/src/stores/TeachingMaterialsStoreProvider.tsx
+++ b/apps/nextjs/src/stores/TeachingMaterialsStoreProvider.tsx
@@ -72,6 +72,12 @@ export const TeachingMaterialsStoresProvider: React.FC<
       void stores.teachingMaterials.getState().actions.fetchOwaData(props);
     }
 
+    if (props.source === "aila" && props.queryParams?.docType) {
+      void stores.teachingMaterials
+        .getState()
+        .actions.createMaterialSession(props.queryParams.docType, 1);
+    }
+
     haveInitialized.current = true;
   }, [isLoaded, isSignedIn, props, stores.teachingMaterials]);
 

--- a/apps/nextjs/src/stores/teachingMaterialsStore/actionFunctions/__tests__/handleCreateMaterialSession.test.ts
+++ b/apps/nextjs/src/stores/teachingMaterialsStore/actionFunctions/__tests__/handleCreateMaterialSession.test.ts
@@ -56,7 +56,10 @@ describe("handleCreateMaterialSession", () => {
       documentType: teachingMaterialTypeEnum.parse("additional-glossary"),
     });
     expect(mockSet).toHaveBeenCalledWith({ stepNumber: 2 });
-    expect(mockSet).toHaveBeenCalledWith({ id: "resource-xyz" });
+    expect(mockSet).toHaveBeenCalledWith({
+      id: "resource-xyz",
+      docType: "additional-glossary",
+    });
     expect(mockTrackMaterialSelected).toHaveBeenCalledWith({
       resourceId: "resource-xyz",
       docType: teachingMaterialTypeEnum.parse("additional-glossary"),
@@ -90,7 +93,10 @@ describe("handleCreateMaterialSession", () => {
       documentType: teachingMaterialTypeEnum.parse("additional-glossary"),
     });
     expect(mockSet).toHaveBeenCalledWith({ stepNumber: 1 });
-    expect(mockSet).toHaveBeenCalledWith({ id: "resource-xyz" });
+    expect(mockSet).toHaveBeenCalledWith({
+      id: "resource-xyz",
+      docType: "additional-glossary",
+    });
     expect(mockTrackMaterialSelected).toHaveBeenCalledWith({
       resourceId: "resource-xyz",
       docType: teachingMaterialTypeEnum.parse("additional-glossary"),
@@ -124,7 +130,10 @@ describe("handleCreateMaterialSession", () => {
       documentType: teachingMaterialTypeEnum.parse("additional-glossary"),
     });
     expect(mockSet).toHaveBeenCalledWith({ stepNumber: 1 });
-    expect(mockSet).toHaveBeenCalledWith({ id: "resource-xyz" });
+    expect(mockSet).toHaveBeenCalledWith({
+      id: "resource-xyz",
+      docType: "additional-glossary",
+    });
     expect(mockTrackMaterialSelected).toHaveBeenCalledWith({
       resourceId: "resource-xyz",
       docType: teachingMaterialTypeEnum.parse("additional-glossary"),

--- a/apps/nextjs/src/stores/teachingMaterialsStore/actionFunctions/handleCreateMaterialSession.ts
+++ b/apps/nextjs/src/stores/teachingMaterialsStore/actionFunctions/handleCreateMaterialSession.ts
@@ -44,8 +44,9 @@ export const handleCreateMaterialSession =
 
       log.info("Material session created ", {
         resourceId: result.resourceId,
+        docType: docTypeParsed,
       });
-      set({ id: resourceId });
+      set({ id: resourceId, docType: docTypeParsed });
       log.info(get().id, "ID after creation");
 
       const source = get().source;

--- a/apps/nextjs/src/stores/teachingMaterialsStore/actionFunctions/handleFetchOwaLesson.ts
+++ b/apps/nextjs/src/stores/teachingMaterialsStore/actionFunctions/handleFetchOwaLesson.ts
@@ -65,8 +65,8 @@ export const handleFetchOwaLesson =
           const response = await callWithHandshakeRetry(
             () =>
               trpc.client.teachingMaterials.handleFetchOwaLesson.mutate({
-                lessonSlug,
-                programmeSlug,
+                lessonSlug: z.string().parse(lessonSlug),
+                programmeSlug: z.string().parse(programmeSlug),
               }),
             refreshAuth,
           );

--- a/apps/nextjs/tests-e2e/tests/teaching-materials/teaching-materials.test.ts
+++ b/apps/nextjs/tests-e2e/tests/teaching-materials/teaching-materials.test.ts
@@ -22,14 +22,10 @@ test.describe("Teaching Materials", () => {
       await applyTeachingMaterialsMockAPIRequests(page);
 
       await test.step("Navigate to teaching materials", async () => {
-        await page.getByTestId("create-teaching-materials-button").click();
+        await page
+          .getByTestId("create-teaching-materials-button-additional-glossary")
+          .click();
         await expect(page).toHaveURL(/\/aila\/teaching-materials/);
-      });
-
-      await test.step("Step 1: Select material type", async () => {
-        await page.getByText("Glossary").click();
-
-        await page.getByText("Next, provide lesson details").click();
       });
 
       await test.step("Step 2: Input lesson context", async () => {
@@ -106,13 +102,10 @@ test.describe("Teaching Materials", () => {
       await applyTeachingMaterialsMockAPIRequests(page);
 
       await test.step("Navigate to teaching materials", async () => {
-        await page.getByTestId("create-teaching-materials-button").click();
+        await page
+          .getByTestId("create-teaching-materials-button-additional-glossary")
+          .click();
         await expect(page).toHaveURL(/\/aila\/teaching-materials/);
-      });
-
-      await test.step("Step 1: Select material type", async () => {
-        await page.getByText("Glossary").click();
-        await page.getByTestId("mobile-next-button").click();
       });
 
       await test.step("Step 2: Input lesson context", async () => {

--- a/apps/nextjs/tests-e2e/tests/teaching-materials/teaching-materials.test.ts
+++ b/apps/nextjs/tests-e2e/tests/teaching-materials/teaching-materials.test.ts
@@ -26,15 +26,12 @@ test.describe("Teaching Materials", () => {
           .getByTestId("create-teaching-materials-button-additional-glossary")
           .click();
         await expect(page).toHaveURL(/\/aila\/teaching-materials/);
-      });
-
-      await test.step("Step 2: Input lesson context", async () => {
         const buttons = page.getByTestId("drop-down-button");
 
         await buttons.first().click();
-        await page.getByText("Year 3").click();
+        await page.getByRole("button", { name: "Year 3", exact: true }).click();
         await buttons.last().click();
-        await page.getByText("Biology").click();
+        await page.getByRole("button", { name: "Biology", exact: true }).click();
 
         // Fill lesson title
         await page
@@ -106,14 +103,13 @@ test.describe("Teaching Materials", () => {
           .getByTestId("create-teaching-materials-button-additional-glossary")
           .click();
         await expect(page).toHaveURL(/\/aila\/teaching-materials/);
-      });
-
-      await test.step("Step 2: Input lesson context", async () => {
         const buttons = page.getByTestId("drop-down-button");
+
         await buttons.first().click();
-        await page.getByText("Year 3").click();
+        await page.getByRole("button", { name: "Year 3", exact: true }).click();
         await buttons.last().click();
-        await page.getByText("Biology").click();
+        await page.getByRole("button", { name: "Biology", exact: true }).click();
+
         await page
           .getByPlaceholder("Type a learning objective")
           .fill("I want a lesson about data representation");

--- a/apps/nextjs/tests-e2e/tests/teaching-materials/teaching-materials.test.ts
+++ b/apps/nextjs/tests-e2e/tests/teaching-materials/teaching-materials.test.ts
@@ -22,10 +22,16 @@ test.describe("Teaching Materials", () => {
       await applyTeachingMaterialsMockAPIRequests(page);
 
       await test.step("Navigate to teaching materials", async () => {
+        const createSessionReady = page.waitForResponse((response) =>
+          response.url().includes("createMaterialSession"),
+        );
+
         await page
           .getByTestId("create-teaching-materials-button-additional-glossary")
           .click();
-        await page.waitForURL(/\/aila\/teaching-materials/);
+        await page.waitForURL(/\/aila\/teaching-materials/, {
+          waitUntil: "load",
+        });
         const buttons = page.getByTestId("drop-down-button");
 
         await buttons.first().click();
@@ -40,6 +46,8 @@ test.describe("Teaching Materials", () => {
           .getByPlaceholder("Type a lesson title or learning outcome")
           .fill("Exploring animal habitats");
 
+        // Ensure the session is created (resourceId + docType set) before submitting
+        await createSessionReady;
         await page.getByText("Next, review lesson details").click();
       });
 
@@ -101,10 +109,16 @@ test.describe("Teaching Materials", () => {
       await applyTeachingMaterialsMockAPIRequests(page);
 
       await test.step("Navigate to teaching materials", async () => {
+        const createSessionReady = page.waitForResponse((response) =>
+          response.url().includes("createMaterialSession"),
+        );
+
         await page
           .getByTestId("create-teaching-materials-button-additional-glossary")
           .click();
-        await page.waitForURL(/\/aila\/teaching-materials/);
+        await page.waitForURL(/\/aila\/teaching-materials/, {
+          waitUntil: "load",
+        });
         const buttons = page.getByTestId("drop-down-button");
 
         await buttons.first().click();
@@ -118,6 +132,9 @@ test.describe("Teaching Materials", () => {
         await page
           .getByPlaceholder("Type a learning objective")
           .fill("I want a lesson about data representation");
+
+        // Ensure the session is created (resourceId + docType set) before submitting
+        await createSessionReady;
         await page.getByTestId("mobile-next-button").click();
       });
 

--- a/apps/nextjs/tests-e2e/tests/teaching-materials/teaching-materials.test.ts
+++ b/apps/nextjs/tests-e2e/tests/teaching-materials/teaching-materials.test.ts
@@ -25,13 +25,15 @@ test.describe("Teaching Materials", () => {
         await page
           .getByTestId("create-teaching-materials-button-additional-glossary")
           .click();
-        await expect(page).toHaveURL(/\/aila\/teaching-materials/);
+        await page.waitForURL(/\/aila\/teaching-materials/);
         const buttons = page.getByTestId("drop-down-button");
 
         await buttons.first().click();
         await page.getByRole("button", { name: "Year 3", exact: true }).click();
         await buttons.last().click();
-        await page.getByRole("button", { name: "Biology", exact: true }).click();
+        await page
+          .getByRole("button", { name: "Biology", exact: true })
+          .click();
 
         // Fill lesson title
         await page
@@ -102,13 +104,16 @@ test.describe("Teaching Materials", () => {
         await page
           .getByTestId("create-teaching-materials-button-additional-glossary")
           .click();
-        await expect(page).toHaveURL(/\/aila\/teaching-materials/);
+        await page.waitForURL(/\/aila\/teaching-materials/);
         const buttons = page.getByTestId("drop-down-button");
 
         await buttons.first().click();
         await page.getByRole("button", { name: "Year 3", exact: true }).click();
         await buttons.last().click();
-        await page.getByRole("button", { name: "Biology", exact: true }).click();
+
+        await page
+          .getByRole("button", { name: "Biology", exact: true })
+          .click();
 
         await page
           .getByPlaceholder("Type a learning objective")


### PR DESCRIPTION
## Description

Updates Aila start to have direct links to TM - figma = https://www.figma.com/design/I8Dulyd7bg2f0tEfbmSEpL/Aila-updates-2026?node-id=45-2072&p=f&m=dev

- [ ]  Existing generic “Create teaching materials” CTA is removed/replaced
- [ ]  Direct links to each resource type are visible on starter page
- [ ]  Links navigate correctly to intended flows (option selected)
- [ ]  Layout matches approved designs

_note  -  changed the padding of Aila card to match teaching materials, the Aila card is coming in a follow up PR._

## Issue(s)

Fixes #

## How to test

-Matches figma designs
-Link correctly takes you to step 2 from type button
-Avo/posthog events still get sent


## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
