### PR TITLE
build: release candidate

### DIFF
--- a/.claude/skills/score-agentic/SKILL.md
+++ b/.claude/skills/score-agentic/SKILL.md
@@ -18,6 +18,33 @@ cd packages/aila && SCORE_RUNS=3 pnpm with-env npx jest --testMatch="**/scoring/
 
 This updates `packages/aila/src/lib/agentic-system/scoring/scores.yaml`.
 
+## Inspect corrector firings
+
+Each scenario in `scores.yaml` now includes an `americanisms_corrector` block summarising how often the British English corrector ran across the scenario's runs:
+
+```yaml
+summary:
+  full-lesson:
+    # …other scorers…
+    americanisms_corrector:
+      corrections_attempted: 1
+      corrections_not_needed: 32
+      corrections_failed: 0
+      correction_rate: "3.0%"
+      correction_failure_rate: "0.0%"
+      corrections_by_section:
+        cycle3: 1
+```
+
+- `corrections_attempted`: sections where the corrector LLM was invoked (i.e. `AilaAmericanisms` flagged an actionable spelling or phrasing issue on that section).
+- `corrections_not_needed`: sections that were scanned but had no actionable flags, so the corrector was skipped.
+- `corrections_failed`: corrector invocations that threw, returned an error envelope, or produced schema-invalid output. The original section is preserved in these cases.
+- `correction_rate`: `corrections_attempted / (corrections_attempted + corrections_not_needed)` as a percentage. Higher means the static prompt guidance is letting more through.
+- `correction_failure_rate`: `corrections_failed / corrections_attempted` as a percentage. High values point at corrector model or schema misbehaviour.
+- `corrections_by_section`: per-section tally of corrector firings aggregated across all runs in the scenario; useful for spotting which sections leak Americanisms most often.
+
+The corrector attempts a correction when `AilaAmericanisms` detects actionable (spelling/phrasing) Americanisms on a freshly generated section. Each attempt is one additional LLM call. A 0% `correction_rate` means the static prompt guidance caught everything; a high rate means the prompts are leaking and the corrector is doing the heavy lifting. A non-zero `corrections_failed` means the corrector errored or returned schema-invalid content — the original section is preserved, but persistent failures should be investigated.
+
 ## Verify freshness
 
 ```bash
@@ -29,8 +56,9 @@ packages/aila/src/lib/agentic-system/scoring/check-scoring-freshness.sh
 1. Make changes to agent prompts, instructions, or execution logic
 2. Run the scoring harness (command above)
 3. Review the report for regressions
-4. Commit `scores.yaml` alongside your code changes
+4. Review the `americanisms_corrector` block if you changed prompt guidance, the corrector, or `AilaAmericanisms` filters
+5. Commit `scores.yaml` alongside your code changes
 
 ## Configuration
 
-- `SCORE_RUNS=N` — number of runs per scenario (default 3). Higher values give more confidence but take longer.
+- `SCORE_RUNS=N`: number of runs per scenario (default 3). Higher values give more confidence but take longer.

--- a/packages/aila/src/core/AilaServices.ts
+++ b/packages/aila/src/core/AilaServices.ts
@@ -20,6 +20,7 @@ import type {
   AilaPersistedChat,
   AilaRagRelevantLesson,
   PartialLessonPlan,
+  RagFetched,
 } from "../protocol/schema";
 import type { Message } from "./chat";
 import type { AilaDocumentContent } from "./document/types";
@@ -52,6 +53,8 @@ export interface AilaChatService {
   readonly persistedChat: AilaPersistedChat | undefined;
   get relevantLessons(): AilaRagRelevantLesson[] | null;
   set relevantLessons(lessons: AilaRagRelevantLesson[] | null);
+  get ragFetched(): RagFetched;
+  set ragFetched(value: RagFetched);
   readonly parsedMessages: MessagePart[][];
   readonly isShared: boolean | undefined;
   readonly quizService: QuizService;

--- a/packages/aila/src/core/chat/AilaChat.ts
+++ b/packages/aila/src/core/chat/AilaChat.ts
@@ -21,6 +21,7 @@ import {
 import type {
   AilaPersistedChat,
   AilaRagRelevantLesson,
+  RagFetched,
 } from "../../protocol/schema";
 import { AilaError } from "../AilaError";
 import type { LLMService } from "../llm/LLMService";
@@ -39,6 +40,7 @@ export class AilaChat implements AilaChatService {
   private readonly _id: string;
   private readonly _messages: Message[];
   private _relevantLessons: AilaRagRelevantLesson[] | null;
+  private _ragFetched: RagFetched;
   private _isShared: boolean | undefined;
   private readonly _userId: string | undefined;
   private readonly _aila: AilaServices;
@@ -82,7 +84,7 @@ export class AilaChat implements AilaChatService {
     this._promptBuilder =
       promptBuilder ?? new AilaLessonPromptBuilder(aila, aila.prisma);
     this._relevantLessons = null; // null means not fetched yet, [] means fetched but none found
-
+    this._ragFetched = { status: "not_fetched", searchIdentity: null };
     this.quizService = buildQuizService(
       {
         sources: aila.options.quizSources,
@@ -133,12 +135,20 @@ export class AilaChat implements AilaChatService {
     return this._relevantLessons;
   }
 
+  public get ragFetched() {
+    return this._ragFetched;
+  }
+
   public get generation() {
     return this._generation;
   }
 
   public set relevantLessons(lessons: AilaRagRelevantLesson[] | null) {
     this._relevantLessons = lessons;
+  }
+
+  public set ragFetched(value: RagFetched) {
+    this._ragFetched = value;
   }
 
   public getPatchEnqueuer(): PatchEnqueuer {
@@ -341,6 +351,10 @@ export class AilaChat implements AilaChatService {
 
     if (persistedChat) {
       this._relevantLessons = persistedChat.relevantLessons ?? null;
+      this._ragFetched = persistedChat.ragFetched ?? {
+        status: "not_fetched",
+        searchIdentity: null,
+      };
       this._isShared = persistedChat.isShared;
       this._iteration = persistedChat.iteration ?? 1;
       this._createdAt = new Date(persistedChat.createdAt);

--- a/packages/aila/src/core/chat/AilaStreamHandler.test.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.test.ts
@@ -13,7 +13,10 @@ import { createOpenAIMessageToUserAgent } from "../../lib/agentic-system/agents/
 import { createOpenAIPlannerAgent } from "../../lib/agentic-system/agents/plannerAgent";
 import { createSectionAgentRegistry as createSectionAgentRegistryFactory } from "../../lib/agentic-system/agents/sectionAgents/sectionAgentRegistry";
 import { ailaTurn } from "../../lib/agentic-system/ailaTurn";
-import type { SectionAgentRegistry } from "../../lib/agentic-system/types";
+import type {
+  AilaTurnOutcome,
+  SectionAgentRegistry,
+} from "../../lib/agentic-system/types";
 import { handleThreatDetectionResult } from "../../utils/threatDetection/threatDetectionHandling";
 import type { AilaPlugin } from "../plugins";
 import { AilaStreamHandler } from "./AilaStreamHandler";
@@ -39,6 +42,15 @@ function createMockSectionAgentRegistry(): SectionAgentRegistry {
       "exitQuiz--maths": jest.fn(),
     },
   });
+}
+
+function createAilaTurnOutcome(
+  status: AilaTurnOutcome["status"],
+): AilaTurnOutcome {
+  return {
+    status,
+    correctorStats: { attempted: [], notNeeded: [], failed: [] },
+  };
 }
 
 jest.mock("@oakai/core/src/llm/openai", () => ({
@@ -232,7 +244,7 @@ describe("AilaStreamHandler", () => {
   });
 
   it("skips completion for failed agentic turns", async () => {
-    mockedAilaTurn.mockResolvedValue({ status: "failed" });
+    mockedAilaTurn.mockResolvedValue(createAilaTurnOutcome("failed"));
 
     const chat = createMockChat({ useAgenticAila: true });
     const handler = new AilaStreamHandler(chat as never);
@@ -480,7 +492,7 @@ describe("AilaStreamHandler", () => {
         ailaMessage:
           "Here's the updated lesson plan. Do you want to make any more changes?",
       });
-      return { status: "success" };
+      return createAilaTurnOutcome("success");
     });
 
     const chat = createMockChat({ useAgenticAila: true });
@@ -524,7 +536,7 @@ describe("AilaStreamHandler", () => {
         ailaMessage:
           "The lesson plan has been updated, but the usual summary wasn't available. Please review the changes and let me know what you'd like to adjust next.",
       });
-      return { status: "success" };
+      return createAilaTurnOutcome("success");
     });
 
     const chat = createMockChat({ useAgenticAila: true });

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -16,7 +16,11 @@ import { ailaTurn } from "../../lib/agentic-system/ailaTurn";
 import { createAilaTurnCallbacks } from "../../lib/agentic-system/compatibility/ailaTurnCallbacks";
 import { createEmptyCorrectorStats } from "../../lib/agentic-system/correctorStats";
 import { deriveQuizBuildMode } from "../../lib/agentic-system/quizOperations/deriveQuizBuildMode";
-import type { AilaTurnOutcome } from "../../lib/agentic-system/types";
+import type {
+  AilaTurnOutcome,
+  SectionAgent,
+} from "../../lib/agentic-system/types";
+import type { LatestQuiz } from "../../protocol/schema";
 import { extractPromptTextFromMessages } from "../../utils/extractPromptTextFromMessages";
 import { handleThreatDetectionResult } from "../../utils/threatDetection/threatDetectionHandling";
 import { AilaChatError } from "../AilaError";
@@ -291,6 +295,45 @@ export class AilaStreamHandler {
       controller: this._controller!,
     });
 
+    // starterQuiz and exitQuiz only differ by quiz path and the words used in
+    // their messages; everything else is the same maths-engine build flow.
+    const buildMathsQuizHandler =
+      (
+        quizType: "/starterQuiz" | "/exitQuiz",
+        quizNoun: string,
+      ): SectionAgent<LatestQuiz>["handler"] =>
+      async (ctx) => {
+        try {
+          const userInstructions =
+            ctx.currentTurn.currentStep?.sectionInstructions;
+          const mode = deriveQuizBuildMode(ctx.currentTurn.currentStep);
+          const tracker = createQuizTracker();
+          const { quiz, note } = await tracker.run(async (task, reportId) => {
+            const result = await this._chat.quizService.buildQuiz(
+              quizType,
+              ctx.currentTurn.document,
+              this._chat.relevantLessons ?? [],
+              task,
+              reportId,
+              mode,
+              userInstructions,
+            );
+            task.addData({ quiz: result.quiz, mode, userInstructions });
+            return result;
+          });
+          await ReportStorage.store(tracker.getReport());
+
+          return { error: null, data: quiz, note };
+        } catch (error) {
+          log.error(`Error generating ${quizNoun}`, { error });
+          return {
+            error: {
+              message: `Failed to generate a ${quizNoun} with maths quiz engine`,
+            },
+          };
+        }
+      };
+
     let relevantLessonsPopulated: Awaited<
       ReturnType<typeof getRagLessonPlansByIds>
     > = [];
@@ -319,82 +362,11 @@ export class AilaStreamHandler {
         sectionAgents: createSectionAgentRegistry({
           openai,
           customAgentHandlers: {
-            "starterQuiz--maths": async (ctx) => {
-              try {
-                const userInstructions =
-                  ctx.currentTurn.currentStep?.sectionInstructions;
-                const mode = deriveQuizBuildMode(ctx.currentTurn.currentStep);
-                const tracker = createQuizTracker();
-                const { quiz, note } = await tracker.run(
-                  async (task, reportId) => {
-                    const result = await this._chat.quizService.buildQuiz(
-                      "/starterQuiz",
-                      ctx.currentTurn.document,
-                      this._chat.relevantLessons ?? [],
-                      task,
-                      reportId,
-                      mode,
-                      userInstructions,
-                    );
-                    task.addData({
-                      quiz: result.quiz,
-                      mode,
-                      userInstructions,
-                    });
-                    return result;
-                  },
-                );
-                await ReportStorage.store(tracker.getReport());
-
-                return { error: null, data: quiz, note };
-              } catch (error) {
-                log.error("Error generating starter quiz", { error });
-                return {
-                  error: {
-                    message:
-                      "Failed to generate a starter quiz with maths quiz engine",
-                  },
-                };
-              }
-            },
-            "exitQuiz--maths": async (ctx) => {
-              try {
-                const userInstructions =
-                  ctx.currentTurn.currentStep?.sectionInstructions;
-                const mode = deriveQuizBuildMode(ctx.currentTurn.currentStep);
-                const tracker = createQuizTracker();
-                const { quiz, note } = await tracker.run(
-                  async (task, reportId) => {
-                    const result = await this._chat.quizService.buildQuiz(
-                      "/exitQuiz",
-                      ctx.currentTurn.document,
-                      this._chat.relevantLessons ?? [],
-                      task,
-                      reportId,
-                      mode,
-                      userInstructions,
-                    );
-                    task.addData({
-                      quiz: result.quiz,
-                      mode,
-                      userInstructions,
-                    });
-                    return result;
-                  },
-                );
-                await ReportStorage.store(tracker.getReport());
-
-                return { error: null, data: quiz, note };
-              } catch (error) {
-                log.error("Error generating exit quiz", { error });
-                return {
-                  error: {
-                    message:
-                      "Failed to generate an exit quiz with maths quiz engine",
-                  },
-                };
-              }
-            },
+            "starterQuiz--maths": buildMathsQuizHandler(
+              "/starterQuiz",
+              "starter quiz",
+            ),
+            "exitQuiz--maths": buildMathsQuizHandler("/exitQuiz", "exit quiz"),
           },
         }),
         messageToUserAgent: createOpenAIMessageToUserAgent(openai),

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -293,6 +293,9 @@ export class AilaStreamHandler {
     const ailaTurnCallbacks = createAilaTurnCallbacks({
       chat: this._chat,
       controller: this._controller!,
+      onRagFetchedChange: async (ragFetched) => {
+        this._chat.ragFetched = ragFetched;
+      },
     });
 
     // starterQuiz and exitQuiz only differ by quiz path and the words used in
@@ -353,6 +356,7 @@ export class AilaStreamHandler {
         messages: extractPromptTextFromMessages(this._chat.messages),
         initialDocument,
         relevantLessons: relevantLessonsPopulated,
+        ragFetched: this._chat.ragFetched,
       },
       runtime: {
         config: {

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -8,11 +8,13 @@ import type { getRagLessonPlansByIds } from "@oakai/rag";
 
 import type { ReadableStreamDefaultController } from "stream/web";
 
+import { createOpenAIBritishEnglishCorrectorAgent } from "../../lib/agentic-system/agents/britishEnglishCorrectorAgent";
 import { createOpenAIMessageToUserAgent } from "../../lib/agentic-system/agents/messageToUserAgent";
 import { createOpenAIPlannerAgent } from "../../lib/agentic-system/agents/plannerAgent";
 import { createSectionAgentRegistry } from "../../lib/agentic-system/agents/sectionAgents/sectionAgentRegistry";
 import { ailaTurn } from "../../lib/agentic-system/ailaTurn";
 import { createAilaTurnCallbacks } from "../../lib/agentic-system/compatibility/ailaTurnCallbacks";
+import { createEmptyCorrectorStats } from "../../lib/agentic-system/correctorStats";
 import { deriveQuizBuildMode } from "../../lib/agentic-system/quizOperations/deriveQuizBuildMode";
 import type { AilaTurnOutcome } from "../../lib/agentic-system/types";
 import { extractPromptTextFromMessages } from "../../utils/extractPromptTextFromMessages";
@@ -178,8 +180,8 @@ export class AilaStreamHandler {
       }
 
       if (this._chat.aila.options.useAgenticAila) {
-        await this.span("start-agent-stream", async () => {
-          agenticTurnOutcome = await this.startAgentStream();
+        agenticTurnOutcome = await this.span("start-agent-stream", async () => {
+          return await this.startAgentStream();
         });
       } else {
         await this.span("set-initial-state", async () => {
@@ -207,7 +209,10 @@ export class AilaStreamHandler {
       );
     } catch (e) {
       if (this._chat.aila.options.useAgenticAila) {
-        agenticTurnOutcome = { status: "failed" };
+        agenticTurnOutcome = {
+          status: "failed",
+          correctorStats: createEmptyCorrectorStats(),
+        };
         // ailaTurn threw rather than returning; its internal failure path never
         // completed, so the client has not received an error message.
         await this._chat.enqueue({
@@ -231,7 +236,9 @@ export class AilaStreamHandler {
         : status !== "FAILED";
       log.info("In finally block", {
         status,
-        agenticTurnOutcome,
+        agenticTurn: agenticTurnOutcome
+          ? { status: agenticTurnOutcome.status }
+          : null,
         skipCompletion,
         chatId: this._chat.id,
       });
@@ -391,6 +398,8 @@ export class AilaStreamHandler {
           },
         }),
         messageToUserAgent: createOpenAIMessageToUserAgent(openai),
+        britishEnglishCorrectorAgent:
+          createOpenAIBritishEnglishCorrectorAgent(openai),
         fetchRelevantLessons: async ({ title, subject, keyStage }) => {
           const {
             getRelevantLessonPlans,

--- a/packages/aila/src/features/americanisms/AilaAmericanisms.ts
+++ b/packages/aila/src/features/americanisms/AilaAmericanisms.ts
@@ -13,6 +13,27 @@ import {
 
 export type AilaDocumentContent = Record<string, unknown>;
 
+// Phrases the translator dictionary flags as Americanisms but which are
+// correct British English in Aila's educational contexts — e.g. "gas" as a
+// state of matter, which the dictionary maps to "petrol". Filtered so the
+// corrector never fires on them and the scorers don't flag them.
+const FILTER_OUT_PHRASES: ReadonlySet<string> = new Set([
+  "practice",
+  "practices",
+  "gas",
+  "gases",
+  "period",
+  "periods",
+  "fall",
+  "falls",
+  "connection",
+  "connections",
+  "line",
+  "lines",
+  "triangle",
+  "triangles",
+]);
+
 export class AilaAmericanisms<T extends AilaDocumentContent>
   implements AilaAmericanismsFeature
 {
@@ -20,17 +41,6 @@ export class AilaAmericanisms<T extends AilaDocumentContent>
     section: keyof T,
     document: T,
   ): AmericanismIssueBySection | undefined {
-    const filterOutPhrases = new Set([
-      "practice",
-      "practices",
-      "gas",
-      "gases",
-      "period",
-      "periods",
-      "fall",
-      "falls",
-    ]);
-
     const sectionContent = document[section];
     if (!sectionContent) return;
 
@@ -43,7 +53,7 @@ export class AilaAmericanisms<T extends AilaDocumentContent>
     Object.values(sectionAmericanismScan).forEach((lineIssues) => {
       lineIssues.forEach((lineIssue) => {
         const [phrase, issueDefinition] = Object.entries(lineIssue)[0] ?? [];
-        if (phrase && issueDefinition && !filterOutPhrases.has(phrase)) {
+        if (phrase && issueDefinition && !FILTER_OUT_PHRASES.has(phrase)) {
           if (!issues.some((issue) => issue.phrase === phrase)) {
             const parsed = americanismIssueSchema.safeParse({
               phrase,

--- a/packages/aila/src/features/persistence/AilaPersistence.ts
+++ b/packages/aila/src/features/persistence/AilaPersistence.ts
@@ -41,6 +41,7 @@ export abstract class AilaPersistence {
       messages,
       isShared,
       relevantLessons,
+      ragFetched,
       iteration,
       createdAt,
     } = this._chat;
@@ -69,6 +70,7 @@ export abstract class AilaPersistence {
       path: `/aila/${id}`,
       lessonPlan: document.content,
       relevantLessons,
+      ragFetched,
       messages: messages.filter((m) => ["assistant", "user"].includes(m.role)),
       options,
     };

--- a/packages/aila/src/lib/agentic-system/agents/__snapshots__/sectionToGenericPromptAgent.test.ts.snap
+++ b/packages/aila/src/lib/agentic-system/agents/__snapshots__/sectionToGenericPromptAgent.test.ts.snap
@@ -14,8 +14,29 @@ You will be given a specific task and the current state of the lesson plan. You 
 ## Markdown
 Do not use markdown formatting unless specified for a specific section.
 
-## Language
-Use British English spelling and vocabulary (e.g. colour not color, centre not centre, rubbish not trash) unless the user sets a different primary language. This reflects our UK teacher audience.
+## Language — British English (mandatory)
+Write **British English** throughout the lesson plan: spelling, vocabulary, and phrasing. This is mandatory because our audience is UK teachers and pupils. The only exception is if the user has explicitly set a different primary language for the lesson.
+
+### Spelling rules — apply these consistently
+- **Verbs ending in -ise/-yse, not -ize/-yze.** Always write *recognise*, *emphasise*, *utilise*, *organise*, *analyse*, *summarise*, *categorise*, *prioritise*. Never *recognize*, *emphasize*, *utilize*, *organize*, *analyze*. This applies to all tenses: *recognised*, *emphasising*, *utilised*.
+- **-our, not -or:** colour, behaviour, favour, neighbour, honour, labour.
+- **-re, not -er:** centre, metre, theatre, fibre, litre.
+- **Double the final L before suffixes** on verbs ending in a single vowel + L: *labelled*, *labelling* (not labeled/labeling); *travelled*, *travelling* (not traveled/traveling); *modelled*, *modelling*; *cancelled*, *cancelling*; *fuelled*, *fuelling*.
+- **Other common forms:** maths (not math), grey (not gray), aluminium (not aluminum), programme (TV/curriculum) vs program (software), practise (verb) / practice (noun), licence (noun) / license (verb).
+
+### Vocabulary rules — UK terms only
+- **rubber** (not eraser), **pavement** (not sidewalk), **lift** (not elevator), **rubbish** (not trash), **biscuit** (not cookie), **trousers** (not pants), **holiday** (not vacation).
+- **autumn** (not fall — except when meaning "to drop"), **at the weekend** (not "on the weekend"), **full stop** (not period), **have** / **have got** (not "have gotten").
+- **Year 7–13** (not "7th grade"), **secondary school** / **sixth form** (not high school), **pupil** (not student where context fits a school lesson).
+
+### Self-check before emitting content
+Before returning your section, scan your output for these specific patterns and correct them:
+1. Any word ending in **-ize**, **-izes**, **-ized**, **-izing**, **-yze**, **-yzes** → change to the **-ise** / **-yse** form.
+2. Any of: eraser, sidewalk, elevator, trash, cookie, vacation, "have gotten", "on the weekend", "period" (when used as punctuation), "math" → replace with the UK term above.
+3. Any **-or** ending in a noun where the **-our** form exists (colour, behaviour, favour, etc.).
+4. Any **-eled** / **-eling** / **-eler** / **-ueled** / **-ueling** / **-odeled** / **-anceled** ending → double the L (*labelled*, *travelling*, *modeller*, *fuelling*, *cancelled*).
+
+Do not mix British and American forms. If unsure, prefer the British form.
 ",
     "role": "developer",
   },
@@ -96,8 +117,29 @@ You will be given a specific task and the current state of the lesson plan. You 
 ## Markdown
 Do not use markdown formatting unless specified for a specific section.
 
-## Language
-Use British English spelling and vocabulary (e.g. colour not color, centre not centre, rubbish not trash) unless the user sets a different primary language. This reflects our UK teacher audience.
+## Language — British English (mandatory)
+Write **British English** throughout the lesson plan: spelling, vocabulary, and phrasing. This is mandatory because our audience is UK teachers and pupils. The only exception is if the user has explicitly set a different primary language for the lesson.
+
+### Spelling rules — apply these consistently
+- **Verbs ending in -ise/-yse, not -ize/-yze.** Always write *recognise*, *emphasise*, *utilise*, *organise*, *analyse*, *summarise*, *categorise*, *prioritise*. Never *recognize*, *emphasize*, *utilize*, *organize*, *analyze*. This applies to all tenses: *recognised*, *emphasising*, *utilised*.
+- **-our, not -or:** colour, behaviour, favour, neighbour, honour, labour.
+- **-re, not -er:** centre, metre, theatre, fibre, litre.
+- **Double the final L before suffixes** on verbs ending in a single vowel + L: *labelled*, *labelling* (not labeled/labeling); *travelled*, *travelling* (not traveled/traveling); *modelled*, *modelling*; *cancelled*, *cancelling*; *fuelled*, *fuelling*.
+- **Other common forms:** maths (not math), grey (not gray), aluminium (not aluminum), programme (TV/curriculum) vs program (software), practise (verb) / practice (noun), licence (noun) / license (verb).
+
+### Vocabulary rules — UK terms only
+- **rubber** (not eraser), **pavement** (not sidewalk), **lift** (not elevator), **rubbish** (not trash), **biscuit** (not cookie), **trousers** (not pants), **holiday** (not vacation).
+- **autumn** (not fall — except when meaning "to drop"), **at the weekend** (not "on the weekend"), **full stop** (not period), **have** / **have got** (not "have gotten").
+- **Year 7–13** (not "7th grade"), **secondary school** / **sixth form** (not high school), **pupil** (not student where context fits a school lesson).
+
+### Self-check before emitting content
+Before returning your section, scan your output for these specific patterns and correct them:
+1. Any word ending in **-ize**, **-izes**, **-ized**, **-izing**, **-yze**, **-yzes** → change to the **-ise** / **-yse** form.
+2. Any of: eraser, sidewalk, elevator, trash, cookie, vacation, "have gotten", "on the weekend", "period" (when used as punctuation), "math" → replace with the UK term above.
+3. Any **-or** ending in a noun where the **-our** form exists (colour, behaviour, favour, etc.).
+4. Any **-eled** / **-eling** / **-eler** / **-ueled** / **-ueling** / **-odeled** / **-anceled** ending → double the L (*labelled*, *travelling*, *modeller*, *fuelling*, *cancelled*).
+
+Do not mix British and American forms. If unsure, prefer the British form.
 ",
     "role": "developer",
   },
@@ -203,8 +245,29 @@ You will be given a specific task and the current state of the lesson plan. You 
 ## Markdown
 Do not use markdown formatting unless specified for a specific section.
 
-## Language
-Use British English spelling and vocabulary (e.g. colour not color, centre not centre, rubbish not trash) unless the user sets a different primary language. This reflects our UK teacher audience.
+## Language — British English (mandatory)
+Write **British English** throughout the lesson plan: spelling, vocabulary, and phrasing. This is mandatory because our audience is UK teachers and pupils. The only exception is if the user has explicitly set a different primary language for the lesson.
+
+### Spelling rules — apply these consistently
+- **Verbs ending in -ise/-yse, not -ize/-yze.** Always write *recognise*, *emphasise*, *utilise*, *organise*, *analyse*, *summarise*, *categorise*, *prioritise*. Never *recognize*, *emphasize*, *utilize*, *organize*, *analyze*. This applies to all tenses: *recognised*, *emphasising*, *utilised*.
+- **-our, not -or:** colour, behaviour, favour, neighbour, honour, labour.
+- **-re, not -er:** centre, metre, theatre, fibre, litre.
+- **Double the final L before suffixes** on verbs ending in a single vowel + L: *labelled*, *labelling* (not labeled/labeling); *travelled*, *travelling* (not traveled/traveling); *modelled*, *modelling*; *cancelled*, *cancelling*; *fuelled*, *fuelling*.
+- **Other common forms:** maths (not math), grey (not gray), aluminium (not aluminum), programme (TV/curriculum) vs program (software), practise (verb) / practice (noun), licence (noun) / license (verb).
+
+### Vocabulary rules — UK terms only
+- **rubber** (not eraser), **pavement** (not sidewalk), **lift** (not elevator), **rubbish** (not trash), **biscuit** (not cookie), **trousers** (not pants), **holiday** (not vacation).
+- **autumn** (not fall — except when meaning "to drop"), **at the weekend** (not "on the weekend"), **full stop** (not period), **have** / **have got** (not "have gotten").
+- **Year 7–13** (not "7th grade"), **secondary school** / **sixth form** (not high school), **pupil** (not student where context fits a school lesson).
+
+### Self-check before emitting content
+Before returning your section, scan your output for these specific patterns and correct them:
+1. Any word ending in **-ize**, **-izes**, **-ized**, **-izing**, **-yze**, **-yzes** → change to the **-ise** / **-yse** form.
+2. Any of: eraser, sidewalk, elevator, trash, cookie, vacation, "have gotten", "on the weekend", "period" (when used as punctuation), "math" → replace with the UK term above.
+3. Any **-or** ending in a noun where the **-our** form exists (colour, behaviour, favour, etc.).
+4. Any **-eled** / **-eling** / **-eler** / **-ueled** / **-ueling** / **-odeled** / **-anceled** ending → double the L (*labelled*, *travelling*, *modeller*, *fuelling*, *cancelled*).
+
+Do not mix British and American forms. If unsure, prefer the British form.
 ",
     "role": "developer",
   },
@@ -293,8 +356,29 @@ You will be given a specific task and the current state of the lesson plan. You 
 ## Markdown
 Do not use markdown formatting unless specified for a specific section.
 
-## Language
-Use British English spelling and vocabulary (e.g. colour not color, centre not centre, rubbish not trash) unless the user sets a different primary language. This reflects our UK teacher audience.
+## Language — British English (mandatory)
+Write **British English** throughout the lesson plan: spelling, vocabulary, and phrasing. This is mandatory because our audience is UK teachers and pupils. The only exception is if the user has explicitly set a different primary language for the lesson.
+
+### Spelling rules — apply these consistently
+- **Verbs ending in -ise/-yse, not -ize/-yze.** Always write *recognise*, *emphasise*, *utilise*, *organise*, *analyse*, *summarise*, *categorise*, *prioritise*. Never *recognize*, *emphasize*, *utilize*, *organize*, *analyze*. This applies to all tenses: *recognised*, *emphasising*, *utilised*.
+- **-our, not -or:** colour, behaviour, favour, neighbour, honour, labour.
+- **-re, not -er:** centre, metre, theatre, fibre, litre.
+- **Double the final L before suffixes** on verbs ending in a single vowel + L: *labelled*, *labelling* (not labeled/labeling); *travelled*, *travelling* (not traveled/traveling); *modelled*, *modelling*; *cancelled*, *cancelling*; *fuelled*, *fuelling*.
+- **Other common forms:** maths (not math), grey (not gray), aluminium (not aluminum), programme (TV/curriculum) vs program (software), practise (verb) / practice (noun), licence (noun) / license (verb).
+
+### Vocabulary rules — UK terms only
+- **rubber** (not eraser), **pavement** (not sidewalk), **lift** (not elevator), **rubbish** (not trash), **biscuit** (not cookie), **trousers** (not pants), **holiday** (not vacation).
+- **autumn** (not fall — except when meaning "to drop"), **at the weekend** (not "on the weekend"), **full stop** (not period), **have** / **have got** (not "have gotten").
+- **Year 7–13** (not "7th grade"), **secondary school** / **sixth form** (not high school), **pupil** (not student where context fits a school lesson).
+
+### Self-check before emitting content
+Before returning your section, scan your output for these specific patterns and correct them:
+1. Any word ending in **-ize**, **-izes**, **-ized**, **-izing**, **-yze**, **-yzes** → change to the **-ise** / **-yse** form.
+2. Any of: eraser, sidewalk, elevator, trash, cookie, vacation, "have gotten", "on the weekend", "period" (when used as punctuation), "math" → replace with the UK term above.
+3. Any **-or** ending in a noun where the **-our** form exists (colour, behaviour, favour, etc.).
+4. Any **-eled** / **-eling** / **-eler** / **-ueled** / **-ueling** / **-odeled** / **-anceled** ending → double the L (*labelled*, *travelling*, *modeller*, *fuelling*, *cancelled*).
+
+Do not mix British and American forms. If unsure, prefer the British form.
 ",
     "role": "developer",
   },
@@ -383,8 +467,29 @@ You will be given a specific task and the current state of the lesson plan. You 
 ## Markdown
 Do not use markdown formatting unless specified for a specific section.
 
-## Language
-Use British English spelling and vocabulary (e.g. colour not color, centre not centre, rubbish not trash) unless the user sets a different primary language. This reflects our UK teacher audience.
+## Language — British English (mandatory)
+Write **British English** throughout the lesson plan: spelling, vocabulary, and phrasing. This is mandatory because our audience is UK teachers and pupils. The only exception is if the user has explicitly set a different primary language for the lesson.
+
+### Spelling rules — apply these consistently
+- **Verbs ending in -ise/-yse, not -ize/-yze.** Always write *recognise*, *emphasise*, *utilise*, *organise*, *analyse*, *summarise*, *categorise*, *prioritise*. Never *recognize*, *emphasize*, *utilize*, *organize*, *analyze*. This applies to all tenses: *recognised*, *emphasising*, *utilised*.
+- **-our, not -or:** colour, behaviour, favour, neighbour, honour, labour.
+- **-re, not -er:** centre, metre, theatre, fibre, litre.
+- **Double the final L before suffixes** on verbs ending in a single vowel + L: *labelled*, *labelling* (not labeled/labeling); *travelled*, *travelling* (not traveled/traveling); *modelled*, *modelling*; *cancelled*, *cancelling*; *fuelled*, *fuelling*.
+- **Other common forms:** maths (not math), grey (not gray), aluminium (not aluminum), programme (TV/curriculum) vs program (software), practise (verb) / practice (noun), licence (noun) / license (verb).
+
+### Vocabulary rules — UK terms only
+- **rubber** (not eraser), **pavement** (not sidewalk), **lift** (not elevator), **rubbish** (not trash), **biscuit** (not cookie), **trousers** (not pants), **holiday** (not vacation).
+- **autumn** (not fall — except when meaning "to drop"), **at the weekend** (not "on the weekend"), **full stop** (not period), **have** / **have got** (not "have gotten").
+- **Year 7–13** (not "7th grade"), **secondary school** / **sixth form** (not high school), **pupil** (not student where context fits a school lesson).
+
+### Self-check before emitting content
+Before returning your section, scan your output for these specific patterns and correct them:
+1. Any word ending in **-ize**, **-izes**, **-ized**, **-izing**, **-yze**, **-yzes** → change to the **-ise** / **-yse** form.
+2. Any of: eraser, sidewalk, elevator, trash, cookie, vacation, "have gotten", "on the weekend", "period" (when used as punctuation), "math" → replace with the UK term above.
+3. Any **-or** ending in a noun where the **-our** form exists (colour, behaviour, favour, etc.).
+4. Any **-eled** / **-eling** / **-eler** / **-ueled** / **-ueling** / **-odeled** / **-anceled** ending → double the L (*labelled*, *travelling*, *modeller*, *fuelling*, *cancelled*).
+
+Do not mix British and American forms. If unsure, prefer the British form.
 ",
     "role": "developer",
   },
@@ -465,8 +570,29 @@ You will be given a specific task and the current state of the lesson plan. You 
 ## Markdown
 Do not use markdown formatting unless specified for a specific section.
 
-## Language
-Use British English spelling and vocabulary (e.g. colour not color, centre not centre, rubbish not trash) unless the user sets a different primary language. This reflects our UK teacher audience.
+## Language — British English (mandatory)
+Write **British English** throughout the lesson plan: spelling, vocabulary, and phrasing. This is mandatory because our audience is UK teachers and pupils. The only exception is if the user has explicitly set a different primary language for the lesson.
+
+### Spelling rules — apply these consistently
+- **Verbs ending in -ise/-yse, not -ize/-yze.** Always write *recognise*, *emphasise*, *utilise*, *organise*, *analyse*, *summarise*, *categorise*, *prioritise*. Never *recognize*, *emphasize*, *utilize*, *organize*, *analyze*. This applies to all tenses: *recognised*, *emphasising*, *utilised*.
+- **-our, not -or:** colour, behaviour, favour, neighbour, honour, labour.
+- **-re, not -er:** centre, metre, theatre, fibre, litre.
+- **Double the final L before suffixes** on verbs ending in a single vowel + L: *labelled*, *labelling* (not labeled/labeling); *travelled*, *travelling* (not traveled/traveling); *modelled*, *modelling*; *cancelled*, *cancelling*; *fuelled*, *fuelling*.
+- **Other common forms:** maths (not math), grey (not gray), aluminium (not aluminum), programme (TV/curriculum) vs program (software), practise (verb) / practice (noun), licence (noun) / license (verb).
+
+### Vocabulary rules — UK terms only
+- **rubber** (not eraser), **pavement** (not sidewalk), **lift** (not elevator), **rubbish** (not trash), **biscuit** (not cookie), **trousers** (not pants), **holiday** (not vacation).
+- **autumn** (not fall — except when meaning "to drop"), **at the weekend** (not "on the weekend"), **full stop** (not period), **have** / **have got** (not "have gotten").
+- **Year 7–13** (not "7th grade"), **secondary school** / **sixth form** (not high school), **pupil** (not student where context fits a school lesson).
+
+### Self-check before emitting content
+Before returning your section, scan your output for these specific patterns and correct them:
+1. Any word ending in **-ize**, **-izes**, **-ized**, **-izing**, **-yze**, **-yzes** → change to the **-ise** / **-yse** form.
+2. Any of: eraser, sidewalk, elevator, trash, cookie, vacation, "have gotten", "on the weekend", "period" (when used as punctuation), "math" → replace with the UK term above.
+3. Any **-or** ending in a noun where the **-our** form exists (colour, behaviour, favour, etc.).
+4. Any **-eled** / **-eling** / **-eler** / **-ueled** / **-ueling** / **-odeled** / **-anceled** ending → double the L (*labelled*, *travelling*, *modeller*, *fuelling*, *cancelled*).
+
+Do not mix British and American forms. If unsure, prefer the British form.
 ",
     "role": "developer",
   },
@@ -555,8 +681,29 @@ You will be given a specific task and the current state of the lesson plan. You 
 ## Markdown
 Do not use markdown formatting unless specified for a specific section.
 
-## Language
-Use British English spelling and vocabulary (e.g. colour not color, centre not centre, rubbish not trash) unless the user sets a different primary language. This reflects our UK teacher audience.
+## Language — British English (mandatory)
+Write **British English** throughout the lesson plan: spelling, vocabulary, and phrasing. This is mandatory because our audience is UK teachers and pupils. The only exception is if the user has explicitly set a different primary language for the lesson.
+
+### Spelling rules — apply these consistently
+- **Verbs ending in -ise/-yse, not -ize/-yze.** Always write *recognise*, *emphasise*, *utilise*, *organise*, *analyse*, *summarise*, *categorise*, *prioritise*. Never *recognize*, *emphasize*, *utilize*, *organize*, *analyze*. This applies to all tenses: *recognised*, *emphasising*, *utilised*.
+- **-our, not -or:** colour, behaviour, favour, neighbour, honour, labour.
+- **-re, not -er:** centre, metre, theatre, fibre, litre.
+- **Double the final L before suffixes** on verbs ending in a single vowel + L: *labelled*, *labelling* (not labeled/labeling); *travelled*, *travelling* (not traveled/traveling); *modelled*, *modelling*; *cancelled*, *cancelling*; *fuelled*, *fuelling*.
+- **Other common forms:** maths (not math), grey (not gray), aluminium (not aluminum), programme (TV/curriculum) vs program (software), practise (verb) / practice (noun), licence (noun) / license (verb).
+
+### Vocabulary rules — UK terms only
+- **rubber** (not eraser), **pavement** (not sidewalk), **lift** (not elevator), **rubbish** (not trash), **biscuit** (not cookie), **trousers** (not pants), **holiday** (not vacation).
+- **autumn** (not fall — except when meaning "to drop"), **at the weekend** (not "on the weekend"), **full stop** (not period), **have** / **have got** (not "have gotten").
+- **Year 7–13** (not "7th grade"), **secondary school** / **sixth form** (not high school), **pupil** (not student where context fits a school lesson).
+
+### Self-check before emitting content
+Before returning your section, scan your output for these specific patterns and correct them:
+1. Any word ending in **-ize**, **-izes**, **-ized**, **-izing**, **-yze**, **-yzes** → change to the **-ise** / **-yse** form.
+2. Any of: eraser, sidewalk, elevator, trash, cookie, vacation, "have gotten", "on the weekend", "period" (when used as punctuation), "math" → replace with the UK term above.
+3. Any **-or** ending in a noun where the **-our** form exists (colour, behaviour, favour, etc.).
+4. Any **-eled** / **-eling** / **-eler** / **-ueled** / **-ueling** / **-odeled** / **-anceled** ending → double the L (*labelled*, *travelling*, *modeller*, *fuelling*, *cancelled*).
+
+Do not mix British and American forms. If unsure, prefer the British form.
 ",
     "role": "developer",
   },
@@ -636,8 +783,29 @@ You will be given a specific task and the current state of the lesson plan. You 
 ## Markdown
 Do not use markdown formatting unless specified for a specific section.
 
-## Language
-Use British English spelling and vocabulary (e.g. colour not color, centre not centre, rubbish not trash) unless the user sets a different primary language. This reflects our UK teacher audience.
+## Language — British English (mandatory)
+Write **British English** throughout the lesson plan: spelling, vocabulary, and phrasing. This is mandatory because our audience is UK teachers and pupils. The only exception is if the user has explicitly set a different primary language for the lesson.
+
+### Spelling rules — apply these consistently
+- **Verbs ending in -ise/-yse, not -ize/-yze.** Always write *recognise*, *emphasise*, *utilise*, *organise*, *analyse*, *summarise*, *categorise*, *prioritise*. Never *recognize*, *emphasize*, *utilize*, *organize*, *analyze*. This applies to all tenses: *recognised*, *emphasising*, *utilised*.
+- **-our, not -or:** colour, behaviour, favour, neighbour, honour, labour.
+- **-re, not -er:** centre, metre, theatre, fibre, litre.
+- **Double the final L before suffixes** on verbs ending in a single vowel + L: *labelled*, *labelling* (not labeled/labeling); *travelled*, *travelling* (not traveled/traveling); *modelled*, *modelling*; *cancelled*, *cancelling*; *fuelled*, *fuelling*.
+- **Other common forms:** maths (not math), grey (not gray), aluminium (not aluminum), programme (TV/curriculum) vs program (software), practise (verb) / practice (noun), licence (noun) / license (verb).
+
+### Vocabulary rules — UK terms only
+- **rubber** (not eraser), **pavement** (not sidewalk), **lift** (not elevator), **rubbish** (not trash), **biscuit** (not cookie), **trousers** (not pants), **holiday** (not vacation).
+- **autumn** (not fall — except when meaning "to drop"), **at the weekend** (not "on the weekend"), **full stop** (not period), **have** / **have got** (not "have gotten").
+- **Year 7–13** (not "7th grade"), **secondary school** / **sixth form** (not high school), **pupil** (not student where context fits a school lesson).
+
+### Self-check before emitting content
+Before returning your section, scan your output for these specific patterns and correct them:
+1. Any word ending in **-ize**, **-izes**, **-ized**, **-izing**, **-yze**, **-yzes** → change to the **-ise** / **-yse** form.
+2. Any of: eraser, sidewalk, elevator, trash, cookie, vacation, "have gotten", "on the weekend", "period" (when used as punctuation), "math" → replace with the UK term above.
+3. Any **-or** ending in a noun where the **-our** form exists (colour, behaviour, favour, etc.).
+4. Any **-eled** / **-eling** / **-eler** / **-ueled** / **-ueling** / **-odeled** / **-anceled** ending → double the L (*labelled*, *travelling*, *modeller*, *fuelling*, *cancelled*).
+
+Do not mix British and American forms. If unsure, prefer the British form.
 ",
     "role": "developer",
   },
@@ -719,8 +887,29 @@ You will be given a specific task and the current state of the lesson plan. You 
 ## Markdown
 Do not use markdown formatting unless specified for a specific section.
 
-## Language
-Use British English spelling and vocabulary (e.g. colour not color, centre not centre, rubbish not trash) unless the user sets a different primary language. This reflects our UK teacher audience.
+## Language — British English (mandatory)
+Write **British English** throughout the lesson plan: spelling, vocabulary, and phrasing. This is mandatory because our audience is UK teachers and pupils. The only exception is if the user has explicitly set a different primary language for the lesson.
+
+### Spelling rules — apply these consistently
+- **Verbs ending in -ise/-yse, not -ize/-yze.** Always write *recognise*, *emphasise*, *utilise*, *organise*, *analyse*, *summarise*, *categorise*, *prioritise*. Never *recognize*, *emphasize*, *utilize*, *organize*, *analyze*. This applies to all tenses: *recognised*, *emphasising*, *utilised*.
+- **-our, not -or:** colour, behaviour, favour, neighbour, honour, labour.
+- **-re, not -er:** centre, metre, theatre, fibre, litre.
+- **Double the final L before suffixes** on verbs ending in a single vowel + L: *labelled*, *labelling* (not labeled/labeling); *travelled*, *travelling* (not traveled/traveling); *modelled*, *modelling*; *cancelled*, *cancelling*; *fuelled*, *fuelling*.
+- **Other common forms:** maths (not math), grey (not gray), aluminium (not aluminum), programme (TV/curriculum) vs program (software), practise (verb) / practice (noun), licence (noun) / license (verb).
+
+### Vocabulary rules — UK terms only
+- **rubber** (not eraser), **pavement** (not sidewalk), **lift** (not elevator), **rubbish** (not trash), **biscuit** (not cookie), **trousers** (not pants), **holiday** (not vacation).
+- **autumn** (not fall — except when meaning "to drop"), **at the weekend** (not "on the weekend"), **full stop** (not period), **have** / **have got** (not "have gotten").
+- **Year 7–13** (not "7th grade"), **secondary school** / **sixth form** (not high school), **pupil** (not student where context fits a school lesson).
+
+### Self-check before emitting content
+Before returning your section, scan your output for these specific patterns and correct them:
+1. Any word ending in **-ize**, **-izes**, **-ized**, **-izing**, **-yze**, **-yzes** → change to the **-ise** / **-yse** form.
+2. Any of: eraser, sidewalk, elevator, trash, cookie, vacation, "have gotten", "on the weekend", "period" (when used as punctuation), "math" → replace with the UK term above.
+3. Any **-or** ending in a noun where the **-our** form exists (colour, behaviour, favour, etc.).
+4. Any **-eled** / **-eling** / **-eler** / **-ueled** / **-ueling** / **-odeled** / **-anceled** ending → double the L (*labelled*, *travelling*, *modeller*, *fuelling*, *cancelled*).
+
+Do not mix British and American forms. If unsure, prefer the British form.
 ",
     "role": "developer",
   },
@@ -809,8 +998,29 @@ You will be given a specific task and the current state of the lesson plan. You 
 ## Markdown
 Do not use markdown formatting unless specified for a specific section.
 
-## Language
-Use British English spelling and vocabulary (e.g. colour not color, centre not centre, rubbish not trash) unless the user sets a different primary language. This reflects our UK teacher audience.
+## Language — British English (mandatory)
+Write **British English** throughout the lesson plan: spelling, vocabulary, and phrasing. This is mandatory because our audience is UK teachers and pupils. The only exception is if the user has explicitly set a different primary language for the lesson.
+
+### Spelling rules — apply these consistently
+- **Verbs ending in -ise/-yse, not -ize/-yze.** Always write *recognise*, *emphasise*, *utilise*, *organise*, *analyse*, *summarise*, *categorise*, *prioritise*. Never *recognize*, *emphasize*, *utilize*, *organize*, *analyze*. This applies to all tenses: *recognised*, *emphasising*, *utilised*.
+- **-our, not -or:** colour, behaviour, favour, neighbour, honour, labour.
+- **-re, not -er:** centre, metre, theatre, fibre, litre.
+- **Double the final L before suffixes** on verbs ending in a single vowel + L: *labelled*, *labelling* (not labeled/labeling); *travelled*, *travelling* (not traveled/traveling); *modelled*, *modelling*; *cancelled*, *cancelling*; *fuelled*, *fuelling*.
+- **Other common forms:** maths (not math), grey (not gray), aluminium (not aluminum), programme (TV/curriculum) vs program (software), practise (verb) / practice (noun), licence (noun) / license (verb).
+
+### Vocabulary rules — UK terms only
+- **rubber** (not eraser), **pavement** (not sidewalk), **lift** (not elevator), **rubbish** (not trash), **biscuit** (not cookie), **trousers** (not pants), **holiday** (not vacation).
+- **autumn** (not fall — except when meaning "to drop"), **at the weekend** (not "on the weekend"), **full stop** (not period), **have** / **have got** (not "have gotten").
+- **Year 7–13** (not "7th grade"), **secondary school** / **sixth form** (not high school), **pupil** (not student where context fits a school lesson).
+
+### Self-check before emitting content
+Before returning your section, scan your output for these specific patterns and correct them:
+1. Any word ending in **-ize**, **-izes**, **-ized**, **-izing**, **-yze**, **-yzes** → change to the **-ise** / **-yse** form.
+2. Any of: eraser, sidewalk, elevator, trash, cookie, vacation, "have gotten", "on the weekend", "period" (when used as punctuation), "math" → replace with the UK term above.
+3. Any **-or** ending in a noun where the **-our** form exists (colour, behaviour, favour, etc.).
+4. Any **-eled** / **-eling** / **-eler** / **-ueled** / **-ueling** / **-odeled** / **-anceled** ending → double the L (*labelled*, *travelling*, *modeller*, *fuelling*, *cancelled*).
+
+Do not mix British and American forms. If unsure, prefer the British form.
 ",
     "role": "developer",
   },
@@ -896,8 +1106,29 @@ You will be given a specific task and the current state of the lesson plan. You 
 ## Markdown
 Do not use markdown formatting unless specified for a specific section.
 
-## Language
-Use British English spelling and vocabulary (e.g. colour not color, centre not centre, rubbish not trash) unless the user sets a different primary language. This reflects our UK teacher audience.
+## Language — British English (mandatory)
+Write **British English** throughout the lesson plan: spelling, vocabulary, and phrasing. This is mandatory because our audience is UK teachers and pupils. The only exception is if the user has explicitly set a different primary language for the lesson.
+
+### Spelling rules — apply these consistently
+- **Verbs ending in -ise/-yse, not -ize/-yze.** Always write *recognise*, *emphasise*, *utilise*, *organise*, *analyse*, *summarise*, *categorise*, *prioritise*. Never *recognize*, *emphasize*, *utilize*, *organize*, *analyze*. This applies to all tenses: *recognised*, *emphasising*, *utilised*.
+- **-our, not -or:** colour, behaviour, favour, neighbour, honour, labour.
+- **-re, not -er:** centre, metre, theatre, fibre, litre.
+- **Double the final L before suffixes** on verbs ending in a single vowel + L: *labelled*, *labelling* (not labeled/labeling); *travelled*, *travelling* (not traveled/traveling); *modelled*, *modelling*; *cancelled*, *cancelling*; *fuelled*, *fuelling*.
+- **Other common forms:** maths (not math), grey (not gray), aluminium (not aluminum), programme (TV/curriculum) vs program (software), practise (verb) / practice (noun), licence (noun) / license (verb).
+
+### Vocabulary rules — UK terms only
+- **rubber** (not eraser), **pavement** (not sidewalk), **lift** (not elevator), **rubbish** (not trash), **biscuit** (not cookie), **trousers** (not pants), **holiday** (not vacation).
+- **autumn** (not fall — except when meaning "to drop"), **at the weekend** (not "on the weekend"), **full stop** (not period), **have** / **have got** (not "have gotten").
+- **Year 7–13** (not "7th grade"), **secondary school** / **sixth form** (not high school), **pupil** (not student where context fits a school lesson).
+
+### Self-check before emitting content
+Before returning your section, scan your output for these specific patterns and correct them:
+1. Any word ending in **-ize**, **-izes**, **-ized**, **-izing**, **-yze**, **-yzes** → change to the **-ise** / **-yse** form.
+2. Any of: eraser, sidewalk, elevator, trash, cookie, vacation, "have gotten", "on the weekend", "period" (when used as punctuation), "math" → replace with the UK term above.
+3. Any **-or** ending in a noun where the **-our** form exists (colour, behaviour, favour, etc.).
+4. Any **-eled** / **-eling** / **-eler** / **-ueled** / **-ueling** / **-odeled** / **-anceled** ending → double the L (*labelled*, *travelling*, *modeller*, *fuelling*, *cancelled*).
+
+Do not mix British and American forms. If unsure, prefer the British form.
 ",
     "role": "developer",
   },
@@ -983,8 +1214,29 @@ You will be given a specific task and the current state of the lesson plan. You 
 ## Markdown
 Do not use markdown formatting unless specified for a specific section.
 
-## Language
-Use British English spelling and vocabulary (e.g. colour not color, centre not centre, rubbish not trash) unless the user sets a different primary language. This reflects our UK teacher audience.
+## Language — British English (mandatory)
+Write **British English** throughout the lesson plan: spelling, vocabulary, and phrasing. This is mandatory because our audience is UK teachers and pupils. The only exception is if the user has explicitly set a different primary language for the lesson.
+
+### Spelling rules — apply these consistently
+- **Verbs ending in -ise/-yse, not -ize/-yze.** Always write *recognise*, *emphasise*, *utilise*, *organise*, *analyse*, *summarise*, *categorise*, *prioritise*. Never *recognize*, *emphasize*, *utilize*, *organize*, *analyze*. This applies to all tenses: *recognised*, *emphasising*, *utilised*.
+- **-our, not -or:** colour, behaviour, favour, neighbour, honour, labour.
+- **-re, not -er:** centre, metre, theatre, fibre, litre.
+- **Double the final L before suffixes** on verbs ending in a single vowel + L: *labelled*, *labelling* (not labeled/labeling); *travelled*, *travelling* (not traveled/traveling); *modelled*, *modelling*; *cancelled*, *cancelling*; *fuelled*, *fuelling*.
+- **Other common forms:** maths (not math), grey (not gray), aluminium (not aluminum), programme (TV/curriculum) vs program (software), practise (verb) / practice (noun), licence (noun) / license (verb).
+
+### Vocabulary rules — UK terms only
+- **rubber** (not eraser), **pavement** (not sidewalk), **lift** (not elevator), **rubbish** (not trash), **biscuit** (not cookie), **trousers** (not pants), **holiday** (not vacation).
+- **autumn** (not fall — except when meaning "to drop"), **at the weekend** (not "on the weekend"), **full stop** (not period), **have** / **have got** (not "have gotten").
+- **Year 7–13** (not "7th grade"), **secondary school** / **sixth form** (not high school), **pupil** (not student where context fits a school lesson).
+
+### Self-check before emitting content
+Before returning your section, scan your output for these specific patterns and correct them:
+1. Any word ending in **-ize**, **-izes**, **-ized**, **-izing**, **-yze**, **-yzes** → change to the **-ise** / **-yse** form.
+2. Any of: eraser, sidewalk, elevator, trash, cookie, vacation, "have gotten", "on the weekend", "period" (when used as punctuation), "math" → replace with the UK term above.
+3. Any **-or** ending in a noun where the **-our** form exists (colour, behaviour, favour, etc.).
+4. Any **-eled** / **-eling** / **-eler** / **-ueled** / **-ueling** / **-odeled** / **-anceled** ending → double the L (*labelled*, *travelling*, *modeller*, *fuelling*, *cancelled*).
+
+Do not mix British and American forms. If unsure, prefer the British form.
 ",
     "role": "developer",
   },

--- a/packages/aila/src/lib/agentic-system/agents/britishEnglishCorrectorAgent/britishEnglishCorrectorAgent.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/britishEnglishCorrectorAgent/britishEnglishCorrectorAgent.instructions.ts
@@ -1,0 +1,18 @@
+import { britishEnglishRules } from "../shared/britishEnglishRules";
+
+export const britishEnglishCorrectorAgentInstructions = `# Identity
+You rewrite a single section of an Oak National Academy lesson plan to remove Americanisms and use standard British English suitable for UK teachers and pupils.
+
+# Task
+You receive a single lesson-plan section as JSON, plus a list of Americanisms detected in that section with their British alternatives. Return the section corrected into British English, preserving structure and meaning.
+
+# Constraints
+- Do not change keys or structure. Return the same shape you received.
+- Do not change the educational meaning of the content.
+- Preserve case: "Recognize" → "Recognise", "RECOGNIZE" → "RECOGNISE".
+- Apply British English consistently across the section, not only to the listed phrases — if you notice closely related Americanisms in the same section, convert those to British English too.
+- Do not add commentary, markdown, or explanations.
+
+# British English rules
+
+${britishEnglishRules}`;

--- a/packages/aila/src/lib/agentic-system/agents/britishEnglishCorrectorAgent/createBritishEnglishCorrectorAgent.ts
+++ b/packages/aila/src/lib/agentic-system/agents/britishEnglishCorrectorAgent/createBritishEnglishCorrectorAgent.ts
@@ -1,0 +1,68 @@
+import type { z } from "zod";
+
+import {
+  AMERICANISM_ISSUE_KIND,
+  type AmericanismIssue,
+} from "../../../../features/americanisms";
+import { DEFAULT_AGENT_MODEL_PARAMS } from "../../constants";
+import type { GenericPromptAgent, SectionKey } from "../../schema";
+import { britishEnglishCorrectorAgentInstructions } from "./britishEnglishCorrectorAgent.instructions";
+
+const issueKindLabel = (issue: AmericanismIssue["issue"]): string => {
+  switch (issue) {
+    case AMERICANISM_ISSUE_KIND.SPELLING:
+      return "spelling";
+    case AMERICANISM_ISSUE_KIND.PHRASING:
+      return "phrasing";
+    case AMERICANISM_ISSUE_KIND.MEANING:
+      return "meaning";
+  }
+};
+
+const issueDetail = (issue: AmericanismIssue): string => {
+  if (issue.issue === AMERICANISM_ISSUE_KIND.MEANING) {
+    return "context-dependent — only correct if used in a US sense";
+  }
+  return issue.details;
+};
+
+const issuesBlock = (issues: AmericanismIssue[]): string => {
+  const lines = issues.map(
+    (i) => `- "${i.phrase}" → ${issueDetail(i)} (${issueKindLabel(i.issue)})`,
+  );
+  return `Issues detected in this section:\n${lines.join("\n")}`;
+};
+
+export type BritishEnglishCorrectorAgentProps = {
+  sectionKey: SectionKey;
+  content: unknown;
+  issues: AmericanismIssue[];
+  responseSchema: z.ZodTypeAny;
+};
+
+export function createBritishEnglishCorrectorAgent({
+  sectionKey,
+  content,
+  issues,
+  responseSchema,
+}: BritishEnglishCorrectorAgentProps): GenericPromptAgent<unknown> {
+  return {
+    responseSchema,
+    input: [
+      {
+        role: "developer" as const,
+        content: britishEnglishCorrectorAgentInstructions,
+      },
+      {
+        role: "developer" as const,
+        content: `Section key: ${sectionKey}`,
+      },
+      { role: "developer" as const, content: issuesBlock(issues) },
+      {
+        role: "user" as const,
+        content: `Original section JSON:\n${JSON.stringify(content)}`,
+      },
+    ],
+    modelParams: DEFAULT_AGENT_MODEL_PARAMS,
+  };
+}

--- a/packages/aila/src/lib/agentic-system/agents/britishEnglishCorrectorAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/britishEnglishCorrectorAgent/index.ts
@@ -1,0 +1,18 @@
+import type OpenAI from "openai";
+
+import type { AgentResult } from "../../types";
+import { executeGenericPromptAgent } from "../executeGenericPromptAgent";
+import {
+  type BritishEnglishCorrectorAgentProps,
+  createBritishEnglishCorrectorAgent,
+} from "./createBritishEnglishCorrectorAgent";
+
+export type { BritishEnglishCorrectorAgentProps } from "./createBritishEnglishCorrectorAgent";
+
+export const createOpenAIBritishEnglishCorrectorAgent =
+  (openai: OpenAI) =>
+  (props: BritishEnglishCorrectorAgentProps): Promise<AgentResult<unknown>> =>
+    executeGenericPromptAgent({
+      agent: createBritishEnglishCorrectorAgent(props),
+      openai,
+    });

--- a/packages/aila/src/lib/agentic-system/agents/plannerAgent/__snapshots__/createPlannerAgent.test.ts.snap
+++ b/packages/aila/src/lib/agentic-system/agents/plannerAgent/__snapshots__/createPlannerAgent.test.ts.snap
@@ -156,6 +156,7 @@ When creating plan steps, extract any user-provided instructions specific to tha
 - For other sections: specific guidance about content, style, or approach
 - Set \`sectionInstructions\` to \`null\` if no specific preferences are mentioned
 - Keep instructions concise but preserve user intent
+- **Write \`sectionInstructions\` in British English.** They are passed verbatim to section agents, so any Americanism here will seed the generated content. If the user's message uses American spellings or vocabulary (e.g. *color*, *organize*, *eraser*, *math*), rephrase them in British English (*colour*, *organise*, *rubber*, *maths*) when extracting. In particular, write verbs in the **-ise** form (*emphasise*, *recognise*, *summarise*), never the *-ize* form.
 
 ---
 
@@ -393,6 +394,7 @@ When creating plan steps, extract any user-provided instructions specific to tha
 - For other sections: specific guidance about content, style, or approach
 - Set \`sectionInstructions\` to \`null\` if no specific preferences are mentioned
 - Keep instructions concise but preserve user intent
+- **Write \`sectionInstructions\` in British English.** They are passed verbatim to section agents, so any Americanism here will seed the generated content. If the user's message uses American spellings or vocabulary (e.g. *color*, *organize*, *eraser*, *math*), rephrase them in British English (*colour*, *organise*, *rubber*, *maths*) when extracting. In particular, write verbs in the **-ise** form (*emphasise*, *recognise*, *summarise*), never the *-ize* form.
 
 ---
 
@@ -621,6 +623,7 @@ When creating plan steps, extract any user-provided instructions specific to tha
 - For other sections: specific guidance about content, style, or approach
 - Set \`sectionInstructions\` to \`null\` if no specific preferences are mentioned
 - Keep instructions concise but preserve user intent
+- **Write \`sectionInstructions\` in British English.** They are passed verbatim to section agents, so any Americanism here will seed the generated content. If the user's message uses American spellings or vocabulary (e.g. *color*, *organize*, *eraser*, *math*), rephrase them in British English (*colour*, *organise*, *rubber*, *maths*) when extracting. In particular, write verbs in the **-ise** form (*emphasise*, *recognise*, *summarise*), never the *-ize* form.
 
 ---
 
@@ -858,6 +861,7 @@ When creating plan steps, extract any user-provided instructions specific to tha
 - For other sections: specific guidance about content, style, or approach
 - Set \`sectionInstructions\` to \`null\` if no specific preferences are mentioned
 - Keep instructions concise but preserve user intent
+- **Write \`sectionInstructions\` in British English.** They are passed verbatim to section agents, so any Americanism here will seed the generated content. If the user's message uses American spellings or vocabulary (e.g. *color*, *organize*, *eraser*, *math*), rephrase them in British English (*colour*, *organise*, *rubber*, *maths*) when extracting. In particular, write verbs in the **-ise** form (*emphasise*, *recognise*, *summarise*), never the *-ize* form.
 
 ---
 
@@ -1084,6 +1088,7 @@ When creating plan steps, extract any user-provided instructions specific to tha
 - For other sections: specific guidance about content, style, or approach
 - Set \`sectionInstructions\` to \`null\` if no specific preferences are mentioned
 - Keep instructions concise but preserve user intent
+- **Write \`sectionInstructions\` in British English.** They are passed verbatim to section agents, so any Americanism here will seed the generated content. If the user's message uses American spellings or vocabulary (e.g. *color*, *organize*, *eraser*, *math*), rephrase them in British English (*colour*, *organise*, *rubber*, *maths*) when extracting. In particular, write verbs in the **-ise** form (*emphasise*, *recognise*, *summarise*), never the *-ize* form.
 
 ---
 
@@ -1321,6 +1326,7 @@ When creating plan steps, extract any user-provided instructions specific to tha
 - For other sections: specific guidance about content, style, or approach
 - Set \`sectionInstructions\` to \`null\` if no specific preferences are mentioned
 - Keep instructions concise but preserve user intent
+- **Write \`sectionInstructions\` in British English.** They are passed verbatim to section agents, so any Americanism here will seed the generated content. If the user's message uses American spellings or vocabulary (e.g. *color*, *organize*, *eraser*, *math*), rephrase them in British English (*colour*, *organise*, *rubber*, *maths*) when extracting. In particular, write verbs in the **-ise** form (*emphasise*, *recognise*, *summarise*), never the *-ize* form.
 
 ---
 

--- a/packages/aila/src/lib/agentic-system/agents/plannerAgent/plannerAgent.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/plannerAgent/plannerAgent.instructions.ts
@@ -151,6 +151,7 @@ When creating plan steps, extract any user-provided instructions specific to tha
 - For other sections: specific guidance about content, style, or approach
 - Set \`sectionInstructions\` to \`null\` if no specific preferences are mentioned
 - Keep instructions concise but preserve user intent
+- **Write \`sectionInstructions\` in British English.** They are passed verbatim to section agents, so any Americanism here will seed the generated content. If the user's message uses American spellings or vocabulary (e.g. *color*, *organize*, *eraser*, *math*), rephrase them in British English (*colour*, *organise*, *rubber*, *maths*) when extracting. In particular, write verbs in the **-ise** form (*emphasise*, *recognise*, *summarise*), never the *-ize* form.
 
 ---
 

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/shared/identityAndVoice.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/shared/identityAndVoice.ts
@@ -1,3 +1,6 @@
+// cspell:ignore izes ized izing yzes eled eling eler ueled ueling odeled anceled sidewalk
+import { britishEnglishRules } from "../../shared/britishEnglishRules";
+
 /**
  * This is context for all Aila agents.
  * It contains shared information that can be used by all agents.
@@ -15,6 +18,17 @@ You will be given a specific task and the current state of the lesson plan. You 
 ## Markdown
 Do not use markdown formatting unless specified for a specific section.
 
-## Language
-Use British English spelling and vocabulary (e.g. colour not color, centre not centre, rubbish not trash) unless the user sets a different primary language. This reflects our UK teacher audience.
+## Language — British English (mandatory)
+Write **British English** throughout the lesson plan: spelling, vocabulary, and phrasing. This is mandatory because our audience is UK teachers and pupils. The only exception is if the user has explicitly set a different primary language for the lesson.
+
+${britishEnglishRules}
+
+### Self-check before emitting content
+Before returning your section, scan your output for these specific patterns and correct them:
+1. Any word ending in **-ize**, **-izes**, **-ized**, **-izing**, **-yze**, **-yzes** → change to the **-ise** / **-yse** form.
+2. Any of: eraser, sidewalk, elevator, trash, cookie, vacation, "have gotten", "on the weekend", "period" (when used as punctuation), "math" → replace with the UK term above.
+3. Any **-or** ending in a noun where the **-our** form exists (colour, behaviour, favour, etc.).
+4. Any **-eled** / **-eling** / **-eler** / **-ueled** / **-ueling** / **-odeled** / **-anceled** ending → double the L (*labelled*, *travelling*, *modeller*, *fuelling*, *cancelled*).
+
+Do not mix British and American forms. If unsure, prefer the British form.
 `;

--- a/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.test.ts
@@ -62,6 +62,7 @@ describe("sectionToGenericPromptAgent", () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       sectionAgents: {} as any, // Mock - not used in this test
       messageToUserAgent: jest.fn(),
+      britishEnglishCorrectorAgent: jest.fn(),
       fetchRelevantLessons: jest.fn(),
       config: {
         mathsQuizEnabled: false,
@@ -76,6 +77,7 @@ describe("sectionToGenericPromptAgent", () => {
       relevantLessonsFetched: false,
       relevantLessons: mockRelevantLessons,
       currentStep: null,
+      correctorStats: { attempted: [], notNeeded: [], failed: [] },
     },
     callbacks: {
       onPlannerComplete: jest.fn(),

--- a/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.test.ts
@@ -56,6 +56,7 @@ describe("sectionToGenericPromptAgent", () => {
       messages: mockMessages,
       initialDocument: mockDocument,
       relevantLessons: mockRelevantLessons,
+      ragFetched: { status: "not_fetched", searchIdentity: null },
     },
     runtime: {
       plannerAgent: jest.fn(),
@@ -82,6 +83,7 @@ describe("sectionToGenericPromptAgent", () => {
     callbacks: {
       onPlannerComplete: jest.fn(),
       onSectionComplete: jest.fn(),
+      onRagFetchedChange: jest.fn(),
       onTurnComplete: jest.fn(),
       onTurnFailed: jest.fn(),
     },

--- a/packages/aila/src/lib/agentic-system/agents/shared/britishEnglishRules.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/shared/britishEnglishRules.test.ts
@@ -1,0 +1,15 @@
+import { britishEnglishCorrectorAgentInstructions } from "../britishEnglishCorrectorAgent/britishEnglishCorrectorAgent.instructions";
+import { identityAndVoice } from "../sectionAgents/shared/identityAndVoice";
+import { britishEnglishRules } from "./britishEnglishRules";
+
+describe("britishEnglishRules", () => {
+  it("is included verbatim in the section agents' identityAndVoice prompt", () => {
+    expect(identityAndVoice).toContain(britishEnglishRules);
+  });
+
+  it("is included verbatim in the corrector agent's instructions", () => {
+    expect(britishEnglishCorrectorAgentInstructions).toContain(
+      britishEnglishRules,
+    );
+  });
+});

--- a/packages/aila/src/lib/agentic-system/agents/shared/britishEnglishRules.ts
+++ b/packages/aila/src/lib/agentic-system/agents/shared/britishEnglishRules.ts
@@ -1,0 +1,21 @@
+// cspell:ignore recognize emphasize utilize organize analyze labeled labeling traveled traveling aluminum eraser sidewalk elevator gotten
+/**
+ * Canonical British English rules used by:
+ *   - sectionAgents identityAndVoice (preventive — applied during generation)
+ *   - britishEnglishCorrectorAgent (corrective — applied after detection)
+ *
+ * Edits here propagate to both agents. Both consumers concatenate this block
+ * into their prompt; keep it self-contained (no leading or trailing newlines)
+ * so callers control surrounding whitespace.
+ */
+export const britishEnglishRules = `### Spelling rules — apply these consistently
+- **Verbs ending in -ise/-yse, not -ize/-yze.** Always write *recognise*, *emphasise*, *utilise*, *organise*, *analyse*, *summarise*, *categorise*, *prioritise*. Never *recognize*, *emphasize*, *utilize*, *organize*, *analyze*. This applies to all tenses: *recognised*, *emphasising*, *utilised*.
+- **-our, not -or:** colour, behaviour, favour, neighbour, honour, labour.
+- **-re, not -er:** centre, metre, theatre, fibre, litre.
+- **Double the final L before suffixes** on verbs ending in a single vowel + L: *labelled*, *labelling* (not labeled/labeling); *travelled*, *travelling* (not traveled/traveling); *modelled*, *modelling*; *cancelled*, *cancelling*; *fuelled*, *fuelling*.
+- **Other common forms:** maths (not math), grey (not gray), aluminium (not aluminum), programme (TV/curriculum) vs program (software), practise (verb) / practice (noun), licence (noun) / license (verb).
+
+### Vocabulary rules — UK terms only
+- **rubber** (not eraser), **pavement** (not sidewalk), **lift** (not elevator), **rubbish** (not trash), **biscuit** (not cookie), **trousers** (not pants), **holiday** (not vacation).
+- **autumn** (not fall — except when meaning "to drop"), **at the weekend** (not "on the weekend"), **full stop** (not period), **have** / **have got** (not "have gotten").
+- **Year 7–13** (not "7th grade"), **secondary school** / **sixth form** (not high school), **pupil** (not student where context fits a school lesson).`;

--- a/packages/aila/src/lib/agentic-system/ailaTurn.e2e.test.ts
+++ b/packages/aila/src/lib/agentic-system/ailaTurn.e2e.test.ts
@@ -34,6 +34,7 @@ const runTurn = async (
   const callbacks: AilaTurnCallbacks = {
     onPlannerComplete: () => void 0,
     onSectionComplete: () => void 0,
+    onRagFetchedChange: () => Promise.resolve(),
     onTurnComplete: ({ document, ailaMessage }) => {
       nextDocCapture = document;
       messageCapture = ailaMessage;
@@ -100,6 +101,7 @@ describe("ailaTurn e2e happy path with continue loop", () => {
       messages,
       initialDocument: {},
       relevantLessons: null,
+      ragFetched: { status: "not_fetched", searchIdentity: null },
     };
 
     let currentDoc: PartialLessonPlan = persisted.initialDocument;

--- a/packages/aila/src/lib/agentic-system/ailaTurn.e2e.test.ts
+++ b/packages/aila/src/lib/agentic-system/ailaTurn.e2e.test.ts
@@ -4,6 +4,7 @@ import {
   CompletedLessonPlanSchema,
   type PartialLessonPlan,
 } from "../../protocol/schema";
+import { createOpenAIBritishEnglishCorrectorAgent } from "./agents/britishEnglishCorrectorAgent";
 import { createOpenAIMessageToUserAgent } from "./agents/messageToUserAgent";
 import { createOpenAIPlannerAgent } from "./agents/plannerAgent";
 import { createSectionAgentRegistry } from "./agents/sectionAgents/sectionAgentRegistry";
@@ -86,6 +87,8 @@ describe("ailaTurn e2e happy path with continue loop", () => {
         },
       }),
       messageToUserAgent: createOpenAIMessageToUserAgent(openai),
+      britishEnglishCorrectorAgent:
+        createOpenAIBritishEnglishCorrectorAgent(openai),
       fetchRelevantLessons: () => Promise.resolve([]),
     };
 

--- a/packages/aila/src/lib/agentic-system/ailaTurn.test.ts
+++ b/packages/aila/src/lib/agentic-system/ailaTurn.test.ts
@@ -9,6 +9,7 @@ function createCallbacks() {
   return {
     onPlannerComplete: jest.fn(),
     onSectionComplete: jest.fn(),
+    onRagFetchedChange: jest.fn(),
     onTurnComplete: jest.fn().mockResolvedValue(undefined),
     onTurnFailed: jest.fn().mockResolvedValue(undefined),
   } satisfies AilaTurnCallbacks;
@@ -19,6 +20,7 @@ function createPersistedState(): AilaPersistedState {
     messages: [{ id: "u1", role: "user", content: "Update the subject" }],
     initialDocument: {},
     relevantLessons: null,
+    ragFetched: { status: "not_fetched", searchIdentity: null },
   };
 }
 

--- a/packages/aila/src/lib/agentic-system/ailaTurn.test.ts
+++ b/packages/aila/src/lib/agentic-system/ailaTurn.test.ts
@@ -30,6 +30,7 @@ function createRuntime(
     plannerAgent: jest.fn(),
     sectionAgents: {} as AilaRuntimeContext["sectionAgents"],
     messageToUserAgent: jest.fn(),
+    britishEnglishCorrectorAgent: jest.fn(),
     fetchRelevantLessons: jest.fn().mockResolvedValue([]),
     ...overrides,
   };
@@ -46,6 +47,173 @@ describe("ailaTurn", () => {
     }
   });
 
+  it("returns empty corrector stats on hard failures before section execution", async () => {
+    const callbacks = createCallbacks();
+    const runtime = createRuntime({
+      plannerAgent: jest
+        .fn()
+        .mockResolvedValue({ error: { message: "planner failed" } }),
+    });
+
+    const outcome = await ailaTurn({
+      persistedState: createPersistedState(),
+      runtime,
+      callbacks,
+    });
+
+    expect(outcome).toEqual({
+      status: "failed",
+      correctorStats: { attempted: [], notNeeded: [], failed: [] },
+    });
+  });
+
+  it("returns corrector stats for successful section execution", async () => {
+    const callbacks = createCallbacks();
+    const runtime = createRuntime({
+      plannerAgent: jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          decision: "plan",
+          parsedUserMessage: "Update the subject",
+          plan: [
+            {
+              type: "section",
+              sectionKey: "subject",
+              action: "generate",
+              sectionInstructions: null,
+            },
+          ],
+        },
+      }),
+      sectionAgents: {
+        "subject--default": {
+          id: "subject--default",
+          description: "subject",
+          handler: jest.fn().mockResolvedValue({
+            error: null,
+            data: "art",
+          }),
+        },
+      } as unknown as AilaRuntimeContext["sectionAgents"],
+    });
+
+    const outcome = await ailaTurn({
+      persistedState: createPersistedState(),
+      runtime,
+      callbacks,
+    });
+
+    expect(outcome).toEqual({
+      status: "success",
+      correctorStats: { attempted: [], notNeeded: ["subject"], failed: [] },
+    });
+  });
+
+  it("emits the corrected section content when the corrector fires", async () => {
+    const callbacks = createCallbacks();
+    const britishEnglishCorrectorAgent = jest.fn().mockResolvedValue({
+      error: null,
+      data: "Introduction to colour theory",
+    });
+    const runtime = createRuntime({
+      plannerAgent: jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          decision: "plan",
+          parsedUserMessage: "Update the title",
+          plan: [
+            {
+              type: "section",
+              sectionKey: "title",
+              action: "generate",
+              sectionInstructions: null,
+            },
+          ],
+        },
+      }),
+      sectionAgents: {
+        "title--default": {
+          id: "title--default",
+          description: "title",
+          handler: jest.fn().mockResolvedValue({
+            error: null,
+            data: "Introduction to color theory",
+          }),
+        },
+      } as unknown as AilaRuntimeContext["sectionAgents"],
+      britishEnglishCorrectorAgent,
+    });
+
+    const outcome = await ailaTurn({
+      persistedState: createPersistedState(),
+      runtime,
+      callbacks,
+    });
+
+    expect(britishEnglishCorrectorAgent).toHaveBeenCalledTimes(1);
+    expect(outcome).toEqual({
+      status: "success",
+      correctorStats: { attempted: ["title"], notNeeded: [], failed: [] },
+    });
+    expect(callbacks.onSectionComplete).toHaveBeenCalledWith([
+      { op: "add", path: "/title", value: "Introduction to colour theory" },
+    ]);
+  });
+
+  it("emits the original section content when the corrector fails", async () => {
+    const callbacks = createCallbacks();
+    const britishEnglishCorrectorAgent = jest
+      .fn()
+      .mockResolvedValue({ error: { message: "corrector failed" } });
+    const runtime = createRuntime({
+      plannerAgent: jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          decision: "plan",
+          parsedUserMessage: "Update the title",
+          plan: [
+            {
+              type: "section",
+              sectionKey: "title",
+              action: "generate",
+              sectionInstructions: null,
+            },
+          ],
+        },
+      }),
+      sectionAgents: {
+        "title--default": {
+          id: "title--default",
+          description: "title",
+          handler: jest.fn().mockResolvedValue({
+            error: null,
+            data: "Introduction to color theory",
+          }),
+        },
+      } as unknown as AilaRuntimeContext["sectionAgents"],
+      britishEnglishCorrectorAgent,
+    });
+
+    const outcome = await ailaTurn({
+      persistedState: createPersistedState(),
+      runtime,
+      callbacks,
+    });
+
+    expect(britishEnglishCorrectorAgent).toHaveBeenCalledTimes(1);
+    expect(outcome).toEqual({
+      status: "success",
+      correctorStats: {
+        attempted: ["title"],
+        notNeeded: [],
+        failed: [{ sectionKey: "title", reason: "errored" }],
+      },
+    });
+    expect(callbacks.onSectionComplete).toHaveBeenCalledWith([
+      { op: "add", path: "/title", value: "Introduction to color theory" },
+    ]);
+  });
+
   it("hard-fails when the planner fails", async () => {
     const callbacks = createCallbacks();
     const runtime = createRuntime({
@@ -60,7 +228,7 @@ describe("ailaTurn", () => {
       callbacks,
     });
 
-    expect(outcome).toEqual({ status: "failed" });
+    expect(outcome).toMatchObject({ status: "failed" });
     expect(callbacks.onPlannerComplete).toHaveBeenCalledWith({
       sectionKeys: [],
     });
@@ -107,7 +275,7 @@ describe("ailaTurn", () => {
       callbacks,
     });
 
-    expect(outcome).toEqual({ status: "failed" });
+    expect(outcome).toMatchObject({ status: "failed" });
     expect(callbacks.onPlannerComplete).toHaveBeenCalledWith({
       sectionKeys: ["subject"],
     });
@@ -168,7 +336,7 @@ describe("ailaTurn", () => {
       callbacks,
     });
 
-    expect(outcome).toEqual({ status: "success" });
+    expect(outcome).toMatchObject({ status: "success" });
     expect(callbacks.onSectionComplete).toHaveBeenCalledWith([
       { op: "add", path: "/subject", value: "art" },
     ]);
@@ -227,7 +395,7 @@ describe("ailaTurn", () => {
       callbacks,
     });
 
-    expect(outcome).toEqual({ status: "success" });
+    expect(outcome).toMatchObject({ status: "success" });
     expect(callbacks.onSectionComplete).toHaveBeenCalledWith([
       { op: "add", path: "/subject", value: "art" },
     ]);
@@ -269,7 +437,7 @@ describe("ailaTurn", () => {
       callbacks,
     });
 
-    expect(outcome).toEqual({ status: "failed" });
+    expect(outcome).toMatchObject({ status: "failed" });
     expect(plannerAgent).not.toHaveBeenCalled();
     expect(callbacks.onTurnFailed).toHaveBeenCalled();
   });
@@ -287,7 +455,7 @@ describe("ailaTurn", () => {
       callbacks,
     });
 
-    expect(outcome).toEqual({ status: "failed" });
+    expect(outcome).toMatchObject({ status: "failed" });
     expect(plannerAgent).not.toHaveBeenCalled();
     expect(callbacks.onTurnFailed).toHaveBeenCalledWith({
       stepsExecuted: [],
@@ -333,7 +501,7 @@ describe("ailaTurn", () => {
       callbacks,
     });
 
-    expect(outcome).toEqual({ status: "failed" });
+    expect(outcome).toMatchObject({ status: "failed" });
     expect(sectionHandler).not.toHaveBeenCalled();
     expect(callbacks.onTurnFailed).toHaveBeenCalledWith({
       stepsExecuted: [],
@@ -383,7 +551,7 @@ describe("ailaTurn", () => {
       callbacks,
     });
 
-    expect(outcome).toEqual({ status: "success" });
+    expect(outcome).toMatchObject({ status: "success" });
     expect(messageToUserAgent).not.toHaveBeenCalled();
     expect(callbacks.onTurnComplete).toHaveBeenCalledWith({
       stepsExecuted: [
@@ -440,7 +608,7 @@ describe("ailaTurn", () => {
       callbacks,
     });
 
-    expect(outcome).toEqual({ status: "success" });
+    expect(outcome).toMatchObject({ status: "success" });
     expect(messageToUserAgent).not.toHaveBeenCalled();
     expect(callbacks.onTurnComplete).toHaveBeenCalledWith({
       stepsExecuted: [
@@ -505,7 +673,7 @@ describe("ailaTurn", () => {
       callbacks,
     });
 
-    expect(outcome).toEqual({ status: "success" });
+    expect(outcome).toMatchObject({ status: "success" });
     expect(callbacks.onTurnComplete).toHaveBeenCalledWith({
       stepsExecuted: [
         {

--- a/packages/aila/src/lib/agentic-system/ailaTurn.ts
+++ b/packages/aila/src/lib/agentic-system/ailaTurn.ts
@@ -1,9 +1,4 @@
-/**
- * #TODO: Add americanisms checking to agentic flow
- * The streaming flow passes detected americanisms to the LLM via AilaLessonPromptBuilder.
- * This isn't wired up here - section agents don't receive americanism warnings.
- * See: packages/aila/src/features/americanisms/AilaAmericanisms.ts
- */
+import { createEmptyCorrectorStats } from "./correctorStats";
 import { executePlanSteps } from "./execution/executePlanSteps";
 import { executePlanningPhase } from "./execution/executePlanningPhase";
 import { handleRelevantLessons } from "./execution/handleRelevantLessons";
@@ -36,6 +31,7 @@ export async function ailaTurn({
       stepsExecuted: [],
       relevantLessonsFetched: false,
       currentStep: null,
+      correctorStats: createEmptyCorrectorStats(),
     },
     callbacks,
   };

--- a/packages/aila/src/lib/agentic-system/compatibility/ailaTurnCallbacks.ts
+++ b/packages/aila/src/lib/agentic-system/compatibility/ailaTurnCallbacks.ts
@@ -8,12 +8,14 @@ import { createOnTurnComplete } from "./onTurnComplete";
 export function createAilaTurnCallbacks({
   chat,
   controller,
+  onRagFetchedChange,
 }: {
   chat: {
     appendChunk: (chunk: string) => void;
     enqueue: <T extends JsonPatchDocumentOptional>(event: T) => Promise<void>;
   };
   controller: ReadableStreamDefaultController;
+  onRagFetchedChange?: AilaTurnCallbacks["onRagFetchedChange"];
 }): AilaTurnCallbacks {
   const patchState = { isFirstSection: true };
   const textStreamer = createTextStreamer(controller, chat);
@@ -24,6 +26,9 @@ export function createAilaTurnCallbacks({
   return {
     onPlannerComplete,
     onSectionComplete,
+    onRagFetchedChange: async (ragFetchedStatus) => {
+      await onRagFetchedChange?.(ragFetchedStatus);
+    },
     onTurnComplete: async (args) => {
       onTurnComplete(args);
       await chat.enqueue({

--- a/packages/aila/src/lib/agentic-system/correctorStats.ts
+++ b/packages/aila/src/lib/agentic-system/correctorStats.ts
@@ -1,0 +1,20 @@
+import type { CorrectorStats } from "./types";
+
+export const createEmptyCorrectorStats = (): CorrectorStats => ({
+  attempted: [],
+  notNeeded: [],
+  failed: [],
+});
+
+/**
+ * Used by the scoring harness to accumulate per-turn stats into a per-run
+ * total.
+ */
+export const mergeCorrectorStats = (
+  target: CorrectorStats,
+  source: CorrectorStats,
+): void => {
+  target.attempted.push(...source.attempted);
+  target.notNeeded.push(...source.notNeeded);
+  target.failed.push(...source.failed);
+};

--- a/packages/aila/src/lib/agentic-system/execution/applyBritishEnglishCorrection.test.ts
+++ b/packages/aila/src/lib/agentic-system/execution/applyBritishEnglishCorrection.test.ts
@@ -1,0 +1,208 @@
+import { z } from "zod";
+
+import { AMERICANISM_ISSUE_KIND } from "../../../features/americanisms";
+import { createEmptyCorrectorStats } from "../correctorStats";
+import type { SectionKey } from "../schema";
+import type { AilaExecutionContext } from "../types";
+import { applyBritishEnglishCorrection } from "./applyBritishEnglishCorrection";
+
+/**
+ * Real `AilaAmericanisms` detector with a mocked corrector agent. Inputs use
+ * phrases that `american-british-english-translator` classifies consistently
+ * across dictionary versions, so the tests stay reproducible:
+ *   - "color" / "recognize" -> SPELLING
+ *   - "eraser"              -> PHRASING
+ *   - "construction"        -> MEANING (advisory, skipped)
+ */
+
+function createContext(correctorAgent: jest.Mock): AilaExecutionContext {
+  return {
+    persistedState: {
+      messages: [],
+      initialDocument: {},
+      relevantLessons: null,
+    },
+    runtime: {
+      britishEnglishCorrectorAgent: correctorAgent,
+    } as unknown as AilaExecutionContext["runtime"],
+    currentTurn: {
+      document: {},
+      plannerOutput: null,
+      errors: [],
+      notes: [],
+      stepsExecuted: [],
+      relevantLessons: null,
+      relevantLessonsFetched: false,
+      currentStep: null,
+      correctorStats: createEmptyCorrectorStats(),
+    },
+    callbacks: {} as AilaExecutionContext["callbacks"],
+  };
+}
+
+const TITLE: SectionKey = "title";
+
+describe("applyBritishEnglishCorrection", () => {
+  it("returns null and skips the corrector when no Americanisms are detected", async () => {
+    const correctorAgent = jest.fn();
+    const context = createContext(correctorAgent);
+
+    const result = await applyBritishEnglishCorrection({
+      context,
+      sectionKey: TITLE,
+      content: "An introduction to fractions",
+      responseSchema: z.string(),
+    });
+
+    expect(result).toBeNull();
+    expect(correctorAgent).not.toHaveBeenCalled();
+    expect(context.currentTurn.notes).toEqual([]);
+    expect(context.currentTurn.correctorStats.attempted).toEqual([]);
+    expect(context.currentTurn.correctorStats.notNeeded).toEqual([TITLE]);
+    expect(context.currentTurn.correctorStats.failed).toEqual([]);
+  });
+
+  it("invokes the corrector and returns validated corrected content for a spelling flag", async () => {
+    const correctorAgent = jest.fn().mockResolvedValue({
+      error: null,
+      data: "This will recognise the colour",
+    });
+    const context = createContext(correctorAgent);
+
+    const result = await applyBritishEnglishCorrection({
+      context,
+      sectionKey: TITLE,
+      content: "This will recognize the color",
+      responseSchema: z.string(),
+    });
+
+    expect(correctorAgent).toHaveBeenCalledTimes(1);
+    expect(result).toBe("This will recognise the colour");
+    expect(context.currentTurn.notes).toEqual([]);
+    expect(context.currentTurn.correctorStats.attempted).toEqual([TITLE]);
+    expect(context.currentTurn.correctorStats.failed).toEqual([]);
+  });
+
+  it("invokes the corrector for a phrasing flag (eraser)", async () => {
+    const correctorAgent = jest.fn().mockResolvedValue({
+      error: null,
+      data: "Use a rubber to erase",
+    });
+    const context = createContext(correctorAgent);
+
+    const result = await applyBritishEnglishCorrection({
+      context,
+      sectionKey: TITLE,
+      content: "Use an eraser to erase",
+      responseSchema: z.string(),
+    });
+
+    expect(correctorAgent).toHaveBeenCalledTimes(1);
+    expect(result).toBe("Use a rubber to erase");
+  });
+
+  it("skips the corrector when only MEANING-class flags are detected", async () => {
+    const correctorAgent = jest.fn();
+    const context = createContext(correctorAgent);
+
+    // "construction" reliably flags as MEANING only
+    const result = await applyBritishEnglishCorrection({
+      context,
+      sectionKey: TITLE,
+      content: "construction",
+      responseSchema: z.string(),
+    });
+
+    expect(result).toBeNull();
+    expect(correctorAgent).not.toHaveBeenCalled();
+    expect(context.currentTurn.notes).toEqual([]);
+  });
+
+  it("returns null without leaking a user-facing note when the corrector errors", async () => {
+    const correctorAgent = jest.fn().mockResolvedValue({
+      error: { message: "model refused" },
+    });
+    const context = createContext(correctorAgent);
+
+    const result = await applyBritishEnglishCorrection({
+      context,
+      sectionKey: TITLE,
+      content: "This will recognize the color",
+      responseSchema: z.string(),
+    });
+
+    expect(result).toBeNull();
+    expect(context.currentTurn.notes).toEqual([]);
+    expect(context.currentTurn.correctorStats.failed).toEqual([
+      { sectionKey: TITLE, reason: "errored" },
+    ]);
+  });
+
+  it("returns null without leaking a user-facing note when the corrector returns schema-invalid content", async () => {
+    const correctorAgent = jest.fn().mockResolvedValue({
+      error: null,
+      data: 42, // not a string — fails responseSchema
+    });
+    const context = createContext(correctorAgent);
+
+    const result = await applyBritishEnglishCorrection({
+      context,
+      sectionKey: TITLE,
+      content: "This will recognize the color",
+      responseSchema: z.string(),
+    });
+
+    expect(result).toBeNull();
+    expect(context.currentTurn.notes).toEqual([]);
+    expect(context.currentTurn.correctorStats.failed).toEqual([
+      { sectionKey: TITLE, reason: "schema-invalid" },
+    ]);
+  });
+
+  it("swallows corrector promise rejections so the turn keeps streaming", async () => {
+    const correctorAgent = jest
+      .fn()
+      .mockRejectedValue(new Error("network timeout"));
+    const context = createContext(correctorAgent);
+
+    const result = await applyBritishEnglishCorrection({
+      context,
+      sectionKey: TITLE,
+      content: "This will recognize the color",
+      responseSchema: z.string(),
+    });
+
+    expect(result).toBeNull();
+    expect(context.currentTurn.notes).toEqual([]);
+    expect(context.currentTurn.correctorStats.failed).toEqual([
+      { sectionKey: TITLE, reason: "threw" },
+    ]);
+  });
+
+  it("passes only actionable issues to the corrector", async () => {
+    let capturedIssues: Array<{ issue: string }> = [];
+    const correctorAgent = jest.fn().mockImplementation((props: unknown) => {
+      const typed = props as { issues: Array<{ issue: string }> };
+      capturedIssues = typed.issues;
+      return Promise.resolve({
+        error: null,
+        data: "Triangle construction recognises the colour",
+      });
+    });
+    const context = createContext(correctorAgent);
+
+    // Mix MEANING ("construction", "triangle") with SPELLING ("recognize", "color").
+    await applyBritishEnglishCorrection({
+      context,
+      sectionKey: TITLE,
+      content: "Triangle construction will recognize the color",
+      responseSchema: z.string(),
+    });
+
+    expect(correctorAgent).toHaveBeenCalledTimes(1);
+    expect(
+      capturedIssues.every((i) => i.issue !== AMERICANISM_ISSUE_KIND.MEANING),
+    ).toBe(true);
+    expect(capturedIssues.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/aila/src/lib/agentic-system/execution/applyBritishEnglishCorrection.test.ts
+++ b/packages/aila/src/lib/agentic-system/execution/applyBritishEnglishCorrection.test.ts
@@ -21,6 +21,7 @@ function createContext(correctorAgent: jest.Mock): AilaExecutionContext {
       messages: [],
       initialDocument: {},
       relevantLessons: null,
+      ragFetched: { status: "not_fetched", searchIdentity: null },
     },
     runtime: {
       britishEnglishCorrectorAgent: correctorAgent,

--- a/packages/aila/src/lib/agentic-system/execution/applyBritishEnglishCorrection.ts
+++ b/packages/aila/src/lib/agentic-system/execution/applyBritishEnglishCorrection.ts
@@ -1,0 +1,89 @@
+import { aiLogger } from "@oakai/logger";
+
+import type { z } from "zod";
+
+import { AMERICANISM_ISSUE_KIND } from "../../../features/americanisms";
+import { AilaAmericanisms } from "../../../features/americanisms/AilaAmericanisms";
+import type { SectionKey } from "../schema";
+import type { AgentResult, AilaExecutionContext } from "../types";
+
+const americanisms = new AilaAmericanisms();
+const log = aiLogger("aila:agents");
+
+/**
+ * Detects Americanisms in a freshly generated section. If actionable issues are
+ * found it invokes the British English corrector agent and returns validated
+ * corrected content. Returns `null` when no correction is needed or the
+ * corrector fails and falls back to the original content.
+ */
+export async function applyBritishEnglishCorrection<S extends z.ZodTypeAny>({
+  context,
+  sectionKey,
+  content,
+  responseSchema,
+}: {
+  context: AilaExecutionContext;
+  sectionKey: SectionKey;
+  content: unknown;
+  responseSchema: S;
+}): Promise<z.infer<S> | null> {
+  const detected = americanisms.findAmericanisms({ [sectionKey]: content });
+  const sectionIssues =
+    detected.find((d) => d.section === sectionKey)?.issues ?? [];
+
+  // MEANING flags are advisory only (high false-positive rate), they should never be corrected.
+  const actionable = sectionIssues.filter(
+    (issue) => issue.issue !== AMERICANISM_ISSUE_KIND.MEANING,
+  );
+
+  const stats = context.currentTurn.correctorStats;
+
+  if (actionable.length === 0) {
+    stats.notNeeded.push(sectionKey);
+    log.info(`british-english-corrector skipped ${sectionKey}`);
+    return null;
+  }
+
+  stats.attempted.push(sectionKey);
+  log.info(
+    `british-english-corrector fired ${sectionKey} actionable=${actionable.length}`,
+  );
+
+  // The corrector is best-effort. Errors are not surfaced in `currentTurn.notes` (as this is displayed to the teacher by the message-to-user agent).
+  let result: AgentResult<unknown>;
+  try {
+    result = await context.runtime.britishEnglishCorrectorAgent({
+      sectionKey,
+      content,
+      issues: actionable,
+      responseSchema,
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    stats.failed.push({ sectionKey, reason: "threw" });
+    log.error(`british-english-corrector threw ${sectionKey} ${message}`);
+    return null;
+  }
+
+  if (result.error) {
+    stats.failed.push({ sectionKey, reason: "errored" });
+    log.error(
+      `british-english-corrector errored ${sectionKey} ${result.error.message}`,
+    );
+    return null;
+  }
+
+  const parsed = responseSchema.safeParse(result.data);
+  if (!parsed.success) {
+    stats.failed.push({ sectionKey, reason: "schema-invalid" });
+    log.error(`british-english-corrector schema-invalid ${sectionKey}`);
+    return null;
+  }
+
+  // `z.infer<S>` resolves to `any` inside this function because `S extends
+  // z.ZodTypeAny` widens S to `ZodType<any, any, any>` from TS's view of the
+  // body. The Zod safeParse above has already validated the shape against the
+  // schema, so this is safe at runtime
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+  return parsed.data;
+}

--- a/packages/aila/src/lib/agentic-system/execution/executePlanSteps.quiz.test.ts
+++ b/packages/aila/src/lib/agentic-system/execution/executePlanSteps.quiz.test.ts
@@ -59,6 +59,7 @@ function makeRuntime(
       error: null,
       data: { message: "Done" },
     }),
+    britishEnglishCorrectorAgent: jest.fn(),
     fetchRelevantLessons: jest.fn().mockResolvedValue([]),
     ...overrides,
   };

--- a/packages/aila/src/lib/agentic-system/execution/executePlanSteps.quiz.test.ts
+++ b/packages/aila/src/lib/agentic-system/execution/executePlanSteps.quiz.test.ts
@@ -31,6 +31,7 @@ function makeCallbacks(): AilaTurnCallbacks {
     onSectionComplete: jest.fn(),
     onTurnComplete: jest.fn().mockResolvedValue(undefined),
     onTurnFailed: jest.fn().mockResolvedValue(undefined),
+    onRagFetchedChange: jest.fn().mockResolvedValue(undefined),
   };
 }
 
@@ -45,6 +46,7 @@ function makePersistedState(): AilaPersistedState {
     ],
     initialDocument: { starterQuiz },
     relevantLessons: null,
+    ragFetched: { status: "not_fetched", searchIdentity: null },
   };
 }
 
@@ -259,6 +261,7 @@ describe("executePlanSteps — quiz dispatch intercept", () => {
           starterQuiz: { version: "v3", questions: [], imageMetadata: [] },
         },
         relevantLessons: null,
+        ragFetched: { status: "not_fetched", searchIdentity: null },
       };
 
       const runtime = makeRuntime({

--- a/packages/aila/src/lib/agentic-system/execution/executePlanSteps.ts
+++ b/packages/aila/src/lib/agentic-system/execution/executePlanSteps.ts
@@ -25,6 +25,7 @@ import {
   shouldForceSectionFailure,
   shouldForceSectionThrow,
 } from "../utils/faultInjection";
+import { applyBritishEnglishCorrection } from "./applyBritishEnglishCorrection";
 import { terminateWithFailure } from "./termination";
 
 const log = aiLogger("aila:agents");
@@ -110,7 +111,15 @@ async function executeGenerateStep(
   }
 
   const sectionSchema = CompletedLessonPlanSchema.shape[step.sectionKey];
-  const validated = sectionSchema.parse(result.data);
+
+  const corrected = await applyBritishEnglishCorrection({
+    context,
+    sectionKey: step.sectionKey,
+    content: result.data,
+    responseSchema: sectionSchema,
+  });
+
+  const validated = corrected ?? sectionSchema.parse(result.data);
 
   // We use immer to generate JSON patches at the granularity we control.
   // Patches are generated at the exact path we mutate:

--- a/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.test.ts
+++ b/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.test.ts
@@ -1,0 +1,146 @@
+import type {
+  AgenticRagLessonPlanResult,
+  AilaExecutionContext,
+  AilaTurnCallbacks,
+} from "../types";
+import { handleRelevantLessons } from "./handleRelevantLessons";
+
+jest.mock("./termination", () => ({
+  terminateWithResponse: jest.fn(),
+}));
+
+function createContext(
+  overrides: {
+    document?: Partial<AilaExecutionContext["currentTurn"]["document"]>;
+    ragFetched?: AilaExecutionContext["persistedState"]["ragFetched"];
+    fetchResult?: AgenticRagLessonPlanResult[];
+  } = {},
+): AilaExecutionContext {
+  return {
+    persistedState: {
+      messages: [],
+      initialDocument: {},
+      relevantLessons: null,
+      ragFetched: overrides.ragFetched ?? {
+        status: "not_fetched",
+        searchIdentity: null,
+      },
+    },
+    runtime: {
+      britishEnglishCorrectorAgent: jest.fn(),
+      plannerAgent: jest.fn(),
+      sectionAgents: {} as AilaExecutionContext["runtime"]["sectionAgents"],
+      messageToUserAgent: jest.fn(),
+      fetchRelevantLessons: jest
+        .fn()
+        .mockResolvedValue(overrides.fetchResult ?? []),
+      config: { mathsQuizEnabled: false },
+    },
+    currentTurn: {
+      document: {
+        title: "Photosynthesis",
+        subject: "science",
+        keyStage: "key-stage-3",
+        ...overrides.document,
+      },
+      plannerOutput: null,
+      errors: [],
+      notes: [],
+      stepsExecuted: [],
+      relevantLessons: null,
+      relevantLessonsFetched: false,
+      currentStep: null,
+      correctorStats: {
+        attempted: [],
+        notNeeded: [],
+        failed: [],
+      },
+    },
+    callbacks: {
+      onPlannerComplete: jest.fn(),
+      onSectionComplete: jest.fn(),
+      onRagFetchedChange: jest.fn().mockResolvedValue(undefined),
+      onTurnComplete: jest.fn(),
+      onTurnFailed: jest.fn(),
+    },
+  };
+}
+
+const fakeLessons: AgenticRagLessonPlanResult[] = [
+  {
+    ragLessonPlanId: "lp1",
+    oakLessonId: 1,
+    oakLessonSlug: "photosynthesis",
+    lessonPlan: { title: "Photosynthesis" },
+  },
+];
+
+describe("handleRelevantLessons", () => {
+  it("skips fetch and persists 'selected' when basedOn is set", async () => {
+    const ctx = createContext({
+      document: { basedOn: { id: "abc", title: "Some lesson" } },
+    });
+
+    const result = await handleRelevantLessons(ctx);
+
+    expect(result).toEqual({ status: "continue" });
+    expect(ctx.runtime.fetchRelevantLessons).not.toHaveBeenCalled();
+    expect(ctx.persistedState.ragFetched.status).toBe("selected");
+  });
+
+  it("skips fetch when title is missing", async () => {
+    const ctx = createContext({ document: { title: undefined } });
+
+    const result = await handleRelevantLessons(ctx);
+
+    expect(result).toEqual({ status: "continue" });
+    expect(ctx.runtime.fetchRelevantLessons).not.toHaveBeenCalled();
+  });
+
+  it("skips fetch when identity has not changed significantly", async () => {
+    const ctx = createContext({
+      ragFetched: {
+        status: "shown",
+        searchIdentity: {
+          title: "Photosynthesis",
+          subject: "science",
+          keyStage: "key-stage-3",
+        },
+      },
+    });
+
+    const result = await handleRelevantLessons(ctx);
+
+    expect(result).toEqual({ status: "continue" });
+    expect(ctx.runtime.fetchRelevantLessons).not.toHaveBeenCalled();
+  });
+
+  it("fetches and continues when no lessons found", async () => {
+    const ctx = createContext({ fetchResult: [] });
+
+    const result = await handleRelevantLessons(ctx);
+
+    expect(result).toEqual({ status: "continue" });
+    expect(ctx.runtime.fetchRelevantLessons).toHaveBeenCalled();
+    expect(ctx.persistedState.ragFetched.status).toBe("none_found");
+  });
+
+  it("does not call onRagFetchedChange when state is unchanged", async () => {
+    const identity = {
+      title: "Photosynthesis",
+      subject: "science",
+      keyStage: "key-stage-3",
+    };
+    const ctx = createContext({
+      document: { basedOn: { id: "abc", title: "X" } },
+      ragFetched: { status: "selected", searchIdentity: identity },
+    });
+
+    await handleRelevantLessons(ctx);
+
+    expect(ctx.callbacks as AilaTurnCallbacks).toHaveProperty(
+      "onRagFetchedChange",
+    );
+    expect(ctx.callbacks.onRagFetchedChange).not.toHaveBeenCalled();
+  });
+});

--- a/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.ts
+++ b/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.ts
@@ -1,39 +1,82 @@
+import type { RagFetched } from "../../../protocol/schema";
 import type { AilaExecutionContext, AilaTurnPhaseOutcome } from "../types";
+import { hasSearchIdentityChangedSignificantly } from "./searchIdentity";
 import { terminateWithResponse } from "./termination";
 
-/**
- * Handle fetching relevant lessons if document metadata has changed
- * @returns `continue` to keep going, otherwise a terminal turn outcome
- */
+function searchIdentityEqual(
+  a: RagFetched["searchIdentity"],
+  b: RagFetched["searchIdentity"],
+): boolean {
+  if (a == null && b == null) return true;
+  if (a == null || b == null) return false;
+  return (
+    a.title === b.title && a.subject === b.subject && a.keyStage === b.keyStage
+  );
+}
+
+async function persistRagFetched(
+  context: AilaExecutionContext,
+  next: RagFetched,
+): Promise<void> {
+  const prev = context.persistedState.ragFetched;
+  if (
+    prev.status === next.status &&
+    searchIdentityEqual(prev.searchIdentity, next.searchIdentity)
+  ) {
+    return;
+  }
+  context.persistedState.ragFetched = next;
+  await context.callbacks.onRagFetchedChange(next);
+}
+
+/** Decide whether to re-fetch RAG lessons; may terminate the turn early. */
 export async function handleRelevantLessons(
   context: AilaExecutionContext,
 ): Promise<AilaTurnPhaseOutcome> {
   const { title, subject, keyStage, basedOn } = context.currentTurn.document;
-
-  if (!title || !subject || !keyStage) {
-    // if any of the above sections are missing, do not refetch RAG lessons
-    return { status: "continue" };
-  }
+  const ragFetched = context.persistedState.ragFetched;
 
   if (basedOn) {
-    // if the user has already chosen a lesson to adapt, do not refetch RAG lessons
+    // user has chosen a lesson to adapt — record that selection
+    await persistRagFetched(context, {
+      status: "selected",
+      searchIdentity:
+        title && subject && keyStage
+          ? { title, subject, keyStage }
+          : ragFetched.searchIdentity,
+    });
     return { status: "continue" };
   }
 
-  const hasDocumentMetadataChanged =
-    title !== context.persistedState.initialDocument.title ||
-    subject !== context.persistedState.initialDocument.subject ||
-    keyStage !== context.persistedState.initialDocument.keyStage;
-
-  if (!hasDocumentMetadataChanged) {
-    // if above sections remain unchanged, do not refetch RAG lessons
+  if (!title || !subject || !keyStage) {
+    // can't form a search identity without all three — don't fetch
     return { status: "continue" };
   }
-  context.currentTurn.relevantLessons =
-    await context.runtime.fetchRelevantLessons({ title, subject, keyStage });
+
+  const nextSearchIdentity = { title, subject, keyStage };
+  if (
+    !hasSearchIdentityChangedSignificantly(
+      ragFetched.searchIdentity,
+      nextSearchIdentity,
+    )
+  ) {
+    return { status: "continue" };
+  }
+
+  const lessons = await context.runtime.fetchRelevantLessons({
+    title,
+    subject,
+    keyStage,
+  });
+  context.currentTurn.relevantLessons = lessons;
   context.currentTurn.relevantLessonsFetched = true;
 
-  if (context.currentTurn.relevantLessons.length > 0) {
+  await persistRagFetched(context, {
+    status: lessons.length > 0 ? "shown" : "none_found",
+    searchIdentity: nextSearchIdentity,
+  });
+
+  if (lessons.length > 0) {
     return await terminateWithResponse(context);
   }
 

--- a/packages/aila/src/lib/agentic-system/execution/searchIdentity.test.ts
+++ b/packages/aila/src/lib/agentic-system/execution/searchIdentity.test.ts
@@ -1,0 +1,171 @@
+import { hasSearchIdentityChangedSignificantly } from "./searchIdentity";
+
+describe("hasSearchIdentityChangedSignificantly", () => {
+  const base = {
+    title: "Photosynthesis",
+    subject: "science",
+    keyStage: "key-stage-3",
+  };
+
+  it("returns true when prev is null", () => {
+    expect(hasSearchIdentityChangedSignificantly(null, base)).toBe(true);
+  });
+
+  it("returns true when prev is undefined", () => {
+    expect(hasSearchIdentityChangedSignificantly(undefined, base)).toBe(true);
+  });
+
+  it("returns false for identical identities", () => {
+    expect(hasSearchIdentityChangedSignificantly(base, { ...base })).toBe(
+      false,
+    );
+  });
+
+  describe("keyStage comparison", () => {
+    it("returns true when keyStage changes", () => {
+      const next = { ...base, keyStage: "key-stage-4" };
+      expect(hasSearchIdentityChangedSignificantly(base, next)).toBe(true);
+    });
+
+    it("returns false for equivalent keyStage aliases", () => {
+      const prev = { ...base, keyStage: "ks3" };
+      const next = { ...base, keyStage: "key-stage-3" };
+      expect(hasSearchIdentityChangedSignificantly(prev, next)).toBe(false);
+    });
+
+    it("normalises year aliases", () => {
+      const prev = { ...base, keyStage: "year_7" };
+      const next = { ...base, keyStage: "key-stage-3" };
+      expect(hasSearchIdentityChangedSignificantly(prev, next)).toBe(false);
+    });
+  });
+
+  describe("subject comparison", () => {
+    it("returns true when subject changes to different domain", () => {
+      const next = { ...base, subject: "history" };
+      expect(hasSearchIdentityChangedSignificantly(base, next)).toBe(true);
+    });
+
+    it("treats maths/mathematics as equivalent", () => {
+      const prev = { ...base, subject: "maths" };
+      const next = { ...base, subject: "mathematics" };
+      expect(hasSearchIdentityChangedSignificantly(prev, next)).toBe(false);
+    });
+
+    it("treats mathematics/maths as equivalent", () => {
+      const prev = { ...base, subject: "mathematics" };
+      const next = { ...base, subject: "maths" };
+      expect(hasSearchIdentityChangedSignificantly(prev, next)).toBe(false);
+    });
+
+    it("treats PE abbreviation as equivalent", () => {
+      const prev = { ...base, subject: "PE" };
+      const next = { ...base, subject: "physical-education" };
+      expect(hasSearchIdentityChangedSignificantly(prev, next)).toBe(false);
+    });
+
+    it("treats bio/biology as equivalent", () => {
+      const prev = { ...base, subject: "bio" };
+      const next = { ...base, subject: "biology" };
+      expect(hasSearchIdentityChangedSignificantly(prev, next)).toBe(false);
+    });
+
+    it("uses slug equality for unknown subjects", () => {
+      const prev = { ...base, subject: "Quantum Computing" };
+      const next = { ...base, subject: "quantum-computing" };
+      expect(hasSearchIdentityChangedSignificantly(prev, next)).toBe(false);
+    });
+
+    it("detects change between different unknown subjects", () => {
+      const prev = { ...base, subject: "Quantum Computing" };
+      const next = { ...base, subject: "Marine Biology" };
+      expect(hasSearchIdentityChangedSignificantly(prev, next)).toBe(true);
+    });
+  });
+
+  describe("title comparison (Jaccard)", () => {
+    it.each([
+      {
+        label: "stopwords stripped",
+        prev: "Understanding Photosynthesis",
+        next: "Photosynthesis",
+        expected: false,
+      },
+      {
+        label: "capitalisation change",
+        prev: "photosynthesis",
+        next: "Photosynthesis",
+        expected: false,
+      },
+      {
+        label: "plural to singular (stem)",
+        prev: "Fractions",
+        next: "Fraction",
+        expected: false,
+      },
+      {
+        label: "ise/ize spelling variants (stem)",
+        prev: "Colonise or colonize",
+        next: "Colonize",
+        expected: false,
+      },
+      {
+        label: "reordered words",
+        prev: "World War Two Causes",
+        next: "Causes of World War Two",
+        expected: false,
+      },
+      {
+        label: "stopwords dominate both sides",
+        prev: "Introduction to Programming",
+        next: "Advanced Programming",
+        expected: false,
+      },
+      {
+        label: "both empty",
+        prev: "",
+        next: "",
+        expected: false,
+      },
+      {
+        label: "both collapse to near-empty after stopword removal",
+        prev: "An Introduction",
+        next: "A Basic Overview",
+        expected: false,
+      },
+      {
+        label: "completely different topic",
+        prev: "Photosynthesis",
+        next: "The Roman Empire",
+        expected: true,
+      },
+      {
+        label: "one key word differs",
+        prev: "World War One",
+        next: "World War Two",
+        expected: true,
+      },
+      {
+        label: "key content word swap",
+        prev: "Photosynthesis in Plants",
+        next: "Respiration in Plants",
+        expected: true,
+      },
+      {
+        label: "low token overlap (borderline)",
+        prev: "Algebra Basics",
+        next: "Introduction to Algebraic Expressions",
+        expected: true,
+      },
+    ])(
+      "$label: $prev → $next should be $expected",
+      ({ prev, next, expected }) => {
+        const prevId = { ...base, title: prev };
+        const nextId = { ...base, title: next };
+        expect(hasSearchIdentityChangedSignificantly(prevId, nextId)).toBe(
+          expected,
+        );
+      },
+    );
+  });
+});

--- a/packages/aila/src/lib/agentic-system/execution/searchIdentity.ts
+++ b/packages/aila/src/lib/agentic-system/execution/searchIdentity.ts
@@ -1,0 +1,129 @@
+import { parseKeyStage } from "@oakai/core/src/data/parseKeyStage";
+import { slugify } from "@oakai/core/src/utils/slugify";
+
+import type { SearchIdentity } from "../../../protocol/schema";
+
+export type { SearchIdentity };
+
+const SUBJECT_SYNONYMS: Record<string, string> = {
+  mathematics: "maths",
+  math: "maths",
+  bio: "biology",
+  chem: "chemistry",
+  phys: "physics",
+  pe: "physical-education",
+  dt: "design-technology",
+  "design-and-technology": "design-technology",
+  "computer-science": "computing",
+  cs: "computing",
+  "comp-sci": "computing",
+  re: "religious-education",
+  rs: "religious-education",
+  "religious-studies": "religious-education",
+  religion: "religious-education",
+  geo: "geography",
+  geog: "geography",
+  hist: "history",
+  eng: "english",
+  sci: "science",
+  "double-science": "combined-science",
+  "dual-science": "combined-science",
+  pshe: "rshe-pshe",
+  rshe: "rshe-pshe",
+  "art-and-design": "art",
+};
+
+function canonicaliseSubject(raw: string): string {
+  const slug = slugify(raw);
+  return SUBJECT_SYNONYMS[slug] ?? slug;
+}
+
+const TITLE_JACCARD_THRESHOLD = 0.7;
+
+const STOPWORDS = new Set([
+  "a",
+  "an",
+  "the",
+  "of",
+  "to",
+  "in",
+  "on",
+  "and",
+  "or",
+  "for",
+  "is",
+  "it",
+  "at",
+  "by",
+  "lesson",
+  "introduction",
+  "introducing",
+  "overview",
+  "about",
+  "exploring",
+  "understanding",
+  "basics",
+  "basic",
+  "advanced",
+]);
+
+function stem(word: string): string {
+  if (word.length <= 3) return word;
+  if (word.endsWith("ies") && word.length > 4) return word.slice(0, -3) + "y";
+  if (word.endsWith("ves") && word.length > 4) return word.slice(0, -3) + "f";
+  if (word.endsWith("ses") || word.endsWith("zes") || word.endsWith("xes"))
+    return word.slice(0, -2);
+  if (word.endsWith("ing") && word.length > 5) {
+    const base = word.slice(0, -3);
+    if (base.at(-1) === base.at(-2)) return base.slice(0, -1);
+    return base;
+  }
+  if (word.endsWith("ise")) return word.slice(0, -3);
+  if (word.endsWith("ize")) return word.slice(0, -3);
+  if (word.endsWith("ed") && word.length > 4) {
+    const base = word.slice(0, -2);
+    if (base.at(-1) === base.at(-2)) return base.slice(0, -1);
+    return base;
+  }
+  if (word.endsWith("s") && !word.endsWith("ss") && word.length > 3)
+    return word.slice(0, -1);
+  return word;
+}
+
+function tokenise(text: string): Set<string> {
+  const tokens = text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s]/gu, " ")
+    .split(/\s+/)
+    .filter(Boolean)
+    .filter((t) => !STOPWORDS.has(t))
+    .map(stem);
+  return new Set(tokens);
+}
+
+function titleJaccard(a: string, b: string): number {
+  const setA = tokenise(a);
+  const setB = tokenise(b);
+  if (setA.size === 0 && setB.size === 0) return 1;
+  let intersection = 0;
+  for (const t of setA) {
+    if (setB.has(t)) intersection++;
+  }
+  const union = new Set([...setA, ...setB]).size;
+  return union === 0 ? 1 : intersection / union;
+}
+
+export function hasSearchIdentityChangedSignificantly(
+  prev: SearchIdentity | null | undefined,
+  next: SearchIdentity,
+): boolean {
+  if (!prev) return true;
+
+  if (parseKeyStage(prev.keyStage) !== parseKeyStage(next.keyStage))
+    return true;
+
+  if (canonicaliseSubject(prev.subject) !== canonicaliseSubject(next.subject))
+    return true;
+
+  return titleJaccard(prev.title, next.title) < TITLE_JACCARD_THRESHOLD;
+}

--- a/packages/aila/src/lib/agentic-system/execution/termination.ts
+++ b/packages/aila/src/lib/agentic-system/execution/termination.ts
@@ -31,7 +31,10 @@ export async function terminateWithFailure(
     stepsExecuted: context.currentTurn.stepsExecuted,
     ailaMessage: hardFailureMessage(),
   });
-  return { status: "failed" };
+  return {
+    status: "failed",
+    correctorStats: context.currentTurn.correctorStats,
+  };
 }
 
 /**
@@ -102,7 +105,10 @@ export async function terminateWithCustomMessage(
     document: context.currentTurn.document,
     ailaMessage: message,
   });
-  return { status: "success" };
+  return {
+    status: "success",
+    correctorStats: context.currentTurn.correctorStats,
+  };
 }
 
 async function resolveMessageToUserError(

--- a/packages/aila/src/lib/agentic-system/scoring/evalHarness.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/evalHarness.ts
@@ -1,0 +1,131 @@
+/* eslint-disable no-console */
+
+/**
+ * Shared scaffolding for the scoring eval harnesses (scoreMathsComposer,
+ * scorePlannerQuizIntent). Each harness supplies its own cells, per-run scorer
+ * and formatters; the run loop, markdown report and YAML output are the same.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import YAML from "yaml";
+
+/** Minimum shape every scored run shares. */
+export type ScoredRun = {
+  pass: boolean;
+  reasons: string[];
+};
+
+/** Minimum shape every eval cell shares. */
+export type EvalCellBase = {
+  id: string;
+  description: string;
+  passThreshold: number;
+};
+
+export type ScoredCell<TRun extends ScoredRun> = {
+  cellId: string;
+  description: string;
+  passThreshold: number;
+  passRate: number;
+  runs: TRun[];
+};
+
+/** Run every cell `runsPerCell` times, logging progress and computing pass rates. */
+export async function runEvalCells<
+  TCell extends EvalCellBase,
+  TRun extends ScoredRun,
+>(
+  cells: TCell[],
+  runsPerCell: number,
+  runOnce: (cell: TCell) => Promise<TRun>,
+  formatConsole: (run: TRun) => string,
+): Promise<ScoredCell<TRun>[]> {
+  const results: ScoredCell<TRun>[] = [];
+  for (const cell of cells) {
+    console.log(`\n--- ${cell.id} (${runsPerCell} runs) ---`);
+    const runs: TRun[] = [];
+    for (let i = 0; i < runsPerCell; i++) {
+      const run = await runOnce(cell);
+      console.log(
+        `  Run ${i + 1} ${run.pass ? "✓" : "🚩"} ${formatConsole(run)}`,
+      );
+      runs.push(run);
+    }
+    const passRate = runs.filter((r) => r.pass).length / runs.length;
+    results.push({
+      cellId: cell.id,
+      description: cell.description,
+      passThreshold: cell.passThreshold,
+      passRate,
+      runs,
+    });
+  }
+  return results;
+}
+
+/** Build the markdown report: a summary table plus per-cell run details. */
+export function generateReport<TRun extends ScoredRun>(
+  title: string,
+  results: ScoredCell<TRun>[],
+  runsPerCell: number,
+  formatActual: (run: TRun) => string,
+): string {
+  const lines: string[] = [];
+  lines.push(
+    `# ${title}`,
+    "",
+    `Generated: ${new Date().toISOString()}`,
+    `Runs per cell: ${runsPerCell}`,
+    "",
+    "| Cell | Threshold | Pass rate | Status |",
+    "|------|-----------|-----------|--------|",
+  );
+  for (const r of results) {
+    let status: string;
+    if (r.passThreshold === 0) {
+      status = "📊 baseline";
+    } else {
+      status = r.passRate >= r.passThreshold ? "✓" : "🚩";
+    }
+    lines.push(
+      `| ${r.cellId} | ${(r.passThreshold * 100).toFixed(0)}% | ${(r.passRate * 100).toFixed(0)}% | ${status} |`,
+    );
+  }
+  lines.push("");
+  for (const r of results) {
+    lines.push(`### ${r.cellId} — ${r.description}`, "");
+    for (let i = 0; i < r.runs.length; i++) {
+      const run = r.runs[i]!;
+      const icon = run.pass ? "✓" : "🚩";
+      const reasonStr = run.reasons.length
+        ? ` — ${run.reasons.join("; ")}`
+        : "";
+      lines.push(`- Run ${i + 1} ${icon} ${formatActual(run)}${reasonStr}`);
+    }
+    lines.push("");
+  }
+  return lines.join("\n");
+}
+
+/** Serialise results to the scores YAML file, delegating per-run shape to the caller. */
+export function writeScores<TRun extends ScoredRun>(
+  outputFile: string,
+  results: ScoredCell<TRun>[],
+  runsPerCell: number,
+  serializeRun: (run: TRun) => unknown,
+): void {
+  const yamlData = {
+    generated: new Date().toISOString(),
+    runsPerCell,
+    cells: results.map((r) => ({
+      id: r.cellId,
+      description: r.description,
+      passThreshold: r.passThreshold,
+      passRate: r.passRate,
+      runs: r.runs.map(serializeRun),
+    })),
+  };
+  fs.mkdirSync(path.dirname(outputFile), { recursive: true });
+  fs.writeFileSync(outputFile, YAML.stringify(yamlData));
+  console.log(`\nReport written to: ${outputFile}`);
+}

--- a/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
@@ -28,22 +28,32 @@ import {
   CompletedLessonPlanSchema,
   type PartialLessonPlan,
 } from "../../../protocol/schema";
+import { createOpenAIBritishEnglishCorrectorAgent } from "../agents/britishEnglishCorrectorAgent";
 import { createOpenAIMessageToUserAgent } from "../agents/messageToUserAgent";
 import { createOpenAIPlannerAgent } from "../agents/plannerAgent";
 import { createSectionAgentRegistry } from "../agents/sectionAgents/sectionAgentRegistry";
 import { ailaTurn } from "../ailaTurn";
 import type { JsonPatchOperation } from "../compatibility/helpers/immerPatchToJsonPatch";
+import {
+  createEmptyCorrectorStats,
+  mergeCorrectorStats,
+} from "../correctorStats";
 import type { PlanStep, PlannerOutput, SectionKey } from "../schema";
 import type {
   AilaPersistedState,
   AilaRuntimeContext,
   AilaTurnCallbacks,
   ChatMessage,
+  CorrectorStats,
 } from "../types";
 import {
   collectMeaningOccurrences,
   formatMeaningEvidence,
 } from "./scoreAgenticIssues.helpers";
+import {
+  type CorrectorSummary,
+  summariseCorrector,
+} from "./summariseCorrector";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -80,7 +90,11 @@ type ScenarioConfig = {
   fetchRelevantLessons: () => Promise<never[]>;
 };
 
-type RunCapture = ScorerInput & { error?: string; durationSec: number };
+type RunCapture = ScorerInput & {
+  error?: string;
+  durationSec: number;
+  correctorStats: CorrectorStats;
+};
 
 // ---------------------------------------------------------------------------
 // Scorers
@@ -402,6 +416,8 @@ async function runOnce(scenario: ScenarioConfig): Promise<RunCapture> {
       },
     }),
     messageToUserAgent: createOpenAIMessageToUserAgent(openai),
+    britishEnglishCorrectorAgent:
+      createOpenAIBritishEnglishCorrectorAgent(openai),
     fetchRelevantLessons: scenario.fetchRelevantLessons,
   };
 
@@ -409,6 +425,7 @@ async function runOnce(scenario: ScenarioConfig): Promise<RunCapture> {
   const allPatches: JsonPatchOperation[] = [];
   let finalDocument: PartialLessonPlan = {};
   let finalMessage = "";
+  const aggregateCorrectorStats = createEmptyCorrectorStats();
 
   const messages: ChatMessage[] = [
     { id: "m0", role: "user", content: scenario.userMessage },
@@ -457,7 +474,12 @@ async function runOnce(scenario: ScenarioConfig): Promise<RunCapture> {
         },
       };
 
-      await ailaTurn({ persistedState: persisted, runtime, callbacks });
+      const outcome = await ailaTurn({
+        persistedState: persisted,
+        runtime,
+        callbacks,
+      });
+      mergeCorrectorStats(aggregateCorrectorStats, outcome.correctorStats);
       turnCount++;
 
       // Record the planner output as a synthetic PlannerOutput for scoring.
@@ -511,6 +533,7 @@ async function runOnce(scenario: ScenarioConfig): Promise<RunCapture> {
       americanismsBySection: new AilaAmericanisms().findAmericanisms(
         finalDocument,
       ),
+      correctorStats: aggregateCorrectorStats,
       error: String(error),
       durationSec,
     };
@@ -525,6 +548,7 @@ async function runOnce(scenario: ScenarioConfig): Promise<RunCapture> {
     americanismsBySection: new AilaAmericanisms().findAmericanisms(
       finalDocument,
     ),
+    correctorStats: aggregateCorrectorStats,
     durationSec: (Date.now() - startTime) / 1000,
   };
 }
@@ -544,6 +568,7 @@ type ScenarioResults = {
     error?: string;
     complete: boolean;
     scores: RunScore[];
+    correctorStats: CorrectorStats;
   }>;
 };
 
@@ -661,16 +686,25 @@ describe("Agentic Issue Scoring", () => {
     const report = generateReport(allResults);
     console.log("\n" + report);
 
-    const summary: Record<string, Record<string, Record<string, number>>> = {};
+    const summary: Record<
+      string,
+      Record<string, Record<string, number> | CorrectorSummary>
+    > = {};
     for (const scenario of allResults) {
-      const scorerTotals: Record<string, Record<string, number>> = {};
+      const scorerTotals: Record<
+        string,
+        Record<string, number> | CorrectorSummary
+      > = {};
       for (const run of scenario.runs) {
         for (const { scorerId, result } of run.scores) {
           scorerTotals[scorerId] ??= {};
-          const counts = scorerTotals[scorerId];
+          const counts = scorerTotals[scorerId] as Record<string, number>;
           counts[result.heuristic] = (counts[result.heuristic] ?? 0) + 1;
         }
       }
+      scorerTotals.americanisms_corrector = summariseCorrector(
+        scenario.runs.map((r) => r.correctorStats),
+      );
       summary[scenario.scenarioName] = scorerTotals;
     }
 
@@ -717,6 +751,7 @@ describe("Agentic Issue Scoring", () => {
           error: capture.error,
           complete: isComplete(capture.finalDocument),
           scores,
+          correctorStats: capture.correctorStats,
         });
       }
 

--- a/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
@@ -434,6 +434,7 @@ async function runOnce(scenario: ScenarioConfig): Promise<RunCapture> {
     messages,
     initialDocument: { ...scenario.initialDocument },
     relevantLessons: null,
+    ragFetched: { status: "not_fetched", searchIdentity: null },
   };
 
   const startTime = Date.now();
@@ -462,6 +463,10 @@ async function runOnce(scenario: ScenarioConfig): Promise<RunCapture> {
           for (const p of patches) {
             console.log(`    [turn ${turnCount + 1}] section done → ${p.path}`);
           }
+        },
+        onRagFetchedChange: (ragFetched) => {
+          persisted.ragFetched = ragFetched;
+          return Promise.resolve();
         },
         onTurnComplete: ({ document, ailaMessage }) => {
           turnDoc = document;

--- a/packages/aila/src/lib/agentic-system/scoring/scoreMathsComposer.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/scoreMathsComposer.ts
@@ -18,9 +18,7 @@
  *
  * Output: packages/aila/src/lib/agentic-system/scoring/scores-maths-composer.yaml
  */
-import fs from "fs";
 import path from "path";
-import YAML from "yaml";
 
 import { LLMComposer } from "../../../core/quiz/composers/LLMQuizComposer";
 import type {
@@ -31,6 +29,12 @@ import type {
 } from "../../../core/quiz/interfaces";
 import { createMockTask } from "../../../core/quiz/reporting/testing";
 import type { PartialLessonPlan, QuizPath } from "../../../protocol/schema";
+import {
+  type ScoredCell,
+  generateReport,
+  runEvalCells,
+  writeScores,
+} from "./evalHarness";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -267,14 +271,6 @@ type CellRun = {
   error?: string;
 };
 
-type CellResult = {
-  cellId: string;
-  description: string;
-  passThreshold: number;
-  passRate: number;
-  runs: CellRun[];
-};
-
 function scoreRun(cell: ComposerEvalCell, result: ComposerResult): CellRun {
   const reasons: string[] = [];
 
@@ -357,42 +353,10 @@ async function runCellOnce(cell: ComposerEvalCell): Promise<CellRun> {
 // Report
 // ---------------------------------------------------------------------------
 
-function generateReport(results: CellResult[], runsPerCell: number): string {
-  const lines: string[] = [];
-  lines.push("# Maths Composer Eval Report");
-  lines.push("");
-  lines.push(`Generated: ${new Date().toISOString()}`);
-  lines.push(`Runs per cell: ${runsPerCell}`);
-  lines.push("");
-  lines.push("| Cell | Threshold | Pass rate | Status |");
-  lines.push("|------|-----------|-----------|--------|");
-  for (const r of results) {
-    const meets = r.passRate >= r.passThreshold;
-    const status = r.passThreshold === 0 ? "📊 baseline" : meets ? "✓" : "🚩";
-    lines.push(
-      `| ${r.cellId} | ${(r.passThreshold * 100).toFixed(0)}% | ${(r.passRate * 100).toFixed(0)}% | ${status} |`,
-    );
-  }
-  lines.push("");
-  for (const r of results) {
-    lines.push(`### ${r.cellId} — ${r.description}`);
-    lines.push("");
-    for (let i = 0; i < r.runs.length; i++) {
-      const run = r.runs[i]!;
-      const icon = run.pass ? "✓" : "🚩";
-      const actual =
-        run.status === "success"
-          ? `status=success count=${run.selectedCount} uids=[${run.selectedUids.join(", ")}]`
-          : `status=bail reason="${run.bailReason ?? ""}"`;
-      const reasonStr = run.reasons.length
-        ? ` — ${run.reasons.join("; ")}`
-        : "";
-      lines.push(`- Run ${i + 1} ${icon} ${actual}${reasonStr}`);
-    }
-    lines.push("");
-  }
-  return lines.join("\n");
-}
+const formatActual = (run: CellRun): string =>
+  run.status === "success"
+    ? `status=success count=${run.selectedCount} uids=[${run.selectedUids.join(", ")}]`
+    : `status=bail reason="${run.bailReason ?? ""}"`;
 
 const OUTPUT_FILE = path.join(__dirname, "scores-maths-composer.yaml");
 const SCORE_RUNS = parseInt(process.env.SCORE_RUNS ?? "3", 10);
@@ -403,56 +367,34 @@ const SCORE_RUNS = parseInt(process.env.SCORE_RUNS ?? "3", 10);
 
 describe("Maths Composer Eval", () => {
   test(`score all cells (${SCORE_RUNS} runs each)`, async () => {
-    const results: CellResult[] = [];
+    const results: ScoredCell<CellRun>[] = await runEvalCells(
+      CELLS,
+      SCORE_RUNS,
+      runCellOnce,
+      (run) =>
+        run.status === "success"
+          ? `success count=${run.selectedCount} uids=[${run.selectedUids.join(", ")}]`
+          : `bail reason="${run.bailReason ?? run.error ?? ""}"`,
+    );
 
-    for (const cell of CELLS) {
-      console.log(`\n--- ${cell.id} (${SCORE_RUNS} runs) ---`);
-      const runs: CellRun[] = [];
-      for (let i = 0; i < SCORE_RUNS; i++) {
-        const run = await runCellOnce(cell);
-        const icon = run.pass ? "✓" : "🚩";
-        const actual =
-          run.status === "success"
-            ? `success count=${run.selectedCount} uids=[${run.selectedUids.join(", ")}]`
-            : `bail reason="${run.bailReason ?? run.error ?? ""}"`;
-        console.log(`  Run ${i + 1} ${icon} ${actual}`);
-        runs.push(run);
-      }
-      const passCount = runs.filter((r) => r.pass).length;
-      const passRate = passCount / runs.length;
-      results.push({
-        cellId: cell.id,
-        description: cell.description,
-        passThreshold: cell.passThreshold,
-        passRate,
-        runs,
-      });
-    }
+    console.log(
+      "\n" +
+        generateReport(
+          "Maths Composer Eval Report",
+          results,
+          SCORE_RUNS,
+          formatActual,
+        ),
+    );
 
-    const report = generateReport(results, SCORE_RUNS);
-    console.log("\n" + report);
-
-    const yamlData = {
-      generated: new Date().toISOString(),
-      runsPerCell: SCORE_RUNS,
-      cells: results.map((r) => ({
-        id: r.cellId,
-        description: r.description,
-        passThreshold: r.passThreshold,
-        passRate: r.passRate,
-        runs: r.runs.map((run) => ({
-          pass: run.pass,
-          reasons: run.reasons,
-          status: run.status,
-          selectedCount: run.selectedCount,
-          selectedUids: run.selectedUids,
-          ...(run.bailReason ? { bailReason: run.bailReason } : {}),
-          ...(run.error ? { error: run.error } : {}),
-        })),
-      })),
-    };
-    fs.mkdirSync(path.dirname(OUTPUT_FILE), { recursive: true });
-    fs.writeFileSync(OUTPUT_FILE, YAML.stringify(yamlData));
-    console.log(`\nReport written to: ${OUTPUT_FILE}`);
+    writeScores(OUTPUT_FILE, results, SCORE_RUNS, (run) => ({
+      pass: run.pass,
+      reasons: run.reasons,
+      status: run.status,
+      selectedCount: run.selectedCount,
+      selectedUids: run.selectedUids,
+      ...(run.bailReason ? { bailReason: run.bailReason } : {}),
+      ...(run.error ? { error: run.error } : {}),
+    }));
   }, 600_000);
 });

--- a/packages/aila/src/lib/agentic-system/scoring/scorePlannerQuizIntent.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/scorePlannerQuizIntent.ts
@@ -15,10 +15,8 @@
  *
  * Output: packages/aila/src/lib/agentic-system/scoring/scores-planner-quiz-intent.yaml
  */
-import fs from "fs";
 import OpenAI from "openai";
 import path from "path";
-import YAML from "yaml";
 
 import type {
   LatestQuiz,
@@ -28,6 +26,12 @@ import type {
 import { createOpenAIPlannerAgent } from "../agents/plannerAgent";
 import type { PlannerOutput, QuizIntent } from "../schema";
 import type { ChatMessage } from "../types";
+import {
+  type ScoredCell,
+  generateReport,
+  runEvalCells,
+  writeScores,
+} from "./evalHarness";
 
 // ---------------------------------------------------------------------------
 // Fixtures
@@ -263,14 +267,6 @@ type CellRun = {
   error?: string;
 };
 
-type CellResult = {
-  cellId: string;
-  description: string;
-  passThreshold: number;
-  passRate: number;
-  runs: CellRun[];
-};
-
 function findQuizStep(
   planner: PlannerOutput,
   sectionKey: "starterQuiz" | "exitQuiz",
@@ -368,43 +364,12 @@ async function runCellOnce(cell: EvalCell, openai: OpenAI): Promise<CellRun> {
 // Report
 // ---------------------------------------------------------------------------
 
-function generateReport(results: CellResult[], runsPerCell: number): string {
-  const lines: string[] = [];
-  lines.push("# Planner Quiz-Intent Eval Report");
-  lines.push("");
-  lines.push(`Generated: ${new Date().toISOString()}`);
-  lines.push(`Runs per cell: ${runsPerCell}`);
-  lines.push("");
-  lines.push("| Cell | Threshold | Pass rate | Status |");
-  lines.push("|------|-----------|-----------|--------|");
-  for (const r of results) {
-    const meets = r.passRate >= r.passThreshold;
-    const status = r.passThreshold === 0 ? "📊 baseline" : meets ? "✓" : "🚩";
-    lines.push(
-      `| ${r.cellId} | ${(r.passThreshold * 100).toFixed(0)}% | ${(r.passRate * 100).toFixed(0)}% | ${status} |`,
-    );
-  }
-  lines.push("");
-  for (const r of results) {
-    lines.push(`### ${r.cellId} — ${r.description}`);
-    lines.push("");
-    for (let i = 0; i < r.runs.length; i++) {
-      const run = r.runs[i]!;
-      const icon = run.pass ? "✓" : "🚩";
-      const actual = run.actual
-        ? `action=${run.actual.action} position=${run.actual.position}`
-        : run.error
-          ? `error=${run.error}`
-          : `decision=${run.decision}`;
-      const reasonStr = run.reasons.length
-        ? ` — ${run.reasons.join("; ")}`
-        : "";
-      lines.push(`- Run ${i + 1} ${icon} ${actual}${reasonStr}`);
-    }
-    lines.push("");
-  }
-  return lines.join("\n");
-}
+const formatActual = (run: CellRun): string =>
+  run.actual
+    ? `action=${run.actual.action} position=${run.actual.position}`
+    : run.error
+      ? `error=${run.error}`
+      : `decision=${run.decision}`;
 
 const OUTPUT_FILE = path.join(__dirname, "scores-planner-quiz-intent.yaml");
 const SCORE_RUNS = parseInt(process.env.SCORE_RUNS ?? "5", 10);
@@ -416,54 +381,34 @@ const SCORE_RUNS = parseInt(process.env.SCORE_RUNS ?? "5", 10);
 describe("Planner Quiz-Intent Eval", () => {
   test(`score all cells (${SCORE_RUNS} runs each)`, async () => {
     const openai = new OpenAI();
-    const results: CellResult[] = [];
 
-    for (const cell of CELLS) {
-      console.log(`\n--- ${cell.id} (${SCORE_RUNS} runs) ---`);
-      const runs: CellRun[] = [];
-      for (let i = 0; i < SCORE_RUNS; i++) {
-        const run = await runCellOnce(cell, openai);
-        const icon = run.pass ? "✓" : "🚩";
-        const actual = run.actual
+    const results: ScoredCell<CellRun>[] = await runEvalCells(
+      CELLS,
+      SCORE_RUNS,
+      (cell) => runCellOnce(cell, openai),
+      (run) =>
+        run.actual
           ? `${run.actual.action} pos=${run.actual.position}`
           : run.error
             ? `error: ${run.error}`
-            : `decision: ${run.decision}`;
-        console.log(`  Run ${i + 1} ${icon} ${actual}`);
-        runs.push(run);
-      }
-      const passCount = runs.filter((r) => r.pass).length;
-      const passRate = passCount / runs.length;
-      results.push({
-        cellId: cell.id,
-        description: cell.description,
-        passThreshold: cell.passThreshold,
-        passRate,
-        runs,
-      });
-    }
+            : `decision: ${run.decision}`,
+    );
 
-    const report = generateReport(results, SCORE_RUNS);
-    console.log("\n" + report);
+    console.log(
+      "\n" +
+        generateReport(
+          "Planner Quiz-Intent Eval Report",
+          results,
+          SCORE_RUNS,
+          formatActual,
+        ),
+    );
 
-    const yamlData = {
-      generated: new Date().toISOString(),
-      runsPerCell: SCORE_RUNS,
-      cells: results.map((r) => ({
-        id: r.cellId,
-        description: r.description,
-        passThreshold: r.passThreshold,
-        passRate: r.passRate,
-        runs: r.runs.map((run) => ({
-          pass: run.pass,
-          reasons: run.reasons,
-          actual: run.actual,
-          ...(run.error ? { error: run.error } : {}),
-        })),
-      })),
-    };
-    fs.mkdirSync(path.dirname(OUTPUT_FILE), { recursive: true });
-    fs.writeFileSync(OUTPUT_FILE, YAML.stringify(yamlData));
-    console.log(`\nReport written to: ${OUTPUT_FILE}`);
+    writeScores(OUTPUT_FILE, results, SCORE_RUNS, (run) => ({
+      pass: run.pass,
+      reasons: run.reasons,
+      actual: run.actual,
+      ...(run.error ? { error: run.error } : {}),
+    }));
   }, 600_000);
 });

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
-codeHash: 9b1e058148e038a671a40d6395a239f35418446197e6fc07454ec52c3bdca74b
-generated: 2026-06-01T23:52:50.873Z
+codeHash: 7324fbcf21c82cc382ea853323c4a00e06f60dc4ba2f0db7ac029551bf94b377
+generated: 2026-06-02T10:39:01.416Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -22,18 +22,19 @@ summary:
     quiz-question-count:
       pass: 3
     americanisms_corrector:
-      corrections_attempted: 2
-      corrections_not_needed: 31
+      corrections_attempted: 0
+      corrections_not_needed: 33
       corrections_failed: 0
-      correction_rate: 6.1%
+      correction_rate: 0.0%
       correction_failure_rate: 0.0%
-      corrections_by_section:
-        cycle2: 2
+      corrections_by_section: {}
   no-rag-lesson:
     plan-groupings:
-      pass: 3
+      pass: 2
+      flag: 1
     additional-materials-tone:
-      skip: 3
+      skip: 2
+      pass: 1
     cycle-verbosity:
       pass: 3
     keyword-casing:
@@ -51,10 +52,9 @@ summary:
     quiz-question-count:
       pass: 3
     americanisms_corrector:
-      corrections_attempted: 1
-      corrections_not_needed: 32
+      corrections_attempted: 0
+      corrections_not_needed: 34
       corrections_failed: 0
-      correction_rate: 3.0%
+      correction_rate: 0.0%
       correction_failure_rate: 0.0%
-      corrections_by_section:
-        starterQuiz: 1
+      corrections_by_section: {}

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
-codeHash: 4942e3b3dd30e00a6c09131283311ebe10b76efbc187ee0ab11fa1846661859b
-generated: 2026-05-28T14:36:49.436Z
+codeHash: 9b1e058148e038a671a40d6395a239f35418446197e6fc07454ec52c3bdca74b
+generated: 2026-06-01T23:52:50.873Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -21,6 +21,14 @@ summary:
       flag: 3
     quiz-question-count:
       pass: 3
+    americanisms_corrector:
+      corrections_attempted: 2
+      corrections_not_needed: 31
+      corrections_failed: 0
+      correction_rate: 6.1%
+      correction_failure_rate: 0.0%
+      corrections_by_section:
+        cycle2: 2
   no-rag-lesson:
     plan-groupings:
       pass: 3
@@ -35,12 +43,18 @@ summary:
     no-basedOn-without-rag:
       pass: 3
     americanisms-spelling:
-      flag: 2
-      pass: 1
+      pass: 3
     americanisms-phrasing:
-      pass: 2
-      flag: 1
+      pass: 3
     americanisms-meanings:
       flag: 3
     quiz-question-count:
       pass: 3
+    americanisms_corrector:
+      corrections_attempted: 1
+      corrections_not_needed: 32
+      corrections_failed: 0
+      correction_rate: 3.0%
+      correction_failure_rate: 0.0%
+      corrections_by_section:
+        starterQuiz: 1

--- a/packages/aila/src/lib/agentic-system/scoring/summariseCorrector.test.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/summariseCorrector.test.ts
@@ -1,0 +1,172 @@
+import type { SectionKey } from "../schema";
+import type { CorrectorStats } from "../types";
+import { summariseCorrector } from "./summariseCorrector";
+
+const TITLE: SectionKey = "title";
+const SUBJECT: SectionKey = "subject";
+const CYCLE1: SectionKey = "cycle1";
+const STARTER_QUIZ: SectionKey = "starterQuiz";
+
+const empty: CorrectorStats = { attempted: [], notNeeded: [], failed: [] };
+
+describe("summariseCorrector (counts and rates)", () => {
+  it("returns zeros and 0.0% rates when given no runs", () => {
+    expect(summariseCorrector([])).toEqual({
+      corrections_attempted: 0,
+      corrections_not_needed: 0,
+      corrections_failed: 0,
+      correction_rate: "0.0%",
+      correction_failure_rate: "0.0%",
+      corrections_by_section: {},
+    });
+  });
+
+  it("returns zeros and 0.0% rates when every run is empty", () => {
+    expect(summariseCorrector([empty, empty, empty])).toEqual({
+      corrections_attempted: 0,
+      corrections_not_needed: 0,
+      corrections_failed: 0,
+      correction_rate: "0.0%",
+      correction_failure_rate: "0.0%",
+      corrections_by_section: {},
+    });
+  });
+
+  it("collapses correction_failure_rate to 0.0% when nothing was attempted (division by zero defence)", () => {
+    const summary = summariseCorrector([
+      { attempted: [], notNeeded: [TITLE, SUBJECT], failed: [] },
+    ]);
+    expect(summary.corrections_attempted).toBe(0);
+    expect(summary.correction_rate).toBe("0.0%");
+    expect(summary.correction_failure_rate).toBe("0.0%");
+  });
+
+  it("counts a single attempt with no failures", () => {
+    const summary = summariseCorrector([
+      { attempted: [CYCLE1], notNeeded: [TITLE, SUBJECT], failed: [] },
+    ]);
+    expect(summary).toEqual({
+      corrections_attempted: 1,
+      corrections_not_needed: 2,
+      corrections_failed: 0,
+      correction_rate: "33.3%",
+      correction_failure_rate: "0.0%",
+      corrections_by_section: { cycle1: 1 },
+    });
+  });
+
+  it("computes a non-trivial failure rate when some attempts fail", () => {
+    const summary = summariseCorrector([
+      {
+        attempted: [CYCLE1, STARTER_QUIZ],
+        notNeeded: [TITLE],
+        failed: [{ sectionKey: STARTER_QUIZ, reason: "schema-invalid" }],
+      },
+    ]);
+    expect(summary.corrections_attempted).toBe(2);
+    expect(summary.corrections_failed).toBe(1);
+    expect(summary.correction_rate).toBe("66.7%");
+    expect(summary.correction_failure_rate).toBe("50.0%");
+  });
+
+  it("counts all failure reasons toward corrections_failed regardless of kind", () => {
+    const summary = summariseCorrector([
+      {
+        attempted: [TITLE, SUBJECT, CYCLE1],
+        notNeeded: [],
+        failed: [
+          { sectionKey: TITLE, reason: "threw" },
+          { sectionKey: SUBJECT, reason: "errored" },
+          { sectionKey: CYCLE1, reason: "schema-invalid" },
+        ],
+      },
+    ]);
+    expect(summary.corrections_failed).toBe(3);
+    expect(summary.correction_failure_rate).toBe("100.0%");
+  });
+
+  it("tallies corrections_by_section, summing duplicates within a run", () => {
+    const summary = summariseCorrector([
+      {
+        attempted: [CYCLE1, CYCLE1, STARTER_QUIZ],
+        notNeeded: [TITLE],
+        failed: [],
+      },
+    ]);
+    expect(summary.corrections_by_section).toEqual({
+      cycle1: 2,
+      starterQuiz: 1,
+    });
+  });
+});
+
+describe("summariseCorrector (multi-run aggregation)", () => {
+  it("flattens stats across multiple runs of a scenario into one summary", () => {
+    const runs: CorrectorStats[] = [
+      // Run 1: clean except for one cycle1 fire
+      {
+        attempted: [CYCLE1],
+        notNeeded: [TITLE, SUBJECT, STARTER_QUIZ],
+        failed: [],
+      },
+      // Run 2: completely clean
+      {
+        attempted: [],
+        notNeeded: [TITLE, SUBJECT, CYCLE1, STARTER_QUIZ],
+        failed: [],
+      },
+      // Run 3: starterQuiz fired and failed (errored)
+      {
+        attempted: [STARTER_QUIZ],
+        notNeeded: [TITLE, SUBJECT, CYCLE1],
+        failed: [{ sectionKey: STARTER_QUIZ, reason: "errored" }],
+      },
+    ];
+
+    expect(summariseCorrector(runs)).toEqual({
+      corrections_attempted: 2,
+      corrections_not_needed: 10,
+      corrections_failed: 1,
+      correction_rate: "16.7%", // 2 / (2 + 10)
+      correction_failure_rate: "50.0%", // 1 / 2
+      corrections_by_section: {
+        cycle1: 1,
+        starterQuiz: 1,
+      },
+    });
+  });
+
+  it("accumulates corrections_by_section across runs (same section firing twice)", () => {
+    // The harness allows the same section to fire across multiple runs
+    const runs: CorrectorStats[] = [
+      { attempted: [CYCLE1], notNeeded: [], failed: [] },
+      { attempted: [CYCLE1], notNeeded: [], failed: [] },
+      { attempted: [CYCLE1, STARTER_QUIZ], notNeeded: [], failed: [] },
+    ];
+
+    expect(summariseCorrector(runs).corrections_by_section).toEqual({
+      cycle1: 3,
+      starterQuiz: 1,
+    });
+  });
+
+  it("produces a YAML-ready shape", () => {
+    const summary = summariseCorrector([
+      {
+        attempted: [STARTER_QUIZ],
+        notNeeded: Array(32).fill(TITLE) as SectionKey[],
+        failed: [],
+      },
+    ]);
+
+    expect(summary).toEqual({
+      corrections_attempted: expect.any(Number),
+      corrections_not_needed: expect.any(Number),
+      corrections_failed: expect.any(Number),
+      correction_rate: expect.stringMatching(/^\d+\.\d%$/),
+      correction_failure_rate: expect.stringMatching(/^\d+\.\d%$/),
+      corrections_by_section: expect.any(Object),
+    });
+    expect(summary.correction_rate).toBe("3.0%"); // 1 / 33
+  });
+});

--- a/packages/aila/src/lib/agentic-system/scoring/summariseCorrector.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/summariseCorrector.ts
@@ -1,0 +1,43 @@
+import type { SectionKey } from "../schema";
+import type { CorrectorStats } from "../types";
+
+export type CorrectorSummary = {
+  corrections_attempted: number;
+  corrections_not_needed: number;
+  corrections_failed: number;
+  correction_rate: string;
+  correction_failure_rate: string;
+  corrections_by_section: Record<string, number>;
+};
+
+/**
+ * Formats `CorrectorStats` (one per run of a scenario) into a shape that's
+ * eventually inserted into `scores.yaml` as the `americanisms_corrector`
+ * block.
+ */
+export function summariseCorrector(stats: CorrectorStats[]): CorrectorSummary {
+  const attempted: SectionKey[] = stats.flatMap((s) => s.attempted);
+  const notNeeded: SectionKey[] = stats.flatMap((s) => s.notNeeded);
+  const failed = stats.flatMap((s) => s.failed);
+
+  const total = attempted.length + notNeeded.length;
+  const rate = (numerator: number, denominator: number): string =>
+    denominator === 0
+      ? "0.0%"
+      : `${((numerator / denominator) * 100).toFixed(1)}%`;
+
+  const correctionsBySection: Record<string, number> = {};
+  for (const sectionKey of attempted) {
+    correctionsBySection[sectionKey] =
+      (correctionsBySection[sectionKey] ?? 0) + 1;
+  }
+
+  return {
+    corrections_attempted: attempted.length,
+    corrections_not_needed: notNeeded.length,
+    corrections_failed: failed.length,
+    correction_rate: rate(attempted.length, total),
+    correction_failure_rate: rate(failed.length, attempted.length),
+    corrections_by_section: correctionsBySection,
+  };
+}

--- a/packages/aila/src/lib/agentic-system/types.ts
+++ b/packages/aila/src/lib/agentic-system/types.ts
@@ -16,6 +16,7 @@ import type {
   PriorKnowledgeSchema,
   SubjectSchema,
 } from "../../protocol/schema";
+import type { BritishEnglishCorrectorAgentProps } from "./agents/britishEnglishCorrectorAgent";
 import type { MessageToUserAgentOutput } from "./agents/messageToUserAgent/messageToUserAgent.schema";
 import type { VoiceId } from "./agents/sectionAgents/shared/voices";
 import type { JsonPatchOperation } from "./compatibility/helpers/immerPatchToJsonPatch";
@@ -53,6 +54,9 @@ export type AilaRuntimeContext = {
   messageToUserAgent: (
     props: MessageToUserAgentProps,
   ) => Promise<AgentResult<MessageToUserAgentOutput>>;
+  britishEnglishCorrectorAgent: (
+    props: BritishEnglishCorrectorAgentProps,
+  ) => Promise<AgentResult<unknown>>;
   fetchRelevantLessons: (
     props: RagSearchArgs,
   ) => Promise<AgenticRagLessonPlanResult[]>;
@@ -81,7 +85,10 @@ export type AilaTurnArgs = {
   callbacks: AilaTurnCallbacks;
 };
 
-export type AilaTurnOutcome = { status: "success" } | { status: "failed" };
+export type AilaTurnOutcome = {
+  status: "success" | "failed";
+  correctorStats: CorrectorStats;
+};
 
 export type AilaTurnPhaseOutcome = { status: "continue" } | AilaTurnOutcome;
 
@@ -173,6 +180,14 @@ export type AilaState = {
   ) => Promise<AgenticRagLessonPlanResult[]>;
 };
 
+export type CorrectorFailureReason = "threw" | "errored" | "schema-invalid";
+
+export type CorrectorStats = {
+  attempted: SectionKey[];
+  notNeeded: SectionKey[];
+  failed: { sectionKey: SectionKey; reason: CorrectorFailureReason }[];
+};
+
 export type AilaCurrentTurn = {
   document: PartialLessonPlan;
   plannerOutput: PlannerOutput | null;
@@ -182,6 +197,7 @@ export type AilaCurrentTurn = {
   relevantLessons: AgenticRagLessonPlanResult[] | null;
   relevantLessonsFetched: boolean;
   currentStep: PlanStep | null;
+  correctorStats: CorrectorStats;
 };
 
 export type AgentResult<T> =

--- a/packages/aila/src/lib/agentic-system/types.ts
+++ b/packages/aila/src/lib/agentic-system/types.ts
@@ -14,6 +14,7 @@ import type {
   MisconceptionsSchema,
   PartialLessonPlan,
   PriorKnowledgeSchema,
+  RagFetched,
   SubjectSchema,
 } from "../../protocol/schema";
 import type { BritishEnglishCorrectorAgentProps } from "./agents/britishEnglishCorrectorAgent";
@@ -42,6 +43,7 @@ export type AilaPersistedState = {
   messages: ChatMessage[];
   initialDocument: PartialLessonPlan;
   relevantLessons: AgenticRagLessonPlanResult[] | null;
+  ragFetched: RagFetched;
 };
 
 type RagSearchArgs = { title: string; subject: string; keyStage: string };
@@ -68,6 +70,7 @@ export type AilaRuntimeContext = {
 export type AilaTurnCallbacks = {
   onPlannerComplete: ({ sectionKeys }: { sectionKeys: SectionKey[] }) => void;
   onSectionComplete: (patches: JsonPatchOperation[]) => void;
+  onRagFetchedChange: (ragFetched: RagFetched) => void | Promise<void>;
   onTurnComplete: (props: {
     stepsExecuted: PlanStep[];
     document: PartialLessonPlan;

--- a/packages/aila/src/lib/agentic-system/utils/fixedResponses.ts
+++ b/packages/aila/src/lib/agentic-system/utils/fixedResponses.ts
@@ -1,9 +1,10 @@
 export function displayRelevantLessons(
   relevantLessons: { title: string }[],
 ): string {
-  return `I have fetched the following existing Oak lessons that look relevant:
-${relevantLessons.map((lesson, i) => `${i + 1}. ${lesson.title}`).join("\n")}
-Would you like to base your lesson on one of these? Otherwise we can create one from scratch!`;
+  const list = relevantLessons
+    .map((lesson, i) => `${i + 1}. ${lesson.title}`)
+    .join("\n");
+  return `I have fetched the following existing Oak lessons that look relevant:\n\n${list}\n\nWould you like to base your lesson on one of these? Otherwise we can create one from scratch!`;
 }
 
 export function hardFailureMessage(): string {

--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -424,6 +424,21 @@ const AilaRagRelevantLessonSchema = z.object({
 
 export type AilaRagRelevantLesson = z.infer<typeof AilaRagRelevantLessonSchema>;
 
+export const searchIdentitySchema = z.object({
+  title: z.string(),
+  subject: z.string(),
+  keyStage: z.string(),
+});
+
+export type SearchIdentity = z.infer<typeof searchIdentitySchema>;
+
+export const ragFetchedSchema = z.object({
+  status: z.enum(["not_fetched", "shown", "none_found", "selected"]),
+  searchIdentity: searchIdentitySchema.nullish(),
+});
+
+export type RagFetched = z.infer<typeof ragFetchedSchema>;
+
 export const chatSchema = z
   .object({
     id: z.string(),
@@ -437,6 +452,7 @@ export const chatSchema = z
     updatedAt: z.union([z.date(), z.number()]).optional(),
     iteration: z.number().optional(),
     startingMessage: z.string().optional(),
+    ragFetched: ragFetchedSchema.optional(),
     messages: z.array(MessageSchema.passthrough()),
   })
   .passthrough();
@@ -455,6 +471,7 @@ export const chatSchemaWithMissingMessageIds = z
     updatedAt: z.union([z.date(), z.number()]).optional(),
     iteration: z.number().optional(),
     startingMessage: z.string().optional(),
+    ragFetched: ragFetchedSchema.optional(),
     messages: z.array(
       z
         .object({

--- a/packages/aila/src/protocol/schemas/quiz/quizV3.ts
+++ b/packages/aila/src/protocol/schemas/quiz/quizV3.ts
@@ -84,7 +84,7 @@ export const QuizV3Schema = z.object({
     .array(ImageMetadataSchema)
     .describe(QUIZ_V3_DESCRIPTIONS.imageMetadata),
   /** Links to the generation report in KV storage (key: quiz:generation-report:{reportId}) */
-  reportId: z.string().optional(),
+  reportId: z.string().nullish(),
 });
 
 export const QuizV3SchemaWithoutLength = QuizV3Schema;

--- a/packages/rag/getRagLessonPlansByIds/getRagLessonPlansByIds.test.ts
+++ b/packages/rag/getRagLessonPlansByIds/getRagLessonPlansByIds.test.ts
@@ -1,0 +1,242 @@
+import type { PrismaClientWithAccelerate } from "@oakai/db";
+
+import { generateMock } from "@anatine/zod-mock";
+import * as Sentry from "@sentry/nextjs";
+
+import { CompletedLessonPlanSchema } from "../../aila/src/protocol/schema";
+import { QuizV1Schema } from "../../aila/src/protocol/schemas/quiz/quizV1";
+import { QuizV2Schema } from "../../aila/src/protocol/schemas/quiz/quizV2";
+import { getRagLessonPlansByIds } from "./getRagLessonPlansByIds";
+
+jest.mock("@sentry/nextjs", () => ({
+  __esModule: true,
+  captureException: jest.fn(),
+}));
+
+type DbRow = {
+  id: string;
+  ingestLessonId: string | null;
+  oakLessonId: number | null;
+  oakLessonSlug: string;
+  lessonPlan: unknown;
+};
+
+function makeRow(overrides: Partial<DbRow> = {}): DbRow {
+  return {
+    id: "rag-id",
+    ingestLessonId: null,
+    oakLessonId: 1,
+    oakLessonSlug: "slug",
+    lessonPlan: generateMock(CompletedLessonPlanSchema),
+    ...overrides,
+  };
+}
+
+describe("getRagLessonPlansByIds", () => {
+  let findManyMock: jest.Mock;
+  let prisma: PrismaClientWithAccelerate;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    findManyMock = jest.fn();
+    prisma = {
+      ragLessonPlan: { findMany: findManyMock },
+    } as unknown as PrismaClientWithAccelerate;
+  });
+
+  describe("query construction", () => {
+    it("queries findMany with id IN lessonPlanIds", async () => {
+      findManyMock.mockResolvedValue([]);
+
+      await getRagLessonPlansByIds({
+        lessonPlanIds: ["a", "b", "c"],
+        prisma,
+      });
+
+      expect(findManyMock).toHaveBeenCalledTimes(1);
+      expect(findManyMock).toHaveBeenCalledWith({
+        where: { id: { in: ["a", "b", "c"] } },
+      });
+    });
+
+    it("returns an empty array when no lesson plan IDs are requested", async () => {
+      findManyMock.mockResolvedValue([]);
+
+      const result = await getRagLessonPlansByIds({
+        lessonPlanIds: [],
+        prisma,
+      });
+
+      expect(result).toEqual([]);
+    });
+
+    it("returns an empty array when findMany matches no rows", async () => {
+      findManyMock.mockResolvedValue([]);
+
+      const result = await getRagLessonPlansByIds({
+        lessonPlanIds: ["missing"],
+        prisma,
+      });
+
+      expect(result).toEqual([]);
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("row mapping", () => {
+    it("returns the expected fields for a valid v3 lesson plan", async () => {
+      findManyMock.mockResolvedValue([
+        makeRow({
+          id: "rag-1",
+          ingestLessonId: "ingest-1",
+          oakLessonId: 100,
+          oakLessonSlug: "slug-1",
+        }),
+      ]);
+
+      const result = await getRagLessonPlansByIds({
+        lessonPlanIds: ["rag-1"],
+        prisma,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]).toMatchObject({
+        ragLessonPlanId: "ingest-1",
+        oakLessonId: 100,
+        oakLessonSlug: "slug-1",
+      });
+      expect(result[0]?.lessonPlan).toBeDefined();
+    });
+
+    it("uses ingestLessonId for ragLessonPlanId when present", async () => {
+      findManyMock.mockResolvedValue([
+        makeRow({ id: "rag-x", ingestLessonId: "ingest-x" }),
+      ]);
+
+      const result = await getRagLessonPlansByIds({
+        lessonPlanIds: ["rag-x"],
+        prisma,
+      });
+
+      expect(result[0]?.ragLessonPlanId).toBe("ingest-x");
+    });
+
+    it("falls back to the input id for ragLessonPlanId when ingestLessonId is null", async () => {
+      findManyMock.mockResolvedValue([
+        makeRow({ id: "rag-y", ingestLessonId: null }),
+      ]);
+
+      const result = await getRagLessonPlansByIds({
+        lessonPlanIds: ["rag-y"],
+        prisma,
+      });
+
+      expect(result[0]?.ragLessonPlanId).toBe("rag-y");
+    });
+
+    it("preserves a null oakLessonId", async () => {
+      findManyMock.mockResolvedValue([makeRow({ oakLessonId: null })]);
+
+      const result = await getRagLessonPlansByIds({
+        lessonPlanIds: ["rag-id"],
+        prisma,
+      });
+
+      expect(result[0]?.oakLessonId).toBeNull();
+    });
+  });
+
+  describe("schema migration", () => {
+    it("migrates a v2 quiz lesson plan to v3 (regression for empty-basedOn bug)", async () => {
+      const baseLesson = generateMock(CompletedLessonPlanSchema);
+      const v2Quiz = generateMock(QuizV2Schema);
+
+      findManyMock.mockResolvedValue([
+        makeRow({
+          id: "rag-v2",
+          lessonPlan: {
+            ...baseLesson,
+            starterQuiz: v2Quiz,
+            exitQuiz: v2Quiz,
+          },
+        }),
+      ]);
+
+      const result = await getRagLessonPlansByIds({
+        lessonPlanIds: ["rag-v2"],
+        prisma,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.lessonPlan.starterQuiz.version).toBe("v3");
+      expect(result[0]?.lessonPlan.exitQuiz.version).toBe("v3");
+      expect(Sentry.captureException).not.toHaveBeenCalled();
+    });
+
+    it("migrates a v1 quiz lesson plan through to v3", async () => {
+      const baseLesson = generateMock(CompletedLessonPlanSchema);
+      const v1Quiz = generateMock(QuizV1Schema);
+
+      findManyMock.mockResolvedValue([
+        makeRow({
+          id: "rag-v1",
+          lessonPlan: {
+            ...baseLesson,
+            starterQuiz: v1Quiz,
+            exitQuiz: v1Quiz,
+          },
+        }),
+      ]);
+
+      const result = await getRagLessonPlansByIds({
+        lessonPlanIds: ["rag-v1"],
+        prisma,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.lessonPlan.starterQuiz.version).toBe("v3");
+      expect(result[0]?.lessonPlan.exitQuiz.version).toBe("v3");
+    });
+  });
+
+  describe("error handling", () => {
+    it("drops a malformed lesson plan and reports it to Sentry", async () => {
+      findManyMock.mockResolvedValue([
+        makeRow({
+          id: "rag-bad",
+          oakLessonId: 999,
+          lessonPlan: { totally: "wrong", shape: 123 },
+        }),
+      ]);
+
+      const result = await getRagLessonPlansByIds({
+        lessonPlanIds: ["rag-bad"],
+        prisma,
+      });
+
+      expect(result).toEqual([]);
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+      expect(Sentry.captureException).toHaveBeenCalledWith(expect.any(Error), {
+        extra: { ragLessonPlanId: "rag-bad", oakLessonId: 999 },
+      });
+    });
+
+    it("returns the surviving rows when only some plans fail validation", async () => {
+      const validLesson = generateMock(CompletedLessonPlanSchema);
+
+      findManyMock.mockResolvedValue([
+        makeRow({ id: "rag-good", lessonPlan: validLesson }),
+        makeRow({ id: "rag-bad", lessonPlan: { broken: true } }),
+      ]);
+
+      const result = await getRagLessonPlansByIds({
+        lessonPlanIds: ["rag-good", "rag-bad"],
+        prisma,
+      });
+
+      expect(result).toHaveLength(1);
+      expect(result[0]?.ragLessonPlanId).toBe("rag-good");
+      expect(Sentry.captureException).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/rag/getRagLessonPlansByIds/getRagLessonPlansByIds.ts
+++ b/packages/rag/getRagLessonPlansByIds/getRagLessonPlansByIds.ts
@@ -1,5 +1,6 @@
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 
+import * as Sentry from "@sentry/nextjs";
 import { isTruthy } from "remeda";
 import invariant from "tiny-invariant";
 
@@ -7,6 +8,7 @@ import {
   type CompletedLessonPlan,
   CompletedLessonPlanSchema,
 } from "../../aila/src/protocol/schema";
+import { migrateLessonPlan } from "../../aila/src/protocol/schemas/versioning/migrateLessonPlan";
 
 /**
  * @todo Implement cache strategy for this function
@@ -37,25 +39,35 @@ export async function getRagLessonPlansByIds({
     },
   });
 
-  return lessonPlans
-    .map((lp, i) => {
-      const parseResult = CompletedLessonPlanSchema.safeParse(lp.lessonPlan);
+  const results = await Promise.all(
+    lessonPlans.map(async (lp, i) => {
+      try {
+        const { lessonPlan: migratedLessonPlan } = await migrateLessonPlan({
+          lessonPlan: lp.lessonPlan as unknown as Record<string, unknown>,
+          persistMigration: null,
+          outputSchema: CompletedLessonPlanSchema,
+        });
 
-      if (!parseResult.success) {
-        // @todo error to sentry
+        const id = lessonPlanIds[i];
+        invariant(id, "No id found for lesson plan, this should be impossible");
+
+        return {
+          ragLessonPlanId: lp.ingestLessonId ?? id,
+          oakLessonId: lp.oakLessonId,
+          oakLessonSlug: lp.oakLessonSlug,
+          lessonPlan: migratedLessonPlan,
+        };
+      } catch (error) {
+        Sentry.captureException(error, {
+          extra: {
+            ragLessonPlanId: lp.id,
+            oakLessonId: lp.oakLessonId,
+          },
+        });
         return null;
       }
+    }),
+  );
 
-      const id = lessonPlanIds[i];
-
-      invariant(id, "No id found for lesson plan, this should be impossible");
-
-      return {
-        ragLessonPlanId: lp.ingestLessonId ?? id,
-        oakLessonId: lp.oakLessonId,
-        oakLessonSlug: lp.oakLessonSlug,
-        lessonPlan: parseResult.data,
-      };
-    })
-    .filter(isTruthy);
+  return results.filter(isTruthy);
 }

--- a/packages/rag/lib/search/search.ts
+++ b/packages/rag/lib/search/search.ts
@@ -58,7 +58,7 @@ export async function vectorSearch({
     prisma,
     queryVector,
     keyStageSlugs: keyStageSlugs.map(keyStageForSearch),
-    subjectSlugs,
+    subjectSlugs: subjectSlugs.map((s) => s.toLowerCase()),
     limit,
   });
   log.info(`Prisma returned ${queryResponse.length} lesson plan part results`);

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -21,6 +21,7 @@
     "@oakai/db": "*",
     "@oakai/logger": "*",
     "@oakai/prettier-config": "*",
+    "@sentry/nextjs": "^10.29.0",
     "zod": "3.25.76"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1111,6 +1111,9 @@ importers:
       '@oakai/prettier-config':
         specifier: '*'
         version: link:../prettier-config
+      '@sentry/nextjs':
+        specifier: ^10.29.0
+        version: 10.31.0(@opentelemetry/context-async-hooks@2.2.0)(@opentelemetry/core@2.2.0)(@opentelemetry/sdk-trace-base@2.2.0)(next@16.0.10)(react@19.2.1)(webpack@5.102.1)
       zod:
         specifier: 3.25.76
         version: 3.25.76


### PR DESCRIPTION
## Description
### Features
- **Add per-section British English corrector agent**: Introduced a new agentic correction flow to apply British English checks at the section level. [#1049](https://github.com/oaknational/oak-ai-lesson-assistant/pull/1049)
- **Prevent refetched RAG**: Updated retrieval behaviour to avoid unnecessary RAG refetching. [#1061](https://github.com/oaknational/oak-ai-lesson-assistant/pull/1061)

### Refactors
- **Deduplicate agentic scoring harnesses and maths quiz handlers**: Reduced duplicated logic across scoring harnesses and maths quiz handling code. [#1063](https://github.com/oaknational/oak-ai-lesson-assistant/pull/1063)