### PR TITLE
feat: block rag if lesson is complete

### DIFF
--- a/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.test.ts
+++ b/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.test.ts
@@ -67,15 +67,6 @@ function createContext(
   };
 }
 
-const fakeLessons: AgenticRagLessonPlanResult[] = [
-  {
-    ragLessonPlanId: "lp1",
-    oakLessonId: 1,
-    oakLessonSlug: "photosynthesis",
-    lessonPlan: { title: "Photosynthesis" },
-  },
-];
-
 describe("handleRelevantLessons", () => {
   it("skips fetch and persists 'selected' when basedOn is set", async () => {
     const ctx = createContext({

--- a/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.test.ts
+++ b/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.test.ts
@@ -1,3 +1,4 @@
+import type { PartialLessonPlan } from "../../../protocol/schema";
 import type {
   AgenticRagLessonPlanResult,
   AilaExecutionContext,
@@ -123,6 +124,58 @@ describe("handleRelevantLessons", () => {
     expect(result).toEqual({ status: "continue" });
     expect(ctx.runtime.fetchRelevantLessons).toHaveBeenCalled();
     expect(ctx.persistedState.ragFetched.status).toBe("none_found");
+  });
+
+  it("skips fetch when lesson is complete", async () => {
+    const minimalQuiz = {
+      version: "v3" as const,
+      questions: [],
+      imageMetadata: [],
+    };
+    const minimalCycle = {
+      title: "Cycle",
+      durationInMinutes: 15,
+      explanation: {
+        spokenExplanation: "Explanation",
+        accompanyingSlideDetails: "Slide details",
+        imagePrompt: "Image prompt",
+        slideText: "Slide text",
+      },
+      checkForUnderstanding: [
+        { question: "Q1?", answers: ["A1"], distractors: ["D1", "D2"] },
+        { question: "Q2?", answers: ["A2"], distractors: ["D3", "D4"] },
+      ],
+      practice: "Practice",
+      feedback: "Feedback",
+    };
+    const completedOverrides: Partial<PartialLessonPlan> = {
+      learningOutcome: "I can explain photosynthesis",
+      learningCycles: ["Introduce photosynthesis"],
+      priorKnowledge: ["Cell biology"],
+      keyLearningPoints: ["Photosynthesis uses light"],
+      misconceptions: [
+        {
+          misconception: "Plants eat soil",
+          description: "Plants make food from light",
+        },
+      ],
+      keywords: [
+        { keyword: "Photosynthesis", definition: "Process of making food" },
+      ],
+      basedOn: null,
+      starterQuiz: minimalQuiz,
+      cycle1: minimalCycle,
+      cycle2: minimalCycle,
+      cycle3: null,
+      exitQuiz: minimalQuiz,
+      additionalMaterials: null,
+    };
+    const ctx = createContext({ document: completedOverrides });
+
+    const result = await handleRelevantLessons(ctx);
+
+    expect(result).toEqual({ status: "continue" });
+    expect(ctx.runtime.fetchRelevantLessons).not.toHaveBeenCalled();
   });
 
   it("does not call onRagFetchedChange when state is unchanged", async () => {

--- a/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.ts
+++ b/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.ts
@@ -1,4 +1,7 @@
-import { CompletedLessonPlanSchema, type RagFetched } from "../../../protocol/schema";
+import {
+  CompletedLessonPlanSchema,
+  type RagFetched,
+} from "../../../protocol/schema";
 import type { AilaExecutionContext, AilaTurnPhaseOutcome } from "../types";
 import { hasSearchIdentityChangedSignificantly } from "./searchIdentity";
 import { terminateWithResponse } from "./termination";
@@ -36,7 +39,9 @@ export async function handleRelevantLessons(
   const { title, subject, keyStage, basedOn } = context.currentTurn.document;
   const ragFetched = context.persistedState.ragFetched;
 
-  if (CompletedLessonPlanSchema.safeParse(context.currentTurn.document).success) {
+  if (
+    CompletedLessonPlanSchema.safeParse(context.currentTurn.document).success
+  ) {
     return { status: "continue" };
   }
 

--- a/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.ts
+++ b/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.ts
@@ -1,4 +1,4 @@
-import type { RagFetched } from "../../../protocol/schema";
+import { CompletedLessonPlanSchema, type RagFetched } from "../../../protocol/schema";
 import type { AilaExecutionContext, AilaTurnPhaseOutcome } from "../types";
 import { hasSearchIdentityChangedSignificantly } from "./searchIdentity";
 import { terminateWithResponse } from "./termination";
@@ -35,6 +35,10 @@ export async function handleRelevantLessons(
 ): Promise<AilaTurnPhaseOutcome> {
   const { title, subject, keyStage, basedOn } = context.currentTurn.document;
   const ragFetched = context.persistedState.ragFetched;
+
+  if (CompletedLessonPlanSchema.safeParse(context.currentTurn.document).success) {
+    return { status: "continue" };
+  }
 
   if (basedOn) {
     // user has chosen a lesson to adapt — record that selection

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,10 +1,11 @@
-codeHash: 7324fbcf21c82cc382ea853323c4a00e06f60dc4ba2f0db7ac029551bf94b377
-generated: 2026-06-02T10:39:01.416Z
+codeHash: 34b200788c63e60f8ea242491f91f8fdd543ef04f9482f05294f1fc6c8698090
+generated: 2026-06-04T07:46:41.431Z
 runsPerScenario: 3
 summary:
   full-lesson:
     plan-groupings:
-      pass: 3
+      flag: 1
+      pass: 2
     additional-materials-tone:
       skip: 3
     cycle-verbosity:
@@ -33,8 +34,7 @@ summary:
       pass: 2
       flag: 1
     additional-materials-tone:
-      skip: 2
-      pass: 1
+      skip: 3
     cycle-verbosity:
       pass: 3
     keyword-casing:
@@ -52,9 +52,11 @@ summary:
     quiz-question-count:
       pass: 3
     americanisms_corrector:
-      corrections_attempted: 0
-      corrections_not_needed: 34
+      corrections_attempted: 3
+      corrections_not_needed: 30
       corrections_failed: 0
-      correction_rate: 0.0%
+      correction_rate: 9.1%
       correction_failure_rate: 0.0%
-      corrections_by_section: {}
+      corrections_by_section:
+        starterQuiz: 2
+        cycle1: 1


### PR DESCRIPTION
## Description

- Blocks showing user rag suggestions if lesson is complete

## Issue(s)

Fixes #

## How to test

1. Go to https://oak-ai-lesson-assistant-website-ksyxqxxtb.vercel.thenational.academy
Complete all lesson sections, ask significant change of title or subject or keystage . No fetched based on subjections in chat



## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
