### PR TITLE
feat(aila): add feedback link beside the beta tag

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/aila-start/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/aila-start/index.tsx
@@ -19,6 +19,7 @@ import styled from "styled-components";
 import useAnalytics from "@/lib/analytics/useAnalytics";
 import { getAilaUrl } from "@/utils/getAilaUrl";
 
+import { AILA_FEEDBACK_FORM_URL, BetaTagWithFeedback } from "../beta-tag";
 import ChatPanelDisclaimer from "../chat-panel-disclaimer";
 import EmptyScreenAccordion from "../empty-screen-accordion";
 
@@ -38,97 +39,112 @@ export function AilaStart() {
       $flexDirection="column"
       $alignItems="center"
       $minHeight={["100%", "100vh", "100vh"]}
+      $pt={["spacing-72"]}
     >
       <OakMaxWidth
-        $mt={["spacing-80"]}
+        $mt={["spacing-48"]}
         $maxWidth="spacing-960"
         $background="bg-decorative3-very-subdued"
         $justifyContent={"space-between"}
       >
-        <OakGrid
-          $height={"100%"}
-          $cg={["spacing-0", "spacing-24", "spacing-48"]}
-          $rg={["spacing-48", "spacing-0", "spacing-0"]}
-          $mh="auto"
-          $mt={["spacing-80"]}
-          $ph={["spacing-12", "spacing-12", "spacing-0"]}
-        >
-          <OakGridArea $alignContent={"center"} $colSpan={[12, 6, 7]}>
-            <OakBox
-              $background="bg-primary"
-              $pa="spacing-32"
-              $borderRadius="border-radius-s"
-              $position={"relative"}
-            >
-              <OakFlex $flexDirection="column">
-                {/* Heading and description */}
-                <OakHeading $mb="spacing-16" $font="heading-5" tag="h2">
-                  Create a lesson with AI
-                </OakHeading>
-                <OakP $mb="spacing-16" $font="body-2">
-                  Aila will guide you step-by-step to create and download a
-                  tailor-made lesson, including:
-                </OakP>
+        <OakFlex $flexDirection="column" $width="100%" $gap="spacing-48">
+          <OakBox $ph={["spacing-12", "spacing-12", "spacing-0"]}>
+            <BetaTagWithFeedback feedbackHref={AILA_FEEDBACK_FORM_URL} />
+          </OakBox>
+          <OakBox $ph={["spacing-12", "spacing-12", "spacing-0"]}>
+            <OakFlex $flexDirection="column" $gap="spacing-8">
+              <OakHeading tag="h1" $font="heading-4">
+                Aila, Oak&apos;s AI lesson assistant
+              </OakHeading>
+              <OakP $font="body-1">
+                Helping teachers create and tailor lessons and resources
+              </OakP>
+            </OakFlex>
+          </OakBox>
+          <OakGrid
+            $cg={["spacing-0", "spacing-24", "spacing-48"]}
+            $rg={["spacing-48", "spacing-0", "spacing-0"]}
+            $mh="auto"
+            $ph={["spacing-12", "spacing-12", "spacing-0"]}
+          >
+            <OakGridArea $alignContent={"center"} $colSpan={[12, 6, 7]}>
+              <OakBox
+                $background="bg-primary"
+                $pa="spacing-32"
+                $borderRadius="border-radius-s"
+                $position={"relative"}
+              >
+                <OakFlex $flexDirection="column">
+                  {/* Heading and description */}
+                  <OakHeading $mb="spacing-16" $font="heading-5" tag="h2">
+                    Create a lesson with AI
+                  </OakHeading>
+                  <OakP $mb="spacing-16" $font="body-2">
+                    Aila will guide you step-by-step to create and download a
+                    tailor-made lesson, including:
+                  </OakP>
 
-                <EmptyScreenAccordion />
-                <OakBox $mt="spacing-48">
-                  <OakPrimaryButton
-                    element={Link}
-                    href={getAilaUrl("lesson")}
-                    iconName="arrow-right"
-                    isTrailingIcon={true}
-                  >
-                    Create a lesson
-                  </OakPrimaryButton>
-                </OakBox>
-              </OakFlex>
-            </OakBox>
-          </OakGridArea>
-          <OakGridArea $colSpan={[12, 6, 5]}>
-            <OakBox
-              $background="bg-primary"
-              $pa="spacing-32"
-              $borderRadius="border-radius-s"
-            >
-              <OakFlex $flexDirection="column">
-                {/* Heading, description, and list */}
-                <OakHeading $mb="spacing-12" $font="heading-5" tag="h2">
-                  Create teaching materials with AI
-                </OakHeading>
-                <OakP $mb="spacing-12" $font="body-2">
-                  Enhance lessons with a range of teaching materials, including:
-                </OakP>
-                <StyledUL>
-                  <OakLI $mv="spacing-12">Glossaries</OakLI>
-                  <OakLI $mv="spacing-12">Comprehension tasks</OakLI>
-                  <OakLI $mt="spacing-12">Quizzes</OakLI>
-                </StyledUL>
-                <OakBox $mt="spacing-24">
-                  <OakPrimaryButton
-                    element={Link}
-                    href={getAilaUrl("teaching-materials")}
-                    data-testid={"create-teaching-materials-button"}
-                    iconName="arrow-right"
-                    isTrailingIcon={true}
-                    onClick={() => {
-                      track.createTeachingMaterialsInitiated({
-                        platform: "aila-beta",
-                        product: "ai lesson assistant",
-                        engagementIntent: "explore",
-                        componentType: "create_additional_materials_button",
-                        eventVersion: "2.0.0",
-                        analyticsUseCase: "Teacher",
-                        isLoggedIn: Boolean(user),
-                      });
-                    }}
-                  >
-                    Create teaching materials
-                  </OakPrimaryButton>
-                </OakBox>
-              </OakFlex>
-            </OakBox>
-          </OakGridArea>
-        </OakGrid>
+                  <EmptyScreenAccordion />
+                  <OakBox $mt="spacing-48">
+                    <OakPrimaryButton
+                      element={Link}
+                      href={getAilaUrl("lesson")}
+                      iconName="arrow-right"
+                      isTrailingIcon={true}
+                    >
+                      Create a lesson
+                    </OakPrimaryButton>
+                  </OakBox>
+                </OakFlex>
+              </OakBox>
+            </OakGridArea>
+            <OakGridArea $colSpan={[12, 6, 5]}>
+              <OakBox
+                $background="bg-primary"
+                $pa="spacing-32"
+                $borderRadius="border-radius-s"
+              >
+                <OakFlex $flexDirection="column">
+                  {/* Heading, description, and list */}
+                  <OakHeading $mb="spacing-12" $font="heading-5" tag="h2">
+                    Create teaching materials with AI
+                  </OakHeading>
+                  <OakP $mb="spacing-12" $font="body-2">
+                    Enhance lessons with a range of teaching materials,
+                    including:
+                  </OakP>
+                  <StyledUL>
+                    <OakLI $mv="spacing-12">Glossaries</OakLI>
+                    <OakLI $mv="spacing-12">Comprehension tasks</OakLI>
+                    <OakLI $mt="spacing-12">Quizzes</OakLI>
+                  </StyledUL>
+                  <OakBox $mt="spacing-24">
+                    <OakPrimaryButton
+                      element={Link}
+                      href={getAilaUrl("teaching-materials")}
+                      data-testid={"create-teaching-materials-button"}
+                      iconName="arrow-right"
+                      isTrailingIcon={true}
+                      onClick={() => {
+                        track.createTeachingMaterialsInitiated({
+                          platform: "aila-beta",
+                          product: "ai lesson assistant",
+                          engagementIntent: "explore",
+                          componentType: "create_additional_materials_button",
+                          eventVersion: "2.0.0",
+                          analyticsUseCase: "Teacher",
+                          isLoggedIn: Boolean(user),
+                        });
+                      }}
+                    >
+                      Create teaching materials
+                    </OakPrimaryButton>
+                  </OakBox>
+                </OakFlex>
+              </OakBox>
+            </OakGridArea>
+          </OakGrid>
+        </OakFlex>
         <OakFlex
           $ph={["spacing-12", "spacing-12", "spacing-0"]}
           $justifyContent={"center"}

--- a/apps/nextjs/src/components/AppComponents/Chat/beta-tag.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/beta-tag.tsx
@@ -26,6 +26,7 @@ export function BetaTagWithFeedback({
         color="text-primary"
         target="_blank"
         rel="noopener noreferrer"
+        style={{ paddingBottom: "0.4rem" }}
       >
         <OakSpan $font="body-3" $color="text-primary">
           Feedback will help us improve Aila

--- a/apps/nextjs/src/components/AppComponents/Chat/beta-tag.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/beta-tag.tsx
@@ -18,7 +18,7 @@ export function BetaTagWithFeedback({
 }>) {
   return (
     <OakFlex $alignItems="center" $gap="spacing-12">
-      <span className="flex items-center justify-center rounded-[12px] bg-teachersPastelBlue px-[8px] py-[6px] text-sm font-semibold leading-5">
+      <span className="flex h-[22px] items-center justify-center rounded-full bg-teachersPastelBlue px-[8px] text-sm font-semibold">
         Beta
       </span>
       <OakLink

--- a/apps/nextjs/src/components/AppComponents/Chat/beta-tag.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/beta-tag.tsx
@@ -18,14 +18,16 @@ export function BetaTagWithFeedback({
 }>) {
   return (
     <OakFlex $alignItems="center" $gap="spacing-12">
-      <BetaTagPage />
+      <span className="flex items-center justify-center rounded-[12px] bg-teachersPastelBlue px-[8px] py-[6px] text-sm font-semibold leading-5">
+        Beta
+      </span>
       <OakLink
         href={feedbackHref}
         color="text-primary"
         target="_blank"
         rel="noopener noreferrer"
       >
-        <OakSpan $font="body-2" $color="text-primary">
+        <OakSpan $font="body-3" $color="text-primary">
           Feedback will help us improve Aila
         </OakSpan>
       </OakLink>

--- a/apps/nextjs/src/components/AppComponents/Chat/beta-tag.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/beta-tag.tsx
@@ -13,9 +13,9 @@ export const AILA_FEEDBACK_FORM_URL =
 
 export function BetaTagWithFeedback({
   feedbackHref,
-}: {
+}: Readonly<{
   feedbackHref: string;
-}) {
+}>) {
   return (
     <OakFlex $alignItems="center" $gap="spacing-12">
       <BetaTagPage />

--- a/apps/nextjs/src/components/AppComponents/Chat/beta-tag.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/beta-tag.tsx
@@ -1,3 +1,5 @@
+import { OakFlex, OakLink, OakSpan } from "@oaknational/oak-components";
+
 export function BetaTagPage() {
   return (
     <span className="flex h-[32px] items-center justify-center rounded-full bg-teachersPastelBlue px-9 py-1 text-sm font-semibold">
@@ -6,10 +8,27 @@ export function BetaTagPage() {
   );
 }
 
-export function BetaTagHeader() {
+export const AILA_FEEDBACK_FORM_URL =
+  "https://docs.google.com/forms/d/e/1FAIpQLSf2AWtTtr4JISeMV4BY5LCMYhDFPz0RPNdXzmy_vjk4BmM69Q/viewform";
+
+export function BetaTagWithFeedback({
+  feedbackHref,
+}: {
+  feedbackHref: string;
+}) {
   return (
-    <span className="flex items-center justify-center rounded-full bg-teachersPastelBlue px-8 py-2 text-sm font-semibold text-black">
-      Beta
-    </span>
+    <OakFlex $alignItems="center" $gap="spacing-12">
+      <BetaTagPage />
+      <OakLink
+        href={feedbackHref}
+        color="text-primary"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        <OakSpan $font="body-2" $color="text-primary">
+          Feedback will help us improve Aila
+        </OakSpan>
+      </OakLink>
+    </OakFlex>
   );
 }

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-start.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-start.tsx
@@ -20,6 +20,7 @@ import { trpc } from "@/utils/trpc";
 
 import { useDialog } from "../DialogContext";
 import { createStartingPromptFromSearchParams } from "./aila-start/search-params-utils";
+import { AILA_FEEDBACK_FORM_URL, BetaTagWithFeedback } from "./beta-tag";
 import ChatPanelDisclaimer from "./chat-panel-disclaimer";
 import { ChatStartForm } from "./chat-start-form";
 import EmptyScreenAccordion from "./empty-screen-accordion";
@@ -147,19 +148,22 @@ export function ChatStart({
           <div className="h-full w-full overflow-y-scroll p-18 px-10 sm:w-[66%]">
             <div className="mx-auto flex h-full max-w-[580px] flex-col justify-between">
               <div className="flex h-full flex-col justify-center gap-18">
-                <div>
-                  <h1
-                    data-testid="chat-h1"
-                    className="mb-11 text-3xl font-semibold capitalize"
-                  >
-                    Hello{userFirstName ? ", " + userFirstName : ""}
-                  </h1>
-                  <p className="mb-7 text-base leading-normal">
-                    I&apos;m Aila, Oak&apos;s AI lesson assistant.
-                    <br />
-                    Tell me what you want to teach and I&apos;ll help you create
-                    your lesson.
-                  </p>
+                <div className="flex flex-col gap-22">
+                  <BetaTagWithFeedback feedbackHref={AILA_FEEDBACK_FORM_URL} />
+                  <div>
+                    <h1
+                      data-testid="chat-h1"
+                      className="mb-11 text-3xl font-semibold capitalize"
+                    >
+                      Hello{userFirstName ? ", " + userFirstName : ""}
+                    </h1>
+                    <p className="mb-7 text-base leading-normal">
+                      I&apos;m Aila, Oak&apos;s AI lesson assistant.
+                      <br />
+                      Tell me what you want to teach and I&apos;ll help you
+                      create your lesson.
+                    </p>
+                  </div>
                 </div>
                 <div>
                   <p className="mb-13 text-xl font-bold">

--- a/apps/nextjs/src/components/AppComponents/Chat/header.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/header.tsx
@@ -16,7 +16,6 @@ import OakIconLogo from "@/components/OakIconLogo";
 import { useClerkDemoMetadata } from "@/hooks/useClerkDemoMetadata";
 
 import { useDialog } from "../DialogContext";
-import { BetaTagHeader } from "./beta-tag";
 import { ChatHistory } from "./chat-history";
 import { DemoBanner } from "./demo-banner";
 import { OpenSideBarButton } from "./open-side-bar-button";
@@ -67,9 +66,16 @@ export function Header({ page }: { page?: "teachingMaterials" | "aila" }) {
               <OakIconLogo />
             </OakLink>
             <OakSpan $font="heading-6">Aila</OakSpan>
-          </OakFlex>
-          <OakFlex>
-            <BetaTagHeader />
+            <OakFlex
+              $display={["none", "flex"]}
+              $alignItems="center"
+              $gap="spacing-12"
+            >
+              <span className="h-[28px] w-[1px] bg-[#cacaca]" />
+              <OakSpan $font="body-2" $color="text-primary">
+                Oak&apos;s AI lesson assistant
+              </OakSpan>
+            </OakFlex>
           </OakFlex>
         </OakFlex>
 


### PR DESCRIPTION
## Description

Adds a feedback link next to the Beta label on the Aila starter and lesson pages. The top nav is also updated to match the new design.

- `beta-tag.tsx`: added a `BetaTagWithFeedback` component (the Beta pill plus the feedback link) and a shared `AILA_FEEDBACK_FORM_URL` constant. The link opens the feedback form in a new tab.
- `aila-start/index.tsx` (starter page): moved the Beta tag into the page body with the feedback link, and added the `Aila, Oak's AI lesson assistant` heading and subheading.
- `chat-start.tsx` (lesson page): added the Beta tag and feedback link above the "Hello" greeting.
- `header.tsx`: removed the Beta tag from the nav and added the `Oak's AI lesson assistant` tagline with a divider beside the logo.

The link points to the existing Oak feedback Google form.

## Issue(s)

Fixes [AI-2218](https://app.notion.com/p/oaknationalacademy/Beta-feedback-link-36626cc4e1b18017997ff9ca401deac0?v=c76315f391b74cf2bd6722b8bdcbc3e6)

## How to test

1. Go to https://oak-ai-lesson-assistant-website-18tf9xvrz.vercel.thenational.academy/aila
2. The nav should read `Aila | Oak's AI lesson assistant`, and a `Beta` pill with "Feedback will help us improve Aila" should sit above the `Aila, Oak's AI lesson assistant` heading.
3. Click the feedback link. The Oak feedback form should open in a new tab.
4. Go to https://oak-ai-lesson-assistant-website-dfocxxgk3.vercel.thenational.academy/aila/lesson. The same `Beta` pill and feedback link should sit above the "Hello, {name}" greeting.
5. Narrow the window to mobile width. The tagline drops out of the nav; the Beta pill and feedback link stay.

## Screenshots

How it used to look (delete if n/a):
<img width="1409" height="802" alt="image" src="https://github.com/user-attachments/assets/1fc3a129-fe8c-4b70-89a9-404a1794ad12" />
<img width="1675" height="1358" alt="image" src="https://github.com/user-attachments/assets/0fb411e8-62b7-4800-817d-3deeb37b5d1c" />

How it should now look:

<img width="1692" height="965" alt="image" src="https://github.com/user-attachments/assets/075b8e87-9ace-4757-8628-830301eceec5" />
<img width="1690" height="1321" alt="image" src="https://github.com/user-attachments/assets/ff4246d9-8e5d-46ec-99d0-f4dc4223cf1b" />

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility (new heading is an `h1`; link has descriptive text)
- [ ] ~~Does this PR update a package with a breaking change~~ (no package changes)
