### PR TITLE
feat: accordion on aila start - AI-2216

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -57,7 +57,7 @@
     "@oakai/prettier-config": "*",
     "@oakai/rag": "*",
     "@oakai/teaching-materials": "*",
-    "@oaknational/oak-components": "^1.174.1",
+    "@oaknational/oak-components": "^2.36.0",
     "@oaknational/oak-consent-client": "^2.1.0",
     "@oaknational/oak-curriculum-schema": "1.61.0",
     "@portabletext/react": "^3.1.0",

--- a/apps/nextjs/src/components/AppComponents/Chat/aila-start/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/aila-start/index.tsx
@@ -135,7 +135,9 @@ export function AilaStart() {
                   <AilaFaqAccordion
                     id="create-lesson-whats-included"
                     header={
-                      <OakSpan $font="body-2-bold">What's included?</OakSpan>
+                      <OakSpan $textAlign="left" $font="body-2-bold">
+                        What's included?
+                      </OakSpan>
                     }
                     $bt="border-solid-s"
                     $bb="border-solid-s"
@@ -171,7 +173,7 @@ export function AilaStart() {
                   <AilaFaqAccordion
                     id="create-lesson-aila-different"
                     header={
-                      <OakSpan $font="body-2-bold">
+                      <OakSpan $textAlign="left" $font="body-2-bold">
                         How's Aila different from other AI tools?
                       </OakSpan>
                     }
@@ -207,7 +209,9 @@ export function AilaStart() {
                   <AilaFaqAccordion
                     id="create-lesson-why-trust"
                     header={
-                      <OakSpan $font="body-2-bold">Why trust Aila?</OakSpan>
+                      <OakSpan $textAlign="left" $font="body-2-bold">
+                        Why trust Aila?
+                      </OakSpan>
                     }
                   >
                     <OakP $font="body-2">

--- a/apps/nextjs/src/components/AppComponents/Chat/aila-start/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/aila-start/index.tsx
@@ -2,17 +2,21 @@
 
 import { useUser } from "@clerk/nextjs";
 import {
+  OakAccordion,
   OakBox,
   OakFlex,
   OakGrid,
   OakGridArea,
   OakHeading,
   OakLI,
+  OakLink,
   OakMaxWidth,
   OakP,
   OakPrimaryButton,
+  OakSpan,
   OakUL,
 } from "@oaknational/oak-components";
+import type { OakAccordionProps } from "@oaknational/oak-components";
 import Link from "next/link";
 import styled from "styled-components";
 
@@ -20,13 +24,47 @@ import useAnalytics from "@/lib/analytics/useAnalytics";
 import { getAilaUrl } from "@/utils/getAilaUrl";
 
 import ChatPanelDisclaimer from "../chat-panel-disclaimer";
-import EmptyScreenAccordion from "../empty-screen-accordion";
 
 const StyledUL = styled(OakUL)`
   list-style-type: disc;
 
   padding-left: 20px;
 `;
+
+type AilaFaqAccordionProps = Pick<
+  OakAccordionProps,
+  "id" | "header" | "$bt" | "$bb"
+> & {
+  readonly children: React.ReactNode;
+};
+
+function AilaFaqAccordion({
+  id,
+  header,
+  $bt,
+  $bb,
+  children,
+}: AilaFaqAccordionProps) {
+  return (
+    <OakAccordion
+      id={id}
+      header={header}
+      $color="text-link-active"
+      $ba="border-solid-none"
+      $bt={$bt}
+      $bb={$bb}
+      $borderColor="border-neutral"
+      openBackground="bg-primary"
+      chevronPosition="right"
+      $pa="spacing-0"
+      $pv="spacing-12"
+    >
+      <OakFlex $mt="spacing-16" $flexDirection="column" $gap="spacing-12">
+        {children}
+      </OakFlex>
+    </OakAccordion>
+  );
+}
 
 export function AilaStart() {
   const { track } = useAnalytics();
@@ -47,12 +85,28 @@ export function AilaStart() {
       >
         <OakGrid
           $height={"100%"}
-          $cg={["spacing-0", "spacing-24", "spacing-48"]}
+          $cg={["spacing-0", "spacing-20", "spacing-20"]}
           $rg={["spacing-48", "spacing-0", "spacing-0"]}
           $mh="auto"
-          $mt={["spacing-80"]}
           $ph={["spacing-12", "spacing-12", "spacing-0"]}
         >
+          <OakGridArea $alignContent={"center"} $colSpan={[12, 12, 12]}>
+            <OakFlex
+              $flexDirection="column"
+              $mv={["spacing-48", "spacing-80", "spacing-48"]}
+              $ph={["spacing-12", "spacing-12", "spacing-0"]}
+            >
+              <OakFlex $alignItems="center" $gap="spacing-12"></OakFlex>
+              <OakFlex $flexDirection="column" $gap="spacing-8">
+                <OakHeading tag="h1" $font="heading-4">
+                  Aila, Oak's AI lesson assistant
+                </OakHeading>
+                <OakP $font="body-1">
+                  Helping teachers create and tailor lessons and resources
+                </OakP>
+              </OakFlex>
+            </OakFlex>
+          </OakGridArea>
           <OakGridArea $alignContent={"center"} $colSpan={[12, 6, 7]}>
             <OakBox
               $background="bg-primary"
@@ -60,26 +114,137 @@ export function AilaStart() {
               $borderRadius="border-radius-s"
               $position={"relative"}
             >
-              <OakFlex $flexDirection="column">
-                {/* Heading and description */}
-                <OakHeading $mb="spacing-16" $font="heading-5" tag="h2">
-                  Create a lesson with AI
+              <OakFlex $flexDirection="column" $gap="spacing-24">
+                <OakHeading $font="heading-5" tag="h2">
+                  Create a lesson
                 </OakHeading>
-                <OakP $mb="spacing-16" $font="body-2">
-                  Aila will guide you step-by-step to create and download a
-                  tailor-made lesson, including:
+                <OakP $font="body-2">
+                  Work <OakSpan $font="body-2-bold">step by step</OakSpan> with
+                  Aila to create, tailor and download formatted lesson resources
+                  you can <OakSpan $font="body-2-bold">build on</OakSpan>.
                 </OakP>
-
-                <EmptyScreenAccordion />
-                <OakBox $mt="spacing-48">
-                  <OakPrimaryButton
-                    element={Link}
-                    href={getAilaUrl("lesson")}
-                    iconName="arrow-right"
-                    isTrailingIcon={true}
+                <OakPrimaryButton
+                  element={Link}
+                  href={getAilaUrl("lesson")}
+                  iconName="arrow-right"
+                  isTrailingIcon={true}
+                >
+                  Create a lesson
+                </OakPrimaryButton>
+                <OakBox>
+                  <AilaFaqAccordion
+                    id="create-lesson-whats-included"
+                    header={
+                      <OakSpan $font="body-2-bold">What's included?</OakSpan>
+                    }
+                    $bt="border-solid-s"
+                    $bb="border-solid-s"
                   >
-                    Create a lesson
-                  </OakPrimaryButton>
+                    <OakP $font="body-2">
+                      Once you've co-created your lesson with Aila, you can
+                      download and tailor a lesson plan, slide deck, worksheet,
+                      prior knowledge starter quiz and assessment exit quiz.
+                    </OakP>
+                    <OakP $font="body-2">
+                      Everything is grounded in Oak's{" "}
+                      <OakLink
+                        href="https://www.thenational.academy/teachers/curriculum"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        curriculum expertise
+                      </OakLink>{" "}
+                      and national curriculum-aligned resources across key
+                      stages 1–4.
+                    </OakP>
+                    <OakP $font="body-2">
+                      Your slide deck is easy to make your own. Add your images,
+                      examples and classroom context, or apply your school's
+                      template once downloaded.
+                    </OakP>
+                    <OakP $font="body-2">
+                      Aila currently helps you create individual lessons, not
+                      full sequences. It also doesn't generate images or web
+                      links; we'd rather you choose your own.
+                    </OakP>
+                  </AilaFaqAccordion>
+                  <AilaFaqAccordion
+                    id="create-lesson-aila-different"
+                    header={
+                      <OakSpan $font="body-2-bold">
+                        How's Aila different from other AI tools?
+                      </OakSpan>
+                    }
+                    $bb="border-solid-s"
+                  >
+                    <OakP $font="body-2">
+                      With a general AI tool, you start from a blank chat box
+                      and figure it out yourself. Aila gives you a structured,
+                      teacher-led process instead, grounded in{" "}
+                      <OakLink
+                        href="https://www.thenational.academy/teachers/curriculum"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        our curriculum expertise
+                      </OakLink>{" "}
+                      and national curriculum-aligned{" "}
+                      <OakLink
+                        href="https://www.thenational.academy/"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        resources across key stages 1–4
+                      </OakLink>
+                      , all ready to tailor to your class and context.
+                    </OakP>
+                    <OakP $font="body-2">
+                      Aila draws on Oak's lessons and resources, so you're
+                      building on a strong foundation rather than starting from
+                      scratch.
+                    </OakP>
+                  </AilaFaqAccordion>
+                  <AilaFaqAccordion
+                    id="create-lesson-why-trust"
+                    header={
+                      <OakSpan $font="body-2-bold">Why trust Aila?</OakSpan>
+                    }
+                  >
+                    <OakP $font="body-2">
+                      Thousands of teachers are using Aila to save up to three
+                      hours a week on lesson planning.
+                    </OakP>
+                    <OakP $font="body-2">
+                      Aila is built specifically for the classroom. It was made
+                      with teachers and curriculum specialists and is grounded
+                      in Oak's curriculum-aligned resources.
+                    </OakP>
+                    <OakP $font="body-2">
+                      You stay in control throughout, working step by step to
+                      create your lesson. Content is moderated to be{" "}
+                      <OakLink
+                        href="https://www.thenational.academy/blog/building-ai-that-s-safe-for-the-classroom-what-we-have-learned-with-aila"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        safe and appropriate
+                      </OakLink>{" "}
+                      for your pupils, and Aila{" "}
+                      <OakLink
+                        href="https://www.thenational.academy/blog/choosing-ai-for-your-school-how-our-ai-tools-exceed-the-dfe-latest-safety-standards"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        meets and exceeds the DfE's AI safety standards
+                      </OakLink>
+                      .
+                    </OakP>
+                    <OakP $font="body-2">
+                      AI can make mistakes, so like with any teaching resource,
+                      it's worth reviewing materials before use. You know your
+                      pupils best.
+                    </OakP>
+                  </AilaFaqAccordion>
                 </OakBox>
               </OakFlex>
             </OakBox>
@@ -133,8 +298,8 @@ export function AilaStart() {
           $ph={["spacing-12", "spacing-12", "spacing-0"]}
           $justifyContent={"center"}
         >
-          <OakBox $mb={"spacing-24"} $mt="spacing-48">
-            <ChatPanelDisclaimer size="sm" />
+          <OakBox $mb={"spacing-16"} $mt="spacing-48">
+            <ChatPanelDisclaimer />
           </OakBox>
         </OakFlex>
       </OakMaxWidth>

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-panel-disclaimer.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-panel-disclaimer.tsx
@@ -1,20 +1,26 @@
-const ChatPanelDisclaimer = ({
-  size,
-}: {
-  readonly size: "sm" | "md" | "lg";
-}) => {
+import { OakLink, OakP } from "@oaknational/oak-components";
+
+const ChatPanelDisclaimer = () => {
   return (
-    <p className={` text-${size}`}>
-      Aila can make mistakes. Check your lesson before use.{" "}
-      <a
-        href="https://www.thenational.academy/legal/terms-and-conditions"
-        className="text-blue underline"
+    <OakP $font="body-3" $textAlign="center">
+      AI can make mistakes. Review content before use. Read our{" "}
+      <OakLink
+        href="https://www.thenational.academy/legal/privacy-policy"
         target="_blank"
+        rel="noopener noreferrer"
       >
-        Oak terms and conditions
-      </a>
-      {"."}
-    </p>
+        privacy policy
+      </OakLink>{" "}
+      and{" "}
+      <OakLink
+        href="https://www.thenational.academy/legal/terms-and-conditions"
+        target="_blank"
+        rel="noopener noreferrer"
+      >
+        terms and conditions
+      </OakLink>
+      .
+    </OakP>
   );
 };
 

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-start.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-start.tsx
@@ -196,7 +196,7 @@ export function ChatStart({
                   </div>
                 </div>
               </div>
-              <ChatPanelDisclaimer size="sm" />
+              <ChatPanelDisclaimer />
             </div>
           </div>
           <div className="hidden h-full w-[34%] items-center overflow-y-scroll bg-white px-25 pb-9 sm:flex">

--- a/apps/nextjs/src/components/AppComponents/Chat/prompt-form.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/prompt-form.tsx
@@ -112,7 +112,7 @@ export function PromptForm({
         $mt={`${formError ? "spacing-0" : "spacing-24"}`}
         $display={["none", "block"]}
       >
-        <ChatPanelDisclaimer size="sm" />
+        <ChatPanelDisclaimer />
       </OakBox>
     </form>
   );

--- a/apps/nextjs/src/components/AppComponents/Moderation/LockingModerationModalContent.tsx
+++ b/apps/nextjs/src/components/AppComponents/Moderation/LockingModerationModalContent.tsx
@@ -74,7 +74,7 @@ export function LockingModerationModalContent({
             $height={"spacing-120"}
             charLimit={500}
             initialValue={comment}
-            onTextAreaChange={setComment}
+            onChange={(e) => setComment(e.target.value)}
             placeholder="Your feedback"
           />
         )}

--- a/apps/nextjs/src/components/AppComponents/ScaleSpan.tsx
+++ b/apps/nextjs/src/components/AppComponents/ScaleSpan.tsx
@@ -2,5 +2,5 @@ import { OakSpan } from "@oaknational/oak-components";
 import styled from "styled-components";
 
 export const ScaleSpan = styled(OakSpan)<{ $scale: number }>`
-  transform: scale(${(props) => props.$scale});
+  transform: scale(${(props: { $scale: number }) => props.$scale});
 `;

--- a/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/SectionContent/QuizSection/index.tsx
@@ -44,7 +44,7 @@ export const QuizSection = ({ quizSection, quizType }: QuizSectionProps) => {
         $borderRadius="border-radius-s"
       >
         <OakFlex $gap="spacing-4" $alignItems="flex-start">
-          <OakIcon $colorFilter="black" iconName="info" alt="" />
+          <OakIcon $colorFilter="icon-primary" iconName="info" alt="" />
           <OakP $font="body-3">
             We weren&apos;t able to generate {quizLabel} for this lesson —
             Oak&apos;s question bank didn&apos;t have {reason}. You can ask me

--- a/apps/nextjs/src/components/AppComponents/TeachingMaterials/StepLayouts/StepFour.tsx
+++ b/apps/nextjs/src/components/AppComponents/TeachingMaterials/StepLayouts/StepFour.tsx
@@ -348,7 +348,7 @@ const StepFour = ({ handleRefineMaterial }: StepFourProps) => {
                         <OakIcon
                           iconName="download"
                           iconWidth="spacing-32"
-                          $colorFilter={"white"}
+                          $colorFilter={"icon-inverted"}
                           data-testid="download-icon-button"
                         />
                       )}

--- a/apps/nextjs/src/components/Header.tsx
+++ b/apps/nextjs/src/components/Header.tsx
@@ -84,7 +84,7 @@ const Header = ({ menuOpen, setMenuOpen, page }: Readonly<HeaderProps>) => {
 
           <div className="h-22 py-8">
             <HamburgerButton onClick={() => setMenuOpen(!menuOpen)}>
-              <OakIcon $colorFilter={"black"} iconName="hamburger" />
+              <OakIcon $colorFilter={"icon-primary"} iconName="hamburger" />
             </HamburgerButton>
           </div>
         </OakFlex>

--- a/apps/nextjs/src/components/OakBoxCustomMaxWidth.tsx
+++ b/apps/nextjs/src/components/OakBoxCustomMaxWidth.tsx
@@ -2,11 +2,11 @@ import { OakBox, OakFlex } from "@oaknational/oak-components";
 import styled from "styled-components";
 
 export const OakBoxCustomMaxWidth = styled(OakBox)<{ customMaxWidth: number }>`
-  max-width: ${(props) => props.customMaxWidth}px;
+  max-width: ${(props: { customMaxWidth: number }) => props.customMaxWidth}px;
 `;
 
 export const OakFlexCustomMaxWidth = styled(OakFlex)<{
   customMaxWidth: number;
 }>`
-  max-width: ${(props) => props.customMaxWidth}px;
+  max-width: ${(props: { customMaxWidth: number }) => props.customMaxWidth}px;
 `;

--- a/apps/nextjs/src/components/OakBoxWithCustomWidth.tsx
+++ b/apps/nextjs/src/components/OakBoxWithCustomWidth.tsx
@@ -2,7 +2,7 @@ import { OakBox } from "@oaknational/oak-components";
 import styled from "styled-components";
 
 const OakBoxWithCustomWidth = styled(OakBox)<{ width: number }>`
-  width: ${({ width }) => width}px;
+  width: ${({ width }: { width: number }) => width}px;
 `;
 
 export default OakBoxWithCustomWidth;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -146,8 +146,8 @@ importers:
         specifier: '*'
         version: link:../../packages/teaching-materials
       '@oaknational/oak-components':
-        specifier: ^1.174.1
-        version: 1.174.1(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11)
+        specifier: ^2.36.0
+        version: 2.36.0(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11)
       '@oaknational/oak-consent-client':
         specifier: ^2.1.0
         version: 2.1.0(react-dom@19.2.1)(react@19.2.1)(zod@3.25.76)
@@ -6387,8 +6387,9 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.15.0
 
-  /@oaknational/oak-components@1.174.1(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11):
-    resolution: {integrity: sha512-Y3bxugFKGiORcdaxVfUGL0pUEyizecnd/S3yj3pjClVs9XXPGFB1UzCnOmgvMqBr7sXTMPzetLUexTO/V0smgA==}
+  /@oaknational/oak-components@2.36.0(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11):
+    resolution: {integrity: sha512-DnGXeTPsSOMfLWU7rhMekQD4NDUEFRRXYc446rHwY4jb/keWt38KwSrJJcM3hWKXsBKr2DAGcR0jqoeNGPqVwg==}
+    engines: {node: '24', pnpm: '>=11'}
     peerDependencies:
       next: '>=14.2.12'
       next-cloudinary: '>=6.16.0'


### PR DESCRIPTION
## Description

  Aila start page redesign  **(excluding beta change)**  
  
  https://www.figma.com/design/I8Dulyd7bg2f0tEfbmSEpL/Aila-updates-2026?node-id=467-5746&m=dev
  
  - Redesigned the /aila start page for Aila lesson plan card

  Fixes from oak-components update

  - ChatPanelDisclaimer: removed stale size prop no longer accepted by the component.
  - OakMultilineText: migrated from removed onTextAreaChange prop to standard onChange={(e) => setComment(e.target.value)}.
  - OakIcon $colorFilter: replaced raw CSS strings ("black", "white") with semantic design tokens ("icon-primary", "icon-inverted") to match the updated ColorFilterToken type.

## Issue(s)

Fixes #

## How to test

1. Go to https://oak-ai-lesson-assistant-website-42p65bnuk.vercel.thenational.academy
  - Page loads and layout renders correctly at mobile, tablet, and desktop breakpoints
  - "Create a lesson" primary button navigates to the lesson flow
  - FAQ accordions expand and collapse 
  
  Chat disclaimer (ChatPanelDisclaimer)
  - Disclaimer text renders in the prompt form and chat-start view — no layout regression from removing the size prop

  Moderation modal (LockingModerationModalContent)
  - Open the locking moderation modal, click "provide feedback", type into the textarea — confirm the character count updates and the value is captured correctly on submit

  Quiz section (QuizSection)
  - View a lesson with an empty starter or exit quiz (quiz with a reportId but no questions) — confirm the info icon renders visibly in the correct dark colour
  
  Download icon (StepFour)
  - On the teaching materials step 4 download area, confirm the download icon renders white/inverted against its dark background button
  
  Header hamburger menu (Header)
  - At mobile breakpoint, confirm the hamburger icon renders in the correct dark colour and the menu opens on click


## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
