### PR TITLE
fix(aila): point beta feedback link to hubspot form

### DIFF
--- a/apps/nextjs/src/app/faqs/index.tsx
+++ b/apps/nextjs/src/app/faqs/index.tsx
@@ -13,6 +13,7 @@ import {
   OakUL,
 } from "@oaknational/oak-components";
 
+import { AILA_FEEDBACK_FORM_URL } from "@/components/AppComponents/Chat/beta-tag";
 import GetInTouchBox from "@/components/AppComponents/GetInTouchBox";
 import Layout from "@/components/Layout";
 import { OakBoxCustomMaxWidth } from "@/components/OakBoxCustomMaxWidth";
@@ -165,7 +166,7 @@ export const FAQPageContent = () => {
               developing Aila. This phase helps identify issues by allowing
               teachers to use the Aila in real-life conditions. Aila is not
               perfect, and will make some mistakes!{" "}
-              <OakLink href="https://docs.google.com/forms/d/e/1FAIpQLSf2AWtTtr4JISeMV4BY5LCMYhDFPz0RPNdXzmy_vjk4BmM69Q/viewform">
+              <OakLink href={AILA_FEEDBACK_FORM_URL}>
                 Your feedback is essential
               </OakLink>{" "}
               to refine and improve Aila.
@@ -409,7 +410,7 @@ export const FAQPageContent = () => {
             <OakP $mb="spacing-16">
               Yes, please do! We love to hear how users are finding our
               resources and how we can improve them. Submit your{" "}
-              <OakLink href="https://docs.google.com/forms/d/e/1FAIpQLSf2AWtTtr4JISeMV4BY5LCMYhDFPz0RPNdXzmy_vjk4BmM69Q/viewform">
+              <OakLink href={AILA_FEEDBACK_FORM_URL}>
                 feedback or suggestions{" "}
               </OakLink>
               .
@@ -598,7 +599,7 @@ export const FAQPageContent = () => {
             <OakP $mb="spacing-16">
               Of course, we would love to hear your thoughts and suggestions for
               other features that would support your teaching. Please{" "}
-              <OakLink href="https://docs.google.com/forms/d/e/1FAIpQLSf2AWtTtr4JISeMV4BY5LCMYhDFPz0RPNdXzmy_vjk4BmM69Q/viewform">
+              <OakLink href={AILA_FEEDBACK_FORM_URL}>
                 give us your feedback!
               </OakLink>
             </OakP>

--- a/apps/nextjs/src/components/AppComponents/Chat/beta-tag.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/beta-tag.tsx
@@ -7,7 +7,7 @@ import {
 } from "@oaknational/oak-components";
 
 export const AILA_FEEDBACK_FORM_URL =
-  "https://docs.google.com/forms/d/e/1FAIpQLSf2AWtTtr4JISeMV4BY5LCMYhDFPz0RPNdXzmy_vjk4BmM69Q/viewform";
+  "https://survey.hsforms.com/184ua72b5RtOD9SDPq4BKKQbvumd";
 
 export function BetaTagWithFeedback({
   feedbackHref,

--- a/apps/nextjs/src/components/AppComponents/Chat/beta-tag.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/beta-tag.tsx
@@ -7,6 +7,7 @@ import {
 } from "@oaknational/oak-components";
 
 export const AILA_FEEDBACK_FORM_URL =
+  process.env.NEXT_PUBLIC_AILA_FEEDBACK_FORM_URL ??
   "https://survey.hsforms.com/184ua72b5RtOD9SDPq4BKKQbvumd";
 
 export function BetaTagWithFeedback({


### PR DESCRIPTION
## Description

Moves the Aila feedback link to the live HubSpot survey, and makes the URL configurable instead of hard-coded.

- `beta-tag.tsx`: the shared `AILA_FEEDBACK_FORM_URL` constant now reads from a `NEXT_PUBLIC_AILA_FEEDBACK_FORM_URL` env var, falling back to the HubSpot survey URL if the var is unset. The link can then be changed in Doppler (plus a redeploy) rather than via a code change.
- `faqs/index.tsx`: pointed the three FAQ feedback links at the same `AILA_FEEDBACK_FORM_URL` constant, replacing the old Google form they still used.

The original feedback link (added in #1069, now part of this base branch) always pointed at the Google form as a stopgap, with the plan to switch to HubSpot once Kath's form was set up. That form is now published and tested.

## Issue(s)

Fixes [AI-2218](https://app.notion.com/p/oaknationalacademy/Beta-feedback-link-36626cc4e1b18017997ff9ca401deac0?source=copy_link)

## How to test

1. Check out this branch and run the app.
2. Go to `/aila` and `/aila/lesson`.
3. The Beta pill and "Your feedback will help us improve Aila" link sit above the heading / greeting as before.
4. Click the feedback link. The **HubSpot** survey should open in a new tab (not the Google form).
5. Go to `/faqs`. Three feedback links there now point at the same HubSpot survey: "Your feedback is essential" (in the beta-phase intro), "feedback or suggestions" (under "Can I provide feedback or suggest improvements for Aila?"), and "give us your feedback!" (under "Can users suggest features for future updates?"). Click each and confirm it opens the HubSpot survey, not the Google form.

## Checklist

- [x] Manually tested across browsers / devices
- [x] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
