### PR TITLE
feat: add maths quiz rag feature flag 

### DIFF
--- a/apps/nextjs/src/app/api/chat/chatHandler.ts
+++ b/apps/nextjs/src/app/api/chat/chatHandler.ts
@@ -19,6 +19,7 @@ import { SentryTracingService } from "@oakai/aila/src/features/tracing";
 import type { PartialLessonPlan } from "@oakai/aila/src/protocol/schema";
 import { migrateChatData } from "@oakai/aila/src/protocol/schemas/versioning/migrateChatData";
 import { getAgenticAilaEnabled } from "@oakai/api/src/utils/getAgenticAilaEnabled";
+import { serverSideFeatureFlag } from "@oakai/api/src/utils/serverSideFeatureFlag";
 import { startSpan } from "@oakai/core/src/tracing";
 import type { TracingSpan } from "@oakai/core/src/tracing";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
@@ -85,6 +86,7 @@ async function setupChatHandler(req: NextRequest) {
       } = json;
 
       const useAgenticAila = await getAgenticAilaEnabled();
+      const useMathsQuizRag = await serverSideFeatureFlag("quiz-rag");
 
       const options: AilaOptions = {
         useRag: chatOptions.useRag ?? true,
@@ -94,6 +96,7 @@ async function setupChatHandler(req: NextRequest) {
         usePersistence: true,
         useModeration: true,
         useAgenticAila,
+        useMathsQuizRag: useMathsQuizRag,
       };
 
       const llmService = getFixtureLLMService(req.headers, chatId);

--- a/apps/nextjs/src/app/api/chat/route.test.ts
+++ b/apps/nextjs/src/app/api/chat/route.test.ts
@@ -15,6 +15,10 @@ jest.mock("./user", () => ({
   fetchAndCheckUser: jest.fn().mockResolvedValue("test-user-id"),
 }));
 
+jest.mock("@oakai/api/src/utils/serverSideFeatureFlag", () => ({
+  serverSideFeatureFlag: jest.fn(),
+}));
+
 jest.mock("@oakai/api/src/utils/getAgenticAilaEnabled", () => ({
   getAgenticAilaEnabled: jest.fn().mockResolvedValue(false),
 }));

--- a/packages/aila/src/core/Aila.ts
+++ b/packages/aila/src/core/Aila.ts
@@ -170,6 +170,7 @@ export class Aila implements AilaServices {
       useThreatDetection: options?.useThreatDetection ?? true,
       useErrorReporting: options?.useErrorReporting ?? true,
       useAgenticAila: options?.useAgenticAila ?? false,
+      useMathsQuizRag: options?.useMathsQuizRag ?? false,
       model: options?.model ?? DEFAULT_MODEL,
       mode: options?.mode ?? "interactive",
     };

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -1,4 +1,3 @@
-import { serverSideFeatureFlag } from "@oakai/api/src/utils/serverSideFeatureFlag";
 import { createOpenAIClient } from "@oakai/core/src/llm/openai";
 import type {
   ThreatDetectionMessage,

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -1,3 +1,4 @@
+import { serverSideFeatureFlag } from "@oakai/api/src/utils/serverSideFeatureFlag";
 import { createOpenAIClient } from "@oakai/core/src/llm/openai";
 import type {
   ThreatDetectionMessage,
@@ -360,7 +361,7 @@ export class AilaStreamHandler {
       },
       runtime: {
         config: {
-          mathsQuizEnabled: true,
+          mathsQuizEnabled: this._chat.aila.options.useMathsQuizRag ?? false,
         },
         plannerAgent: createOpenAIPlannerAgent(openai),
         sectionAgents: createSectionAgentRegistry({

--- a/packages/aila/src/core/types.ts
+++ b/packages/aila/src/core/types.ts
@@ -48,6 +48,7 @@ export type AilaOptions = AilaPublicChatOptions & {
   useModeration?: boolean;
   useAnalytics?: boolean;
   useThreatDetection?: boolean;
+  useMathsQuizRag?: boolean;
   useAgenticAila?: boolean;
   model?: string;
   mode?: AilaGenerateDocumentMode;

--- a/packages/core/src/rag/index.ts
+++ b/packages/core/src/rag/index.ts
@@ -326,7 +326,6 @@ Thank you and happy classifying!`;
 
   normaliseLessonPlan(plan: LessonPlan) {
     return plan;
-    
   }
 
   async fetchLessonPlans({
@@ -655,7 +654,6 @@ Thank you and happy classifying!`;
 
     // If none of that works, fall back to categorising the subject based on free text
     if (!foundSubject) {
-      
       const categorisation = await this.categoriseKeyStageAndSubject(
         subject,
         this._chatMeta,


### PR DESCRIPTION
## Description

- Add a feature flag for quiz rag off unless you add your email to `quiz-rag` posthog

## Issue(s)

Fixes #

## How to test

1. Go to <!-- vercel-preview -->https://oak-ai-lesson-assistant-website-35c0dh4bm.vercel.thenational.academy<!-- /vercel-preview -->

Go to staging posthog feature flag and add/remove email to toggle flag


## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
