### PR TITLE
fix: prettier formatting in rag/index.ts

### DIFF
--- a/packages/core/src/rag/index.ts
+++ b/packages/core/src/rag/index.ts
@@ -326,7 +326,6 @@ Thank you and happy classifying!`;
 
   normaliseLessonPlan(plan: LessonPlan) {
     return plan;
-    
   }
 
   async fetchLessonPlans({
@@ -655,7 +654,6 @@ Thank you and happy classifying!`;
 
     // If none of that works, fall back to categorising the subject based on free text
     if (!foundSubject) {
-      
       const categorisation = await this.categoriseKeyStageAndSubject(
         subject,
         this._chatMeta,


### PR DESCRIPTION
## Description

- Remove trailing whitespace on two blank lines in `packages/core/src/rag/index.ts`.

The `lint` check (`prettier --check .`) is currently failing on `main`, blocking all open PRs. This file was last touched in #1075 and merged with a prettier violation.

## Issue(s)

Fixes #

## How to test

1. `pnpm prettier --check packages/core/src/rag/index.ts` → passes.
2. The `lint` CI check goes green.

## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change

🤖 Generated with [Claude Code](https://claude.com/claude-code)