### PR TITLE
build: release candidate

### DIFF
--- a/apps/nextjs/src/app/api/cron-jobs/expired-exports/route.ts
+++ b/apps/nextjs/src/app/api/cron-jobs/expired-exports/route.ts
@@ -139,7 +139,6 @@ export async function GET(request: NextRequest) {
 
       if (!files || files.length === 0) {
         log.info("No expired files found.");
-        hasMoreFiles = false;
         break;
       }
 
@@ -147,7 +146,6 @@ export async function GET(request: NextRequest) {
 
       if (validFileIds.length === 0) {
         log.info("No valid file IDs to process.");
-        hasMoreFiles = false;
         break;
       }
 

--- a/apps/nextjs/src/stores/lessonPlanStore/__tests__/handleMessagesUpdated.test.ts
+++ b/apps/nextjs/src/stores/lessonPlanStore/__tests__/handleMessagesUpdated.test.ts
@@ -1,0 +1,67 @@
+import type { AiMessage } from "@/stores/chatStore/types";
+import type { TrpcUtils } from "@/utils/trpc";
+
+import { createLessonPlanStore } from "..";
+import type { LessonPlanState } from "../types";
+
+const trpcUtils = {} as unknown as TrpcUtils;
+
+const recordSeparator = "␞";
+
+function assistantMessage(parts: object[]): AiMessage {
+  return {
+    id: "msg-1",
+    role: "assistant",
+    content: parts.map((p) => JSON.stringify(p)).join(recordSeparator),
+  };
+}
+
+const setupStore = (initialValues?: Partial<LessonPlanState>) =>
+  createLessonPlanStore({ id: "test-id", trpcUtils, initialValues });
+
+const basedOn = { id: "old-1", title: "Angles in triangles" };
+
+describe("lessonPlanStore messagesUpdated", () => {
+  it("removes the basedOn attribution when a remove patch streams", () => {
+    const store = setupStore({
+      lessonPlan: { title: "Angle bisectors", basedOn },
+      isAcceptingChanges: true,
+    });
+
+    store.getState().actions.messagesUpdated([
+      assistantMessage([
+        {
+          type: "patch",
+          reasoning: "stale basedOn cleared",
+          value: { op: "remove", path: "/basedOn" },
+          status: "complete",
+        },
+      ]),
+    ]);
+
+    expect(store.getState().lessonPlan.basedOn).toBeUndefined();
+    expect(store.getState().lessonPlan.title).toBe("Angle bisectors");
+  });
+
+  it("shows a basedOn only after an add patch streams", () => {
+    const store = setupStore({
+      lessonPlan: { title: "Angle bisectors" },
+      isAcceptingChanges: true,
+    });
+
+    expect(store.getState().lessonPlan.basedOn).toBeUndefined();
+
+    store.getState().actions.messagesUpdated([
+      assistantMessage([
+        {
+          type: "patch",
+          reasoning: "user selected a lesson to adapt",
+          value: { op: "add", path: "/basedOn", value: basedOn },
+          status: "complete",
+        },
+      ]),
+    ]);
+
+    expect(store.getState().lessonPlan.basedOn).toEqual(basedOn);
+  });
+});

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/basedOnAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/basedOnAgent/index.ts
@@ -4,8 +4,9 @@ import { BasedOnSchema } from "../../../../../protocol/schema";
 import { DEFAULT_AGENT_MODEL_PARAMS } from "../../../constants";
 import { createSectionAgent } from "../createSectionAgent";
 import { basedOnInstructions } from "./basedOn.instructions";
+import { resolveBasedOnAgainstRelevantLessons } from "./resolveBasedOnAgainstRelevantLessons";
 
-export const basedOnAgent = createSectionAgent({
+const createBaseAgent = createSectionAgent({
   responseSchema: BasedOnSchema.nullable(),
   instructions: basedOnInstructions,
   modelParams: DEFAULT_AGENT_MODEL_PARAMS,
@@ -27,3 +28,23 @@ export const basedOnAgent = createSectionAgent({
     ].filter(isTruthy);
   },
 });
+
+export const basedOnAgent: typeof createBaseAgent = (args) => {
+  const agent = createBaseAgent(args);
+  return {
+    ...agent,
+    handler: async (ctx) => {
+      const result = await agent.handler(ctx);
+      if (result.error !== null || result.data == null) {
+        return result;
+      }
+      return {
+        ...result,
+        data: resolveBasedOnAgainstRelevantLessons(
+          result.data,
+          ctx.persistedState.relevantLessons,
+        ),
+      };
+    },
+  };
+};

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/basedOnAgent/resolveBasedOnAgainstRelevantLessons.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/basedOnAgent/resolveBasedOnAgainstRelevantLessons.test.ts
@@ -1,0 +1,57 @@
+import type { AgenticRagLessonPlanResult } from "../../../types";
+import { resolveBasedOnAgainstRelevantLessons } from "./resolveBasedOnAgainstRelevantLessons";
+
+const relevantLessons: AgenticRagLessonPlanResult[] = [
+  {
+    ragLessonPlanId: "lp1",
+    oakLessonId: 1,
+    oakLessonSlug: "angles-in-triangles",
+    lessonPlan: { title: "Angles in triangles" },
+  },
+  {
+    ragLessonPlanId: "lp2",
+    oakLessonId: 2,
+    oakLessonSlug: "missing-angles",
+    lessonPlan: { title: "Missing angles" },
+  },
+];
+
+describe("resolveBasedOnAgainstRelevantLessons", () => {
+  it("restores the offered lesson's title when the id matches", () => {
+    const result = resolveBasedOnAgainstRelevantLessons(
+      { id: "lp1", title: "Constructing angle bisectors" },
+      relevantLessons,
+    );
+
+    expect(result).toEqual({ id: "lp1", title: "Angles in triangles" });
+  });
+
+  it("restores the offered lesson's id when only the title matches", () => {
+    const result = resolveBasedOnAgainstRelevantLessons(
+      { id: "made-up-id", title: "missing angles" },
+      relevantLessons,
+    );
+
+    expect(result).toEqual({ id: "lp2", title: "Missing angles" });
+  });
+
+  it("returns the value unchanged when nothing matches", () => {
+    const basedOn = { id: "made-up-id", title: "A lesson never offered" };
+
+    const result = resolveBasedOnAgainstRelevantLessons(
+      basedOn,
+      relevantLessons,
+    );
+
+    expect(result).toEqual(basedOn);
+  });
+
+  it("returns the value unchanged when no lessons were offered", () => {
+    const basedOn = { id: "lp1", title: "Angles in triangles" };
+
+    expect(resolveBasedOnAgainstRelevantLessons(basedOn, null)).toEqual(
+      basedOn,
+    );
+    expect(resolveBasedOnAgainstRelevantLessons(basedOn, [])).toEqual(basedOn);
+  });
+});

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/basedOnAgent/resolveBasedOnAgainstRelevantLessons.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/basedOnAgent/resolveBasedOnAgainstRelevantLessons.ts
@@ -1,0 +1,25 @@
+import type { BasedOn } from "../../../../../protocol/schema";
+import type { AgenticRagLessonPlanResult } from "../../../types";
+
+// The LLM can mislabel basedOn (e.g. "use lesson 1 and rename it to X" puts
+// the new title in basedOn.title), so resolve it against the offered lessons.
+export function resolveBasedOnAgainstRelevantLessons(
+  basedOn: BasedOn,
+  relevantLessons: AgenticRagLessonPlanResult[] | null,
+): BasedOn {
+  if (!relevantLessons?.length) return basedOn;
+
+  const byId = relevantLessons.find((l) => l.ragLessonPlanId === basedOn.id);
+  if (byId) {
+    return { id: byId.ragLessonPlanId, title: byId.lessonPlan.title };
+  }
+
+  const byTitle = relevantLessons.find(
+    (l) => l.lessonPlan.title.toLowerCase() === basedOn.title.toLowerCase(),
+  );
+  if (byTitle) {
+    return { id: byTitle.ragLessonPlanId, title: byTitle.lessonPlan.title };
+  }
+
+  return basedOn;
+}

--- a/packages/aila/src/lib/agentic-system/ailaTurn.test.ts
+++ b/packages/aila/src/lib/agentic-system/ailaTurn.test.ts
@@ -417,6 +417,116 @@ describe("ailaTurn", () => {
     expect(callbacks.onTurnFailed).not.toHaveBeenCalled();
   });
 
+  it.each([
+    { label: "null", relevantLessons: null },
+    { label: "empty", relevantLessons: [] },
+  ])(
+    "strips a basedOn step the planner produced when relevant lessons are $label",
+    async ({ relevantLessons }) => {
+      const callbacks = createCallbacks();
+      const basedOnHandler = jest.fn();
+      const runtime = createRuntime({
+        plannerAgent: jest.fn().mockResolvedValue({
+          error: null,
+          data: {
+            decision: "plan",
+            parsedUserMessage: "Update the subject",
+            plan: [
+              {
+                type: "section",
+                sectionKey: "basedOn",
+                action: "generate",
+                sectionInstructions: null,
+              },
+              {
+                type: "section",
+                sectionKey: "subject",
+                action: "generate",
+                sectionInstructions: null,
+              },
+            ],
+          },
+        }),
+        sectionAgents: {
+          "basedOn--default": {
+            id: "basedOn--default",
+            description: "basedOn",
+            handler: basedOnHandler,
+          },
+          "subject--default": {
+            id: "subject--default",
+            description: "subject",
+            handler: jest.fn().mockResolvedValue({ error: null, data: "art" }),
+          },
+        } as unknown as AilaRuntimeContext["sectionAgents"],
+      });
+
+      await ailaTurn({
+        persistedState: { ...createPersistedState(), relevantLessons },
+        runtime,
+        callbacks,
+      });
+
+      expect(callbacks.onPlannerComplete).toHaveBeenCalledWith({
+        sectionKeys: ["subject"],
+      });
+      expect(basedOnHandler).not.toHaveBeenCalled();
+    },
+  );
+
+  it("keeps a basedOn step when relevant lessons exist", async () => {
+    const callbacks = createCallbacks();
+    const basedOnHandler = jest.fn().mockResolvedValue({
+      error: null,
+      data: { id: "lp1", title: "Angles in triangles" },
+    });
+    const runtime = createRuntime({
+      plannerAgent: jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          decision: "plan",
+          parsedUserMessage: "Use the first lesson",
+          plan: [
+            {
+              type: "section",
+              sectionKey: "basedOn",
+              action: "generate",
+              sectionInstructions: null,
+            },
+          ],
+        },
+      }),
+      sectionAgents: {
+        "basedOn--default": {
+          id: "basedOn--default",
+          description: "basedOn",
+          handler: basedOnHandler,
+        },
+      } as unknown as AilaRuntimeContext["sectionAgents"],
+    });
+
+    await ailaTurn({
+      persistedState: {
+        ...createPersistedState(),
+        relevantLessons: [
+          {
+            ragLessonPlanId: "lp1",
+            oakLessonId: 1,
+            oakLessonSlug: "angles-in-triangles",
+            lessonPlan: { title: "Angles in triangles" },
+          },
+        ],
+      },
+      runtime,
+      callbacks,
+    });
+
+    expect(callbacks.onPlannerComplete).toHaveBeenCalledWith({
+      sectionKeys: ["basedOn"],
+    });
+    expect(basedOnHandler).toHaveBeenCalled();
+  });
+
   it("supports forced planner failures via env var", async () => {
     process.env.AILA_AGENTIC_FORCE_FAIL = "planner";
 

--- a/packages/aila/src/lib/agentic-system/execution/executePlanningPhase.ts
+++ b/packages/aila/src/lib/agentic-system/execution/executePlanningPhase.ts
@@ -36,6 +36,17 @@ export async function executePlanningPhase(
     return await terminateWithResponse(context);
   }
 
+  // basedOn can only be planned when relevant lessons were fetched and offered,
+  // so strip any basedOn step the planner produced without that backing.
+  const hasRelevantLessons =
+    (context.persistedState.relevantLessons?.length ?? 0) > 0;
+  if (!hasRelevantLessons) {
+    context.currentTurn.plannerOutput.plan =
+      context.currentTurn.plannerOutput.plan.filter(
+        (step) => step.sectionKey !== "basedOn",
+      );
+  }
+
   context.callbacks.onPlannerComplete({
     sectionKeys: context.currentTurn.plannerOutput.plan.map(
       (step) => step.sectionKey,

--- a/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.test.ts
+++ b/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.test.ts
@@ -1,3 +1,4 @@
+// cspell:ignore trangles
 import type { PartialLessonPlan } from "../../../protocol/schema";
 import type {
   AgenticRagLessonPlanResult,
@@ -5,6 +6,7 @@ import type {
   AilaTurnCallbacks,
 } from "../types";
 import { handleRelevantLessons } from "./handleRelevantLessons";
+import { terminateWithResponse } from "./termination";
 
 jest.mock("./termination", () => ({
   terminateWithResponse: jest.fn(),
@@ -13,6 +15,7 @@ jest.mock("./termination", () => ({
 function createContext(
   overrides: {
     document?: Partial<AilaExecutionContext["currentTurn"]["document"]>;
+    initialDocument?: PartialLessonPlan;
     ragFetched?: AilaExecutionContext["persistedState"]["ragFetched"];
     fetchResult?: AgenticRagLessonPlanResult[];
   } = {},
@@ -20,7 +23,7 @@ function createContext(
   return {
     persistedState: {
       messages: [],
-      initialDocument: {},
+      initialDocument: overrides.initialDocument ?? {},
       relevantLessons: null,
       ragFetched: overrides.ragFetched ?? {
         status: "not_fetched",
@@ -66,6 +69,67 @@ function createContext(
     },
   };
 }
+
+const fakeLessons: AgenticRagLessonPlanResult[] = [
+  {
+    ragLessonPlanId: "lp1",
+    oakLessonId: 1,
+    oakLessonSlug: "photosynthesis",
+    lessonPlan: { title: "Photosynthesis" },
+  },
+];
+
+const previousTopicIdentity = {
+  title: "Angles in triangles",
+  subject: "maths",
+  keyStage: "ks2",
+};
+
+const staleBasedOn = { id: "old-1", title: "Angles in triangles" };
+
+const minimalQuiz = {
+  version: "v3" as const,
+  questions: [],
+  imageMetadata: [],
+};
+const minimalCycle = {
+  title: "Cycle",
+  durationInMinutes: 15,
+  explanation: {
+    spokenExplanation: "Explanation",
+    accompanyingSlideDetails: "Slide details",
+    imagePrompt: "Image prompt",
+    slideText: "Slide text",
+  },
+  checkForUnderstanding: [
+    { question: "Q1?", answers: ["A1"], distractors: ["D1", "D2"] },
+    { question: "Q2?", answers: ["A2"], distractors: ["D3", "D4"] },
+  ],
+  practice: "Practice",
+  feedback: "Feedback",
+};
+const completedOverrides: Partial<PartialLessonPlan> = {
+  learningOutcome: "I can explain photosynthesis",
+  learningCycles: ["Introduce photosynthesis"],
+  priorKnowledge: ["Cell biology"],
+  keyLearningPoints: ["Photosynthesis uses light"],
+  misconceptions: [
+    {
+      misconception: "Plants eat soil",
+      description: "Plants make food from light",
+    },
+  ],
+  keywords: [
+    { keyword: "Photosynthesis", definition: "Process of making food" },
+  ],
+  basedOn: null,
+  starterQuiz: minimalQuiz,
+  cycle1: minimalCycle,
+  cycle2: minimalCycle,
+  cycle3: null,
+  exitQuiz: minimalQuiz,
+  additionalMaterials: null,
+};
 
 describe("handleRelevantLessons", () => {
   it("skips fetch and persists 'selected' when basedOn is set", async () => {
@@ -118,55 +182,119 @@ describe("handleRelevantLessons", () => {
   });
 
   it("skips fetch when lesson is complete", async () => {
-    const minimalQuiz = {
-      version: "v3" as const,
-      questions: [],
-      imageMetadata: [],
-    };
-    const minimalCycle = {
-      title: "Cycle",
-      durationInMinutes: 15,
-      explanation: {
-        spokenExplanation: "Explanation",
-        accompanyingSlideDetails: "Slide details",
-        imagePrompt: "Image prompt",
-        slideText: "Slide text",
-      },
-      checkForUnderstanding: [
-        { question: "Q1?", answers: ["A1"], distractors: ["D1", "D2"] },
-        { question: "Q2?", answers: ["A2"], distractors: ["D3", "D4"] },
-      ],
-      practice: "Practice",
-      feedback: "Feedback",
-    };
-    const completedOverrides: Partial<PartialLessonPlan> = {
-      learningOutcome: "I can explain photosynthesis",
-      learningCycles: ["Introduce photosynthesis"],
-      priorKnowledge: ["Cell biology"],
-      keyLearningPoints: ["Photosynthesis uses light"],
-      misconceptions: [
-        {
-          misconception: "Plants eat soil",
-          description: "Plants make food from light",
-        },
-      ],
-      keywords: [
-        { keyword: "Photosynthesis", definition: "Process of making food" },
-      ],
-      basedOn: null,
-      starterQuiz: minimalQuiz,
-      cycle1: minimalCycle,
-      cycle2: minimalCycle,
-      cycle3: null,
-      exitQuiz: minimalQuiz,
-      additionalMaterials: null,
-    };
     const ctx = createContext({ document: completedOverrides });
 
     const result = await handleRelevantLessons(ctx);
 
     expect(result).toEqual({ status: "continue" });
     expect(ctx.runtime.fetchRelevantLessons).not.toHaveBeenCalled();
+  });
+
+  it("clears a stale basedOn on a topic change when no identity was recorded", async () => {
+    const ctx = createContext({
+      document: {
+        title: "Angle bisectors",
+        subject: "maths",
+        keyStage: "ks2",
+        basedOn: staleBasedOn,
+      },
+      initialDocument: {
+        title: "Angles in triangles",
+        subject: "maths",
+        keyStage: "ks2",
+        basedOn: staleBasedOn,
+      },
+      ragFetched: { status: "not_fetched", searchIdentity: null },
+      fetchResult: [],
+    });
+
+    const result = await handleRelevantLessons(ctx);
+
+    expect(result).toEqual({ status: "continue" });
+    expect(ctx.currentTurn.document.basedOn).toBeUndefined();
+    expect(ctx.callbacks.onSectionComplete).toHaveBeenCalledWith([
+      { op: "remove", path: "/basedOn" },
+    ]);
+    expect(ctx.runtime.fetchRelevantLessons).toHaveBeenCalled();
+  });
+
+  it("keeps a basedOn on an unchanged topic when no identity was recorded", async () => {
+    const ctx = createContext({
+      document: {
+        title: "Angles in triangles",
+        subject: "maths",
+        keyStage: "ks2",
+        basedOn: staleBasedOn,
+      },
+      initialDocument: {
+        title: "Angles in triangles",
+        subject: "maths",
+        keyStage: "ks2",
+        basedOn: staleBasedOn,
+      },
+      ragFetched: { status: "not_fetched", searchIdentity: null },
+    });
+
+    const result = await handleRelevantLessons(ctx);
+
+    expect(result).toEqual({ status: "continue" });
+    expect(ctx.currentTurn.document.basedOn).toEqual(staleBasedOn);
+    expect(ctx.runtime.fetchRelevantLessons).not.toHaveBeenCalled();
+    expect(ctx.persistedState.ragFetched).toEqual({
+      status: "selected",
+      searchIdentity: {
+        title: "Angles in triangles",
+        subject: "maths",
+        keyStage: "ks2",
+      },
+    });
+  });
+
+  it("clears a stale basedOn without refetching when the lesson is complete", async () => {
+    const ctx = createContext({
+      document: {
+        ...completedOverrides,
+        title: "Angle bisectors",
+        subject: "maths",
+        keyStage: "ks2",
+        basedOn: staleBasedOn,
+      },
+      initialDocument: { basedOn: staleBasedOn },
+      ragFetched: { status: "selected", searchIdentity: previousTopicIdentity },
+      fetchResult: fakeLessons,
+    });
+
+    const result = await handleRelevantLessons(ctx);
+
+    expect(result).toEqual({ status: "continue" });
+    expect(ctx.currentTurn.document.basedOn).toBeUndefined();
+    expect(ctx.callbacks.onSectionComplete).toHaveBeenCalledWith([
+      { op: "remove", path: "/basedOn" },
+    ]);
+    expect(ctx.runtime.fetchRelevantLessons).not.toHaveBeenCalled();
+  });
+
+  it("keeps a valid basedOn untouched when the lesson is complete", async () => {
+    const validBasedOn = { id: "sel-1", title: "Photosynthesis" };
+    const ctx = createContext({
+      document: { ...completedOverrides, basedOn: validBasedOn },
+      initialDocument: { basedOn: validBasedOn },
+      ragFetched: {
+        status: "selected",
+        searchIdentity: {
+          title: "Photosynthesis",
+          subject: "science",
+          keyStage: "key-stage-3",
+        },
+      },
+    });
+
+    const result = await handleRelevantLessons(ctx);
+
+    expect(result).toEqual({ status: "continue" });
+    expect(ctx.currentTurn.document.basedOn).toEqual(validBasedOn);
+    expect(ctx.runtime.fetchRelevantLessons).not.toHaveBeenCalled();
+    expect(ctx.callbacks.onSectionComplete).not.toHaveBeenCalled();
   });
 
   it("does not call onRagFetchedChange when state is unchanged", async () => {
@@ -186,5 +314,154 @@ describe("handleRelevantLessons", () => {
       "onRagFetchedChange",
     );
     expect(ctx.callbacks.onRagFetchedChange).not.toHaveBeenCalled();
+  });
+
+  it("keeps an existing basedOn when the topic is unchanged", async () => {
+    const ctx = createContext({
+      document: {
+        title: "Angles in triangles",
+        subject: "maths",
+        keyStage: "ks2",
+        basedOn: staleBasedOn,
+      },
+      initialDocument: { basedOn: staleBasedOn },
+      ragFetched: {
+        status: "shown",
+        searchIdentity: previousTopicIdentity,
+      },
+    });
+
+    const result = await handleRelevantLessons(ctx);
+
+    expect(result).toEqual({ status: "continue" });
+    expect(ctx.runtime.fetchRelevantLessons).not.toHaveBeenCalled();
+    expect(ctx.currentTurn.document.basedOn).toEqual(staleBasedOn);
+    expect(ctx.callbacks.onSectionComplete).not.toHaveBeenCalled();
+  });
+
+  it("clears a stale basedOn and re-fetches when the topic changed", async () => {
+    const ctx = createContext({
+      document: {
+        title: "Angle bisectors",
+        subject: "maths",
+        keyStage: "ks2",
+        basedOn: staleBasedOn,
+      },
+      initialDocument: { basedOn: staleBasedOn },
+      ragFetched: { status: "selected", searchIdentity: previousTopicIdentity },
+      fetchResult: [],
+    });
+
+    const result = await handleRelevantLessons(ctx);
+
+    expect(result).toEqual({ status: "continue" });
+    expect(ctx.runtime.fetchRelevantLessons).toHaveBeenCalledWith({
+      title: "Angle bisectors",
+      subject: "maths",
+      keyStage: "ks2",
+    });
+    expect(ctx.currentTurn.document.basedOn).toBeUndefined();
+    expect(ctx.callbacks.onSectionComplete).toHaveBeenCalledWith([
+      { op: "remove", path: "/basedOn" },
+    ]);
+    expect(ctx.persistedState.ragFetched.status).toBe("none_found");
+  });
+
+  it("ends the turn with the lesson picker when lessons are found", async () => {
+    const actual = jest.requireActual<{
+      terminateWithResponse: typeof terminateWithResponse;
+    }>("./termination");
+    jest
+      .mocked(terminateWithResponse)
+      .mockImplementationOnce(actual.terminateWithResponse);
+    const ctx = createContext({ fetchResult: fakeLessons });
+
+    const result = await handleRelevantLessons(ctx);
+
+    expect(result.status).toBe("success");
+    expect(ctx.currentTurn.relevantLessonsFetched).toBe(true);
+    expect(ctx.callbacks.onTurnComplete).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ailaMessage: expect.stringContaining("1. Photosynthesis"),
+      }),
+    );
+  });
+
+  it("keeps a selected basedOn when a later turn fixes a title typo", async () => {
+    const selectedBasedOn = { id: "sel-1", title: "Angles in triangles" };
+    const ctx = createContext({
+      document: {
+        title: "Angles in triangles",
+        subject: "maths",
+        keyStage: "ks2",
+        basedOn: selectedBasedOn,
+      },
+      initialDocument: { basedOn: selectedBasedOn },
+      ragFetched: {
+        status: "selected",
+        searchIdentity: {
+          title: "Angles in trangles",
+          subject: "maths",
+          keyStage: "ks2",
+        },
+      },
+    });
+
+    const result = await handleRelevantLessons(ctx);
+
+    expect(result).toEqual({ status: "continue" });
+    expect(ctx.currentTurn.document.basedOn).toEqual(selectedBasedOn);
+    expect(ctx.runtime.fetchRelevantLessons).not.toHaveBeenCalled();
+    expect(ctx.callbacks.onSectionComplete).not.toHaveBeenCalled();
+  });
+
+  it("keeps a basedOn chosen this turn when the topic also changed", async () => {
+    const freshBasedOn = { id: "new-1", title: "Angle bisectors" };
+    const ctx = createContext({
+      document: {
+        title: "Constructing angle bisectors",
+        subject: "maths",
+        keyStage: "ks2",
+        basedOn: freshBasedOn,
+      },
+      initialDocument: {},
+      ragFetched: { status: "shown", searchIdentity: previousTopicIdentity },
+    });
+
+    const result = await handleRelevantLessons(ctx);
+
+    expect(result).toEqual({ status: "continue" });
+    expect(ctx.currentTurn.document.basedOn).toEqual(freshBasedOn);
+    expect(ctx.runtime.fetchRelevantLessons).not.toHaveBeenCalled();
+    expect(ctx.callbacks.onSectionComplete).not.toHaveBeenCalled();
+    expect(ctx.persistedState.ragFetched).toEqual({
+      status: "selected",
+      searchIdentity: {
+        title: "Constructing angle bisectors",
+        subject: "maths",
+        keyStage: "ks2",
+      },
+    });
+  });
+
+  it("prompts the user to pick when a stale basedOn is cleared and lessons are found", async () => {
+    const ctx = createContext({
+      document: {
+        title: "Angle bisectors",
+        subject: "maths",
+        keyStage: "ks2",
+        basedOn: staleBasedOn,
+      },
+      initialDocument: { basedOn: staleBasedOn },
+      ragFetched: { status: "selected", searchIdentity: previousTopicIdentity },
+      fetchResult: fakeLessons,
+    });
+
+    await handleRelevantLessons(ctx);
+
+    expect(ctx.currentTurn.document.basedOn).toBeUndefined();
+    expect(ctx.runtime.fetchRelevantLessons).toHaveBeenCalled();
+    expect(terminateWithResponse).toHaveBeenCalledWith(ctx);
+    expect(ctx.persistedState.ragFetched.status).toBe("shown");
   });
 });

--- a/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.ts
+++ b/packages/aila/src/lib/agentic-system/execution/handleRelevantLessons.ts
@@ -1,10 +1,15 @@
+import { enablePatches, produceWithPatches } from "immer";
+
 import {
   CompletedLessonPlanSchema,
   type RagFetched,
 } from "../../../protocol/schema";
+import { immerPatchToJsonPatch } from "../compatibility/helpers/immerPatchToJsonPatch";
 import type { AilaExecutionContext, AilaTurnPhaseOutcome } from "../types";
 import { hasSearchIdentityChangedSignificantly } from "./searchIdentity";
 import { terminateWithResponse } from "./termination";
+
+enablePatches();
 
 function searchIdentityEqual(
   a: RagFetched["searchIdentity"],
@@ -39,30 +44,69 @@ export async function handleRelevantLessons(
   const { title, subject, keyStage, basedOn } = context.currentTurn.document;
   const ragFetched = context.persistedState.ragFetched;
 
+  const nextSearchIdentity =
+    title && subject && keyStage ? { title, subject, keyStage } : null;
+
+  if (basedOn) {
+    const initialDocument = context.persistedState.initialDocument;
+
+    // A basedOn that wasn't in the document at the start of the turn means the
+    // user just chose a lesson to adapt, so it is valid even if the search
+    // identity changed in the same turn.
+    const basedOnSetThisTurn = basedOn !== initialDocument.basedOn;
+
+    // Chats from the legacy pipeline have no recorded search identity, so fall
+    // back to the document as it stood at the start of the turn.
+    const prevSearchIdentity =
+      ragFetched.searchIdentity ??
+      (initialDocument.title &&
+      initialDocument.subject &&
+      initialDocument.keyStage
+        ? {
+            title: initialDocument.title,
+            subject: initialDocument.subject,
+            keyStage: initialDocument.keyStage,
+          }
+        : null);
+
+    const basedOnIsStale =
+      !basedOnSetThisTurn &&
+      prevSearchIdentity != null &&
+      nextSearchIdentity != null &&
+      hasSearchIdentityChangedSignificantly(
+        prevSearchIdentity,
+        nextSearchIdentity,
+      );
+
+    if (basedOnIsStale) {
+      // The lesson metadata changed significantly, so a basedOn carried over
+      // from a previous lesson no longer applies. A wrong attribution is
+      // cleared even on a complete lesson, where fetching stays blocked below.
+      clearBasedOn(context);
+    }
+  }
+
   if (
     CompletedLessonPlanSchema.safeParse(context.currentTurn.document).success
   ) {
     return { status: "continue" };
   }
 
-  if (basedOn) {
-    // user has chosen a lesson to adapt — record that selection
+  if (context.currentTurn.document.basedOn) {
+    // user has chosen a lesson to adapt and the search identity still
+    // matches — record the selection and stop
     await persistRagFetched(context, {
       status: "selected",
-      searchIdentity:
-        title && subject && keyStage
-          ? { title, subject, keyStage }
-          : ragFetched.searchIdentity,
+      searchIdentity: nextSearchIdentity ?? ragFetched.searchIdentity,
     });
     return { status: "continue" };
   }
 
-  if (!title || !subject || !keyStage) {
+  if (!nextSearchIdentity) {
     // can't form a search identity without all three — don't fetch
     return { status: "continue" };
   }
 
-  const nextSearchIdentity = { title, subject, keyStage };
   if (
     !hasSearchIdentityChangedSignificantly(
       ragFetched.searchIdentity,
@@ -72,11 +116,8 @@ export async function handleRelevantLessons(
     return { status: "continue" };
   }
 
-  const lessons = await context.runtime.fetchRelevantLessons({
-    title,
-    subject,
-    keyStage,
-  });
+  const lessons =
+    await context.runtime.fetchRelevantLessons(nextSearchIdentity);
   context.currentTurn.relevantLessons = lessons;
   context.currentTurn.relevantLessonsFetched = true;
 
@@ -90,4 +131,16 @@ export async function handleRelevantLessons(
   }
 
   return { status: "continue" };
+}
+
+function clearBasedOn(context: AilaExecutionContext) {
+  const [nextDoc, patches] = produceWithPatches(
+    context.currentTurn.document,
+    (draft) => {
+      delete draft.basedOn;
+    },
+  );
+
+  context.currentTurn.document = nextDoc;
+  context.callbacks.onSectionComplete(patches.map(immerPatchToJsonPatch));
 }

--- a/packages/aila/src/lib/agentic-system/execution/searchIdentity.test.ts
+++ b/packages/aila/src/lib/agentic-system/execution/searchIdentity.test.ts
@@ -1,3 +1,4 @@
+// cspell:ignore trangles
 import { hasSearchIdentityChangedSignificantly } from "./searchIdentity";
 
 describe("hasSearchIdentityChangedSignificantly", () => {
@@ -132,6 +133,24 @@ describe("hasSearchIdentityChangedSignificantly", () => {
         prev: "An Introduction",
         next: "A Basic Overview",
         expected: false,
+      },
+      {
+        label: "single-character typo fix (fuzzy match)",
+        prev: "Angles in trangles",
+        next: "Angles in triangles",
+        expected: false,
+      },
+      {
+        label: "US to UK spelling (fuzzy match)",
+        prev: "Organizing an argument",
+        next: "Organising an argument",
+        expected: false,
+      },
+      {
+        label: "word replacement of similar length",
+        prev: "Angles in triangles",
+        next: "Angle bisectors",
+        expected: true,
       },
       {
         label: "completely different topic",

--- a/packages/aila/src/lib/agentic-system/execution/searchIdentity.ts
+++ b/packages/aila/src/lib/agentic-system/execution/searchIdentity.ts
@@ -101,15 +101,55 @@ function tokenise(text: string): Set<string> {
   return new Set(tokens);
 }
 
+// cspell:ignore trangle
+// Single-character typo fixes ("trangle" -> "triangle") shouldn't count as a
+// different word. Only fuzzy-match longer tokens — short words have too many
+// real one-edit neighbours (one/two, light/sight).
+const FUZZY_MIN_TOKEN_LENGTH = 6;
+
+function withinOneEdit(a: string, b: string): boolean {
+  if (Math.abs(a.length - b.length) > 1) return false;
+  const [short, long] = a.length <= b.length ? [a, b] : [b, a];
+  let i = 0;
+  let j = 0;
+  let edits = 0;
+  while (i < short.length && j < long.length) {
+    if (short[i] === long[j]) {
+      i++;
+      j++;
+      continue;
+    }
+    if (edits === 1) return false;
+    edits = 1;
+    if (short.length === long.length) i++;
+    j++;
+  }
+  return edits + (long.length - j) <= 1;
+}
+
+function tokensMatch(a: string, b: string): boolean {
+  if (a === b) return true;
+  if (a.length < FUZZY_MIN_TOKEN_LENGTH || b.length < FUZZY_MIN_TOKEN_LENGTH)
+    return false;
+  return withinOneEdit(a, b);
+}
+
 function titleJaccard(a: string, b: string): number {
   const setA = tokenise(a);
   const setB = tokenise(b);
   if (setA.size === 0 && setB.size === 0) return 1;
+  const unmatched = new Set(setB);
   let intersection = 0;
   for (const t of setA) {
-    if (setB.has(t)) intersection++;
+    const match = unmatched.has(t)
+      ? t
+      : [...unmatched].find((u) => tokensMatch(t, u));
+    if (match !== undefined) {
+      unmatched.delete(match);
+      intersection++;
+    }
   }
-  const union = new Set([...setA, ...setB]).size;
+  const union = setA.size + setB.size - intersection;
   return union === 0 ? 1 : intersection / union;
 }
 

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,11 +1,10 @@
-codeHash: 34b200788c63e60f8ea242491f91f8fdd543ef04f9482f05294f1fc6c8698090
-generated: 2026-06-04T07:46:41.431Z
+codeHash: ec29ccef813954ab5d41ff3df15ab94491e4bf4d05f60ae20b3d1d2d4a29a5a1
+generated: 2026-06-11T00:34:54.870Z
 runsPerScenario: 3
 summary:
   full-lesson:
     plan-groupings:
-      flag: 1
-      pass: 2
+      pass: 3
     additional-materials-tone:
       skip: 3
     cycle-verbosity:
@@ -19,7 +18,8 @@ summary:
     americanisms-phrasing:
       pass: 3
     americanisms-meanings:
-      flag: 3
+      pass: 1
+      flag: 2
     quiz-question-count:
       pass: 3
     americanisms_corrector:
@@ -31,8 +31,7 @@ summary:
       corrections_by_section: {}
   no-rag-lesson:
     plan-groupings:
-      pass: 2
-      flag: 1
+      pass: 3
     additional-materials-tone:
       skip: 3
     cycle-verbosity:
@@ -52,11 +51,9 @@ summary:
     quiz-question-count:
       pass: 3
     americanisms_corrector:
-      corrections_attempted: 3
-      corrections_not_needed: 30
+      corrections_attempted: 0
+      corrections_not_needed: 33
       corrections_failed: 0
-      correction_rate: 9.1%
+      correction_rate: 0.0%
       correction_failure_rate: 0.0%
-      corrections_by_section:
-        starterQuiz: 2
-        cycle1: 1
+      corrections_by_section: {}

--- a/packages/core/src/rag/index.ts
+++ b/packages/core/src/rag/index.ts
@@ -326,7 +326,6 @@ Thank you and happy classifying!`;
 
   normaliseLessonPlan(plan: LessonPlan) {
     return plan;
-    
   }
 
   async fetchLessonPlans({
@@ -655,7 +654,6 @@ Thank you and happy classifying!`;
 
     // If none of that works, fall back to categorising the subject based on free text
     if (!foundSubject) {
-      
       const categorisation = await this.categoriseKeyStageAndSubject(
         subject,
         this._chatMeta,

--- a/packages/core/src/rag/index.ts
+++ b/packages/core/src/rag/index.ts
@@ -326,10 +326,7 @@ Thank you and happy classifying!`;
 
   normaliseLessonPlan(plan: LessonPlan) {
     return plan;
-    // return {
-    //   ...plan,
-    //   content: JSON.parse(this.normaliseLessonPlanContent(plan.content)),
-    // };
+    
   }
 
   async fetchLessonPlans({
@@ -658,9 +655,7 @@ Thank you and happy classifying!`;
 
     // If none of that works, fall back to categorising the subject based on free text
     if (!foundSubject) {
-      //  log.info(
-      //   "No subject found. Categorise the input to try to work out what it is using categoriseKeyStageAndSubject",
-      // );
+      
       const categorisation = await this.categoriseKeyStageAndSubject(
         subject,
         this._chatMeta,

--- a/packages/core/src/utils/getCaptionsFromFile.ts
+++ b/packages/core/src/utils/getCaptionsFromFile.ts
@@ -134,14 +134,14 @@ export async function getFileFromBucket(bucketName: string, fileName: string) {
     const contents = await bucket.file(fileName).download();
     return contents.toString();
   } catch (err) {
+    let errorMessage: string;
+    if (typeof err === "string") {
+      errorMessage = err;
+    } else {
+      errorMessage = err instanceof Error ? err.message : JSON.stringify(err);
+    }
     log.error(
-      `Error fetching file: ${fileName} from bucket: ${bucketName}. Error: ${
-        typeof err === "string"
-          ? err
-          : err instanceof Error
-            ? err.message
-            : JSON.stringify(err)
-      }`,
+      `Error fetching file: ${fileName} from bucket: ${bucketName}. Error: ${errorMessage}`,
     );
     return;
   }

--- a/packages/rag/utils/parseSubjectsForRagSearch.test.ts
+++ b/packages/rag/utils/parseSubjectsForRagSearch.test.ts
@@ -1,0 +1,31 @@
+import { parseSubjectsForRagSearch } from "./parseSubjectsForRagSearch";
+
+describe("parseSubjectsForRagSearch", () => {
+  it("expands a mapped subject into its related slugs", () => {
+    expect(parseSubjectsForRagSearch("science")).toEqual([
+      "biology",
+      "chemistry",
+      "physics",
+      "science",
+      "combined-science",
+    ]);
+  });
+
+  it("matches regardless of casing", () => {
+    expect(parseSubjectsForRagSearch("Science")).toEqual(
+      parseSubjectsForRagSearch("science"),
+    );
+  });
+
+  it("matches spaced sentence-case subjects against slug keys", () => {
+    expect(parseSubjectsForRagSearch("Combined Science")).toEqual(
+      parseSubjectsForRagSearch("combined-science"),
+    );
+  });
+
+  it("returns the subject as a slug when unmapped", () => {
+    expect(parseSubjectsForRagSearch("Religious Education")).toEqual([
+      "religious-education",
+    ]);
+  });
+});

--- a/packages/rag/utils/parseSubjectsForRagSearch.ts
+++ b/packages/rag/utils/parseSubjectsForRagSearch.ts
@@ -1,3 +1,5 @@
+import { slugify } from "@oakai/core/src/utils/slugify";
+
 const subjectMap: Record<string, string[]> = {
   science: ["biology", "chemistry", "physics", "science", "combined-science"],
   biology: ["biology", "science", "combined-science"],
@@ -13,5 +15,8 @@ const subjectMap: Record<string, string[]> = {
 };
 
 export function parseSubjectsForRagSearch(subject: string): string[] {
-  return subjectMap[subject] ?? [subject];
+  // Slugify so callers passing "Science" or "Combined Science" still match
+  // the slug keys.
+  const key = slugify(subject);
+  return subjectMap[key] ?? [key];
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17687,7 +17687,7 @@ packages:
       acorn: 8.15.0
       acorn-import-attributes: 1.9.5(acorn@8.15.0)
       cjs-module-lexer: 1.4.3
-      module-details-from-path: 1.0.3
+      module-details-from-path: 1.0.4
     dev: false
 
   /import-lazy@4.0.0:


### PR DESCRIPTION
## Description
### Fixes
- **Removed dead stores and commented code**: Cleaned up unused store code and removed commented-out sections to reduce maintenance overhead. [#1075](https://github.com/oaknational/oak-ai-lesson-assistant/pull/1075)
- **Reset stale `basedOn` attribution**: Fixed an issue where outdated `basedOn` attribution could persist incorrectly. [#1065](https://github.com/oaknational/oak-ai-lesson-assistant/pull/1065)

### Chore
- **Applied Prettier formatting in `rag/index.ts`**: Updated formatting to keep the file aligned with project style standards. [#1083](https://github.com/oaknational/oak-ai-lesson-assistant/pull/1083)