### PR TITLE
refactor: [AI-2210] Simplify AilaStreamHandler

### DIFF
--- a/packages/aila/src/core/chat/AilaStreamHandler.test.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.test.ts
@@ -595,19 +595,53 @@ describe("AilaStreamHandler", () => {
   });
 
   it("skips complete when generationFailed rejects", async () => {
+    const streamError = new Error("LLM stream failed");
+    const recoveryError = new Error("generationFailed failed");
     const chat = createMockChat({ useAgenticAila: false });
     chat.createChatCompletionObjectStream = jest
       .fn()
-      .mockRejectedValue(new Error("LLM stream failed"));
-    chat.generationFailed = jest
-      .fn()
-      .mockRejectedValue(new Error("generationFailed failed"));
+      .mockRejectedValue(streamError);
+    chat.generationFailed = jest.fn().mockRejectedValue(recoveryError);
 
     const handler = new AilaStreamHandler(chat as never);
     await consumeStream(handler.startStreaming());
 
     expect(chat.generationFailed).toHaveBeenCalledTimes(1);
+    expect(chat.aila.errorReporter.reportError).toHaveBeenCalledWith(
+      recoveryError,
+    );
+    expect(chat.aila.errorReporter.reportError).toHaveBeenCalledWith(
+      streamError,
+    );
     expect(chat.complete).not.toHaveBeenCalled();
+  });
+
+  it("closes cleanly when completion and its fallback error message both fail", async () => {
+    const completionError = new Error("complete failed");
+    const enqueueError = new Error("enqueue failed");
+    const chat = createMockChat({ useAgenticAila: false });
+    chat.complete = jest.fn().mockRejectedValue(completionError);
+    chat.enqueue.mockImplementation((message: { value?: string }) => {
+      if (
+        message.value ===
+        "Something went wrong. Please try sending your message again."
+      ) {
+        throw enqueueError;
+      }
+      return Promise.resolve();
+    });
+
+    const handler = new AilaStreamHandler(chat as never);
+
+    await expect(consumeStream(handler.startStreaming())).resolves.toBe(
+      undefined,
+    );
+    expect(chat.aila.errorReporter.reportError).toHaveBeenCalledWith(
+      completionError,
+    );
+    expect(chat.aila.errorReporter.reportError).toHaveBeenCalledWith(
+      enqueueError,
+    );
   });
 
   it("skips complete when non-agentic setup fails before generation exists", async () => {

--- a/packages/aila/src/core/chat/AilaStreamHandler.test.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.test.ts
@@ -567,21 +567,29 @@ describe("AilaStreamHandler", () => {
 
   it("calls generationFailed and skips complete when non-agentic stream errors", async () => {
     const chat = createMockChat({ useAgenticAila: false });
-    // Override: stream throws immediately
     chat.createChatCompletionObjectStream = jest
       .fn()
       .mockRejectedValue(new Error("LLM stream failed"));
-    // Override: generationFailed must update status so shouldComplete becomes false
-    chat.generationFailed = jest.fn().mockImplementation(() => {
-      if (chat.generation) {
-        (chat.generation as { status: string }).status = "FAILED";
-      }
-      return Promise.resolve();
-    });
+    chat.generationFailed = jest.fn().mockResolvedValue(undefined);
 
     const handler = new AilaStreamHandler(chat as never);
     await consumeStream(handler.startStreaming());
 
+    expect(chat.generationFailed).toHaveBeenCalledTimes(1);
+    expect(chat.complete).not.toHaveBeenCalled();
+  });
+
+  it("skips complete after a non-agentic stream error even if generation status is unchanged", async () => {
+    const chat = createMockChat({ useAgenticAila: false });
+    chat.createChatCompletionObjectStream = jest
+      .fn()
+      .mockRejectedValue(new Error("LLM stream failed"));
+    chat.generationFailed = jest.fn().mockResolvedValue(undefined);
+
+    const handler = new AilaStreamHandler(chat as never);
+    await consumeStream(handler.startStreaming());
+
+    expect(chat.generation?.status).toBe("REQUESTED");
     expect(chat.generationFailed).toHaveBeenCalledTimes(1);
     expect(chat.complete).not.toHaveBeenCalled();
   });
@@ -599,6 +607,20 @@ describe("AilaStreamHandler", () => {
     await consumeStream(handler.startStreaming());
 
     expect(chat.generationFailed).toHaveBeenCalledTimes(1);
+    expect(chat.complete).not.toHaveBeenCalled();
+  });
+
+  it("skips complete when non-agentic setup fails before generation exists", async () => {
+    const chat = createMockChat({ useAgenticAila: false });
+    chat.generation = undefined;
+    chat.setupGeneration = jest
+      .fn()
+      .mockRejectedValue(new Error("Generation setup failed"));
+
+    const handler = new AilaStreamHandler(chat as never);
+    await consumeStream(handler.startStreaming());
+
+    expect(chat.generationFailed).not.toHaveBeenCalled();
     expect(chat.complete).not.toHaveBeenCalled();
   });
 

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -6,6 +6,7 @@ import type {
 import { aiLogger } from "@oakai/logger";
 import type { getRagLessonPlansByIds } from "@oakai/rag";
 
+import type OpenAI from "openai";
 import type { ReadableStreamDefaultController } from "stream/web";
 
 import { createOpenAIBritishEnglishCorrectorAgent } from "../../lib/agentic-system/agents/britishEnglishCorrectorAgent";
@@ -15,7 +16,11 @@ import { createSectionAgentRegistry } from "../../lib/agentic-system/agents/sect
 import { ailaTurn } from "../../lib/agentic-system/ailaTurn";
 import { createAilaTurnCallbacks } from "../../lib/agentic-system/compatibility/ailaTurnCallbacks";
 import { deriveQuizBuildMode } from "../../lib/agentic-system/quizOperations/deriveQuizBuildMode";
-import type { AilaTurnOutcome } from "../../lib/agentic-system/types";
+import type {
+  AilaTurnOutcome,
+  SectionAgent,
+} from "../../lib/agentic-system/types";
+import type { LatestQuiz } from "../../protocol/schema";
 import { extractPromptTextFromMessages } from "../../utils/extractPromptTextFromMessages";
 import { handleThreatDetectionResult } from "../../utils/threatDetection/threatDetectionHandling";
 import { AilaChatError } from "../AilaError";
@@ -33,28 +38,18 @@ type ThreatCheckOutcome =
 
 type StreamOutcome =
   | { status: "success" }
-  | { status: "failed"; error?: unknown }
+  | { status: "failed" }
   | { status: "aborted" }
   | { status: "threat_detected" }
-  | { status: "threat_check_failed"; error?: unknown };
+  | { status: "threat_check_failed" };
 
-type StreamReadOutcome = { status: "success" } | { status: "aborted" };
-
-type SectionAgentRegistryOptions = Parameters<
-  typeof createSectionAgentRegistry
->[0];
-type MathsQuizAgentHandlers =
-  SectionAgentRegistryOptions["customAgentHandlers"];
-type MathsQuizAgentContext = Parameters<
-  MathsQuizAgentHandlers["starterQuiz--maths"]
->[0];
-type MathsQuizAgentResult = Awaited<
-  ReturnType<MathsQuizAgentHandlers["starterQuiz--maths"]>
+type StreamReadOutcome = Extract<
+  StreamOutcome,
+  { status: "success" | "aborted" }
 >;
-
-function shouldComplete(outcome: StreamOutcome): boolean {
-  return outcome.status === "success";
-}
+type MathsQuizAgentHandler = SectionAgent<LatestQuiz>["handler"];
+type MathsQuizAgentContext = Parameters<MathsQuizAgentHandler>[0];
+type MathsQuizAgentResult = Awaited<ReturnType<MathsQuizAgentHandler>>;
 
 class ThreatDetectionFailureError extends Error {
   public readonly detectorName: string;
@@ -188,47 +183,27 @@ export class AilaStreamHandler {
         this._chat.id,
       );
     } catch (e) {
-      outcome = { status: "failed", error: e };
-      if (this._chat.aila.options.useAgenticAila) {
-        // ailaTurn threw rather than returning; its internal failure path never
-        // completed, so the client has not received an error message.
-        await this._chat.enqueue({
-          type: "error",
-          value: "Something went wrong. Please try sending your message again.",
-        });
-      } else if (this._chat.generation) {
-        await this._chat.generationFailed(e);
-      }
+      outcome = { status: "failed" };
       log.info("Caught error in stream", {
         error: e,
         type: e?.constructor?.name,
       });
       await this.handleStreamError(e);
     } finally {
-      const status = this._chat.generation?.status;
-      log.info("In finally block", {
-        outcome,
-        status,
-        chatId: this._chat.id,
-      });
-      if (shouldComplete(outcome)) {
-        try {
-          await this.span("chat-completion", async () => {
-            await this._chat.complete();
-          });
-          log.info("Chat completed", this._chat.iteration, this._chat.id);
-        } catch (e) {
-          log.error("Error in complete", e);
-          this._chat.aila.errorReporter?.reportError(e);
-          await this._chat.enqueue({
-            type: "error",
-            value:
-              "Something went wrong. Please try sending your message again.",
-          });
+      try {
+        const status = this._chat.generation?.status;
+        log.info("In finally block", {
+          outcome,
+          status,
+          chatId: this._chat.id,
+        });
+        if (outcome.status === "success") {
+          await this.completeChat();
         }
+      } finally {
+        this.closeController();
+        log.info("Stream closed", this._chat.iteration, this._chat.id);
       }
-      this.closeController();
-      log.info("Stream closed", this._chat.iteration, this._chat.id);
     }
   }
 
@@ -262,7 +237,6 @@ export class AilaStreamHandler {
       });
       return {
         status: "threat_check_failed",
-        error: threatCheckOutcome.error,
       };
     }
 
@@ -392,14 +366,63 @@ export class AilaStreamHandler {
     });
   }
 
-  private createSectionAgents(openai: SectionAgentRegistryOptions["openai"]) {
+  private async notifyClientOfStreamError(error: unknown) {
+    try {
+      if (this._chat.aila.options.useAgenticAila) {
+        // ailaTurn threw rather than returning; its internal failure path never
+        // completed, so the client has not received an error message.
+        await this.enqueueGenericRetryError();
+      } else if (this._chat.generation) {
+        await this._chat.generationFailed(error);
+      }
+    } catch (recoveryError) {
+      log.error("Error while handling stream failure", {
+        error: recoveryError,
+        originalError: error,
+      });
+      this._chat.aila.errorReporter?.reportError(recoveryError);
+    }
+  }
+
+  private async completeChat() {
+    try {
+      await this.span("chat-completion", async () => {
+        await this._chat.complete();
+      });
+      log.info("Chat completed", this._chat.iteration, this._chat.id);
+    } catch (error) {
+      log.error("Error in complete", error);
+      this._chat.aila.errorReporter?.reportError(error);
+      try {
+        await this.enqueueGenericRetryError();
+      } catch (enqueueError) {
+        log.error("Error enqueueing completion failure message", {
+          error: enqueueError,
+          completionError: error,
+        });
+        this._chat.aila.errorReporter?.reportError(enqueueError);
+      }
+    }
+  }
+
+  private async enqueueGenericRetryError() {
+    await this._chat.enqueue({
+      type: "error",
+      value: "Something went wrong. Please try sending your message again.",
+    });
+  }
+
+  private createSectionAgents(openai: OpenAI) {
     return createSectionAgentRegistry({
       openai,
       customAgentHandlers: this.createMathsQuizAgentHandlers(),
     });
   }
 
-  private createMathsQuizAgentHandlers(): MathsQuizAgentHandlers {
+  private createMathsQuizAgentHandlers(): {
+    "starterQuiz--maths": MathsQuizAgentHandler;
+    "exitQuiz--maths": MathsQuizAgentHandler;
+  } {
     return {
       "starterQuiz--maths": async (ctx) =>
         await this.runMathsQuizAgent(
@@ -531,6 +554,8 @@ export class AilaStreamHandler {
   }
 
   private async handleStreamError(error: unknown) {
+    await this.notifyClientOfStreamError(error);
+
     for (const plugin of this._chat.aila.plugins ?? []) {
       await plugin.onStreamError?.(error, {
         aila: this._chat.aila,

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -14,13 +14,8 @@ import { createOpenAIPlannerAgent } from "../../lib/agentic-system/agents/planne
 import { createSectionAgentRegistry } from "../../lib/agentic-system/agents/sectionAgents/sectionAgentRegistry";
 import { ailaTurn } from "../../lib/agentic-system/ailaTurn";
 import { createAilaTurnCallbacks } from "../../lib/agentic-system/compatibility/ailaTurnCallbacks";
-import { createEmptyCorrectorStats } from "../../lib/agentic-system/correctorStats";
 import { deriveQuizBuildMode } from "../../lib/agentic-system/quizOperations/deriveQuizBuildMode";
-import type {
-  AilaTurnOutcome,
-  SectionAgent,
-} from "../../lib/agentic-system/types";
-import type { LatestQuiz } from "../../protocol/schema";
+import type { AilaTurnOutcome } from "../../lib/agentic-system/types";
 import { extractPromptTextFromMessages } from "../../utils/extractPromptTextFromMessages";
 import { handleThreatDetectionResult } from "../../utils/threatDetection/threatDetectionHandling";
 import { AilaChatError } from "../AilaError";
@@ -31,14 +26,35 @@ import type { Message } from "./types";
 
 const log = aiLogger("aila:stream");
 
-function agenticTurnSucceeded(outcome: AilaTurnOutcome | null): boolean {
-  return outcome?.status === "success";
-}
-
 type ThreatCheckOutcome =
   | { status: "safe" }
   | { status: "threat_detected"; threatDetection: ThreatDetectionResult }
   | { status: "check_failed"; error: Error; detectorName: string };
+
+type StreamOutcome =
+  | { status: "success" }
+  | { status: "failed"; error?: unknown }
+  | { status: "aborted" }
+  | { status: "threat_detected" }
+  | { status: "threat_check_failed"; error?: unknown };
+
+type StreamReadOutcome = { status: "success" } | { status: "aborted" };
+
+type SectionAgentRegistryOptions = Parameters<
+  typeof createSectionAgentRegistry
+>[0];
+type MathsQuizAgentHandlers =
+  SectionAgentRegistryOptions["customAgentHandlers"];
+type MathsQuizAgentContext = Parameters<
+  MathsQuizAgentHandlers["starterQuiz--maths"]
+>[0];
+type MathsQuizAgentResult = Awaited<
+  ReturnType<MathsQuizAgentHandlers["starterQuiz--maths"]>
+>;
+
+function shouldComplete(outcome: StreamOutcome): boolean {
+  return outcome.status === "success";
+}
 
 class ThreatDetectionFailureError extends Error {
   public readonly detectorName: string;
@@ -145,19 +161,9 @@ export class AilaStreamHandler {
   ) {
     log.info("Starting stream", { chatId: this._chat.id });
     this.setupController(controller);
-    let agenticTurnOutcome: AilaTurnOutcome | null = null;
-    let skipCompletion = false;
+    let outcome: StreamOutcome = { status: "failed" };
     try {
-      if (!this._chat.aila.options.useAgenticAila) {
-        await this.span("set-up-generation", async () => {
-          await this._chat.setupGeneration();
-        });
-      } else {
-        await this.span("initialise-chunks", () => {
-          this._chat.initialiseChunks();
-          return Promise.resolve();
-        });
-      }
+      await this.setupStreamMode();
 
       await this.span("persist-chat-before-threat-check", async () => {
         await this._chat.persistChat();
@@ -167,44 +173,14 @@ export class AilaStreamHandler {
         return await this.checkForThreats();
       });
 
-      if (threatCheckOutcome.status === "threat_detected") {
-        skipCompletion = true;
-        await this.span("handle-threat-detected", async () => {
-          await this.enqueueThreatResponse(threatCheckOutcome.threatDetection);
-        });
+      const threatOutcome =
+        await this.handleThreatCheckOutcome(threatCheckOutcome);
+      if (threatOutcome) {
+        outcome = threatOutcome;
         return;
       }
 
-      if (threatCheckOutcome.status === "check_failed") {
-        skipCompletion = true;
-        await this.span("handle-threat-check-failure", async () => {
-          await this.handleThreatDetectionFailure(threatCheckOutcome);
-        });
-        return;
-      }
-
-      if (this._chat.aila.options.useAgenticAila) {
-        agenticTurnOutcome = await this.span("start-agent-stream", async () => {
-          return await this.startAgentStream();
-        });
-      } else {
-        await this.span("set-initial-state", async () => {
-          await this._chat.handleSettingInitialState();
-        });
-
-        await this.span("handle-subject-warning", async () => {
-          await this._chat.handleSubjectWarning();
-        });
-        await this.span("start-llm-stream", async () => {
-          await this.startLLMStream();
-        });
-        await this.span("read-from-stream", async () => {
-          await this.readFromStream(abortController);
-        });
-        if (abortController?.signal.aborted) {
-          skipCompletion = true;
-        }
-      }
+      outcome = await this.runTurn(abortController);
 
       log.info(
         "Finished reading from stream",
@@ -212,11 +188,8 @@ export class AilaStreamHandler {
         this._chat.id,
       );
     } catch (e) {
+      outcome = { status: "failed", error: e };
       if (this._chat.aila.options.useAgenticAila) {
-        agenticTurnOutcome = {
-          status: "failed",
-          correctorStats: createEmptyCorrectorStats(),
-        };
         // ailaTurn threw rather than returning; its internal failure path never
         // completed, so the client has not received an error message.
         await this._chat.enqueue({
@@ -224,8 +197,6 @@ export class AilaStreamHandler {
           value: "Something went wrong. Please try sending your message again.",
         });
       } else if (this._chat.generation) {
-        // Sets status → FAILED so the finally block skips complete() (and moderation).
-        skipCompletion = true;
         await this._chat.generationFailed(e);
       }
       log.info("Caught error in stream", {
@@ -235,18 +206,12 @@ export class AilaStreamHandler {
       await this.handleStreamError(e);
     } finally {
       const status = this._chat.generation?.status;
-      const shouldComplete = this._chat.aila.options.useAgenticAila
-        ? agenticTurnSucceeded(agenticTurnOutcome)
-        : status !== "FAILED";
       log.info("In finally block", {
+        outcome,
         status,
-        agenticTurn: agenticTurnOutcome
-          ? { status: agenticTurnOutcome.status }
-          : null,
-        skipCompletion,
         chatId: this._chat.id,
       });
-      if (shouldComplete && !skipCompletion) {
+      if (shouldComplete(outcome)) {
         try {
           await this.span("chat-completion", async () => {
             await this._chat.complete();
@@ -265,6 +230,80 @@ export class AilaStreamHandler {
       this.closeController();
       log.info("Stream closed", this._chat.iteration, this._chat.id);
     }
+  }
+
+  private async setupStreamMode() {
+    if (!this._chat.aila.options.useAgenticAila) {
+      await this.span("set-up-generation", async () => {
+        await this._chat.setupGeneration();
+      });
+      return;
+    }
+
+    await this.span("initialise-chunks", () => {
+      this._chat.initialiseChunks();
+      return Promise.resolve();
+    });
+  }
+
+  private async handleThreatCheckOutcome(
+    threatCheckOutcome: ThreatCheckOutcome,
+  ): Promise<StreamOutcome | null> {
+    if (threatCheckOutcome.status === "threat_detected") {
+      await this.span("handle-threat-detected", async () => {
+        await this.enqueueThreatResponse(threatCheckOutcome.threatDetection);
+      });
+      return { status: "threat_detected" };
+    }
+
+    if (threatCheckOutcome.status === "check_failed") {
+      await this.span("handle-threat-check-failure", async () => {
+        await this.handleThreatDetectionFailure(threatCheckOutcome);
+      });
+      return {
+        status: "threat_check_failed",
+        error: threatCheckOutcome.error,
+      };
+    }
+
+    return null;
+  }
+
+  private async runTurn(
+    abortController?: AbortController,
+  ): Promise<StreamOutcome> {
+    if (this._chat.aila.options.useAgenticAila) {
+      return await this.runAgenticTurn();
+    }
+
+    return await this.runNonAgenticTurn(abortController);
+  }
+
+  private async runAgenticTurn(): Promise<StreamOutcome> {
+    return await this.span("start-agent-stream", async () => {
+      const agenticTurnOutcome = await this.startAgentStream();
+      return agenticTurnOutcome.status === "success"
+        ? { status: "success" }
+        : { status: "failed" };
+    });
+  }
+
+  private async runNonAgenticTurn(
+    abortController?: AbortController,
+  ): Promise<StreamOutcome> {
+    await this.span("set-initial-state", async () => {
+      await this._chat.handleSettingInitialState();
+    });
+
+    await this.span("handle-subject-warning", async () => {
+      await this._chat.handleSubjectWarning();
+    });
+    await this.span("start-llm-stream", async () => {
+      await this.startLLMStream();
+    });
+    return await this.span("read-from-stream", async () => {
+      return await this.readFromStream(abortController);
+    });
   }
 
   private setupController(controller: ReadableStreamDefaultController) {
@@ -298,45 +337,6 @@ export class AilaStreamHandler {
       },
     });
 
-    // starterQuiz and exitQuiz only differ by quiz path and the words used in
-    // their messages; everything else is the same maths-engine build flow.
-    const buildMathsQuizHandler =
-      (
-        quizType: "/starterQuiz" | "/exitQuiz",
-        quizNoun: string,
-      ): SectionAgent<LatestQuiz>["handler"] =>
-      async (ctx) => {
-        try {
-          const userInstructions =
-            ctx.currentTurn.currentStep?.sectionInstructions;
-          const mode = deriveQuizBuildMode(ctx.currentTurn.currentStep);
-          const tracker = createQuizTracker();
-          const { quiz, note } = await tracker.run(async (task, reportId) => {
-            const result = await this._chat.quizService.buildQuiz(
-              quizType,
-              ctx.currentTurn.document,
-              this._chat.relevantLessons ?? [],
-              task,
-              reportId,
-              mode,
-              userInstructions,
-            );
-            task.addData({ quiz: result.quiz, mode, userInstructions });
-            return result;
-          });
-          await ReportStorage.store(tracker.getReport());
-
-          return { error: null, data: quiz, note };
-        } catch (error) {
-          log.error(`Error generating ${quizNoun}`, { error });
-          return {
-            error: {
-              message: `Failed to generate a ${quizNoun} with maths quiz engine`,
-            },
-          };
-        }
-      };
-
     let relevantLessonsPopulated: Awaited<
       ReturnType<typeof getRagLessonPlansByIds>
     > = [];
@@ -363,16 +363,7 @@ export class AilaStreamHandler {
           mathsQuizEnabled: true,
         },
         plannerAgent: createOpenAIPlannerAgent(openai),
-        sectionAgents: createSectionAgentRegistry({
-          openai,
-          customAgentHandlers: {
-            "starterQuiz--maths": buildMathsQuizHandler(
-              "/starterQuiz",
-              "starter quiz",
-            ),
-            "exitQuiz--maths": buildMathsQuizHandler("/exitQuiz", "exit quiz"),
-          },
-        }),
+        sectionAgents: this.createSectionAgents(openai),
         messageToUserAgent: createOpenAIMessageToUserAgent(openai),
         britishEnglishCorrectorAgent:
           createOpenAIBritishEnglishCorrectorAgent(openai),
@@ -401,6 +392,68 @@ export class AilaStreamHandler {
     });
   }
 
+  private createSectionAgents(openai: SectionAgentRegistryOptions["openai"]) {
+    return createSectionAgentRegistry({
+      openai,
+      customAgentHandlers: this.createMathsQuizAgentHandlers(),
+    });
+  }
+
+  private createMathsQuizAgentHandlers(): MathsQuizAgentHandlers {
+    return {
+      "starterQuiz--maths": async (ctx) =>
+        await this.runMathsQuizAgent(
+          ctx,
+          "/starterQuiz",
+          "starter quiz",
+          "Failed to generate a starter quiz with maths quiz engine",
+        ),
+      "exitQuiz--maths": async (ctx) =>
+        await this.runMathsQuizAgent(
+          ctx,
+          "/exitQuiz",
+          "exit quiz",
+          "Failed to generate an exit quiz with maths quiz engine",
+        ),
+    };
+  }
+
+  private async runMathsQuizAgent(
+    ctx: MathsQuizAgentContext,
+    quizPath: "/starterQuiz" | "/exitQuiz",
+    quizName: string,
+    failureMessage: string,
+  ): Promise<MathsQuizAgentResult> {
+    try {
+      const userInstructions = ctx.currentTurn.currentStep?.sectionInstructions;
+      const mode = deriveQuizBuildMode(ctx.currentTurn.currentStep);
+      const tracker = createQuizTracker();
+      const { quiz, note } = await tracker.run(async (task, reportId) => {
+        const result = await this._chat.quizService.buildQuiz(
+          quizPath,
+          ctx.currentTurn.document,
+          this._chat.relevantLessons ?? [],
+          task,
+          reportId,
+          mode,
+          userInstructions,
+        );
+        task.addData({ quiz: result.quiz, mode, userInstructions });
+        return result;
+      });
+      await ReportStorage.store(tracker.getReport());
+
+      return { error: null, data: quiz, note };
+    } catch (error) {
+      log.error(`Error generating ${quizName}`, { error });
+      return {
+        error: {
+          message: failureMessage,
+        },
+      };
+    }
+  }
+
   private async startLLMStream() {
     await this._chat.enqueue({
       type: "comment",
@@ -411,7 +464,9 @@ export class AilaStreamHandler {
       await this._chat.createChatCompletionObjectStream(messages);
   }
 
-  private async readFromStream(abortController?: AbortController) {
+  private async readFromStream(
+    abortController?: AbortController,
+  ): Promise<StreamReadOutcome> {
     if (!this._streamReader) {
       throw new Error("Stream reader is not defined");
     }
@@ -428,10 +483,16 @@ export class AilaStreamHandler {
           this._controller?.enqueue(value);
         }
       }
+      if (abortController?.signal.aborted) {
+        log.info("Stream aborted", this._chat.iteration, this._chat.id);
+        return { status: "aborted" };
+      }
+      return { status: "success" };
     } catch (e) {
       log.error("Error reading from stream", { error: e });
       if (abortController?.signal.aborted) {
         log.info("Stream aborted", this._chat.iteration, this._chat.id);
+        return { status: "aborted" };
       } else {
         throw e;
       }

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -6,7 +6,6 @@ import type {
 import { aiLogger } from "@oakai/logger";
 import type { getRagLessonPlansByIds } from "@oakai/rag";
 
-import type OpenAI from "openai";
 import type { ReadableStreamDefaultController } from "stream/web";
 
 import { createOpenAIBritishEnglishCorrectorAgent } from "../../lib/agentic-system/agents/britishEnglishCorrectorAgent";
@@ -43,10 +42,6 @@ type StreamOutcome =
   | { status: "threat_detected" }
   | { status: "threat_check_failed" };
 
-type StreamReadOutcome = Extract<
-  StreamOutcome,
-  { status: "success" | "aborted" }
->;
 type MathsQuizAgentHandler = SectionAgent<LatestQuiz>["handler"];
 type MathsQuizAgentContext = Parameters<MathsQuizAgentHandler>[0];
 type MathsQuizAgentResult = Awaited<ReturnType<MathsQuizAgentHandler>>;
@@ -337,7 +332,10 @@ export class AilaStreamHandler {
           mathsQuizEnabled: true,
         },
         plannerAgent: createOpenAIPlannerAgent(openai),
-        sectionAgents: this.createSectionAgents(openai),
+        sectionAgents: createSectionAgentRegistry({
+          openai,
+          customAgentHandlers: this.createMathsQuizAgentHandlers(),
+        }),
         messageToUserAgent: createOpenAIMessageToUserAgent(openai),
         britishEnglishCorrectorAgent:
           createOpenAIBritishEnglishCorrectorAgent(openai),
@@ -366,7 +364,7 @@ export class AilaStreamHandler {
     });
   }
 
-  private async notifyClientOfStreamError(error: unknown) {
+  private async onStreamFailed(error: unknown) {
     try {
       if (this._chat.aila.options.useAgenticAila) {
         // ailaTurn threw rather than returning; its internal failure path never
@@ -409,13 +407,6 @@ export class AilaStreamHandler {
     await this._chat.enqueue({
       type: "error",
       value: "Something went wrong. Please try sending your message again.",
-    });
-  }
-
-  private createSectionAgents(openai: OpenAI) {
-    return createSectionAgentRegistry({
-      openai,
-      customAgentHandlers: this.createMathsQuizAgentHandlers(),
     });
   }
 
@@ -489,7 +480,7 @@ export class AilaStreamHandler {
 
   private async readFromStream(
     abortController?: AbortController,
-  ): Promise<StreamReadOutcome> {
+  ): Promise<{ status: "success" | "aborted" }> {
     if (!this._streamReader) {
       throw new Error("Stream reader is not defined");
     }
@@ -554,7 +545,7 @@ export class AilaStreamHandler {
   }
 
   private async handleStreamError(error: unknown) {
-    await this.notifyClientOfStreamError(error);
+    await this.onStreamFailed(error);
 
     for (const plugin of this._chat.aila.plugins ?? []) {
       await plugin.onStreamError?.(error, {

--- a/packages/exports/jest.config.mjs
+++ b/packages/exports/jest.config.mjs
@@ -12,6 +12,7 @@ const config = {
   },
   preset: "ts-jest/presets/default-esm",
   moduleNameMapper: {
+    "^@oakai/core/src/(.*)$": "<rootDir>/../core/src/$1",
     "^@oakai/test-support$": "<rootDir>/../test-support/index.cjs",
     "^@oakai/test-support/jest$": "<rootDir>/../test-support/jest.cjs",
     "^(\\.{1,2}/.*)\\.js$": "$1",

--- a/packages/exports/tsconfig.json
+++ b/packages/exports/tsconfig.json
@@ -5,6 +5,9 @@
   },
   "include": ["src/**/*.ts", "index.ts", "*.ts"],
   "compilerOptions": {
-    "baseUrl": "./src"
+    "baseUrl": "./src",
+    "paths": {
+      "@oakai/core/src/*": ["../../core/src/*"]
+    }
   }
 }


### PR DESCRIPTION
## Description

This PR refactors `AilaStreamHandler` to make stream outcomes explicit and reduce completion/error-handling coupling. The handler now decides whether to complete from a clear `StreamOutcome` rather than a mix of generation status, agentic turn state, and skip flags.

Additionally the monolithic `stream` function has been broken into a series of smaller focused helpers.

This makes the stream lifecycle easier to reason about and safer in failure paths. In particular, secondary recovery failures no longer mask the original stream error, completion failures still close the stream cleanly, and abort/threat/error paths explicitly skip completion.

- Also includes a small exports test/TS resolver configuration fix for `@oakai/core` workspace imports so the full suite resolves consistently.

## Issue(s)

Fixes #AI-2210

## How to test

1. Go to <!-- vercel-preview -->{deployment_url}<!-- /vercel-preview -->
2. Confirm lesson generation remains functional for both agentic and non-agentic modes