### PR TITLE
fix: add missing subjects - AI-2304

### DIFF
--- a/packages/api/src/router/owaLesson/schemas.ts
+++ b/packages/api/src/router/owaLesson/schemas.ts
@@ -10,7 +10,7 @@ import { z } from "zod";
 const subjectSchema = z.union([
   subjects,
   z.literal("Rule of law"),
-  z.literal("Digital Literacy"),
+  z.literal("Digital literacy"),
 ]);
 
 const subjectSlugSchema = z.union([

--- a/packages/api/src/router/owaLesson/schemas.ts
+++ b/packages/api/src/router/owaLesson/schemas.ts
@@ -1,9 +1,33 @@
 import {
   lessonContentSchema as lessonContentSchemaFull,
+  subjectSlugs,
+  subjects,
   syntheticUnitvariantLessonsByKsSchema,
   syntheticUnitvariantLessonsSchema,
 } from "@oaknational/oak-curriculum-schema";
 import { z } from "zod";
+
+const subjectSchema = z.union([
+  subjects,
+  z.literal("Rule of law"),
+  z.literal("Digital Literacy"),
+]);
+
+const subjectSlugSchema = z.union([
+  subjectSlugs,
+  z.literal("rule-of-law"),
+  z.literal("digital-literacy"),
+]);
+
+const programmeFieldsSchema = z
+  .object({
+    subject: subjectSchema.nullish(),
+    subject_slug: subjectSlugSchema.nullish(),
+    phase: z.string().nullish(),
+    keystage: z.string().nullish(),
+    year: z.string().nullish(),
+  })
+  .passthrough();
 
 export const lessonContentSchema = lessonContentSchemaFull
   .pick({
@@ -39,6 +63,7 @@ export const lessonBrowseDataByKsSchema = syntheticUnitvariantLessonsSchema
     supplementary_data: true,
     null_unitvariant_id: true,
     unit_data: true,
+    programme_fields: true,
   })
   .extend({
     lesson_data: z.object({
@@ -51,11 +76,22 @@ export const lessonBrowseDataByKsSchema = syntheticUnitvariantLessonsSchema
       prior_knowledge_requirements: z.array(z.string()).nullish(),
       connection_prior_unit_description: z.string().nullish(),
     }),
+    programme_fields: programmeFieldsSchema,
   });
 
-export type LessonBrowseDataByKsSchema = z.infer<
+type LessonBrowseDataByKsSchemaBase = z.infer<
   typeof lessonBrowseDataByKsSchema
 >;
+
+export type LessonBrowseDataByKsSchema = LessonBrowseDataByKsSchemaBase & {
+  programme_fields: {
+    subject?: string | null;
+    subject_slug?: string | null;
+    phase?: string | null;
+    keystage?: string | null;
+    year?: string | null;
+  };
+};
 
 export type LessonContentSchema = z.infer<typeof lessonContentSchema>;
 


### PR DESCRIPTION
## Description

This is a temp fix for create with Ai generations where there is a schema mismatch. More details in the ticket and linked slack message. Two new subjects have been added to the schema. Rule of law and digital literacy

The curriculum schema has moved to new repo, there have been some breaking changes to the quiz and there is a zod mismatch with this repo.

We need to upgrade to zod 4 to use the new scheme and resolve the new schema shapes. 

I have added a new housekeeping task for this which should be set as high priority.
https://app.notion.com/p/oaknationalacademy/Migrate-zod-to-v4-and-update-to-new-Curriculum-schema-38926cc4e1b180f9a3d2d04c0f7b92d8

Fixes #

## How to test

1. Go to <!-- vercel-preview -->https://oak-ai-lesson-assistant-website-aqob0yxj9.vercel.thenational.academy<!-- /vercel-preview -->

Check you can create a teaching material with 

aila/teaching-materials?lessonSlug=how-does-the-rule-of-law-help-people-live-together-in-society&programmeSlug=rule-of-law-primary-ks2&docType=additional-comprehension


## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
