### PR TITLE
chore(claude): remove pre-commit reminder Bash hook

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -8,17 +8,6 @@
     ]
   },
   "hooks": {
-    "PreToolUse": [
-      {
-        "matcher": "Bash",
-        "hooks": [
-          {
-            "type": "command",
-            "command": ".claude/hooks/pre-commit-reminder.sh"
-          }
-        ]
-      }
-    ],
     "PostToolUse": [
       {
         "matcher": "Edit|Write",


### PR DESCRIPTION
## Description

Removes the `PreToolUse` Bash hook from `.claude/settings.json` that pointed at `.claude/hooks/pre-commit-reminder.sh`. The script it referenced is no longer present in the repo, so the hook would give a warning on every `Bash` tool call.

## Issue(s)

N/A

## How to test

No need for testing, as this only touches local Claude Code tooling config. No application or runtime behaviour is affected.

## Screenshots

n/a — no UI change.

## Checklist

- [ ] ~~Manually tested across browsers / devices~~ (tooling config only, no runtime change)
- [ ] ~~Considered impact on accessibility~~ (no UI change)
- [ ] ~~Does this PR update a package with a breaking change~~ (no)
