### PR TITLE
fix: render MathJax in chat markdown

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-message/ChatMessagePart.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-message/ChatMessagePart.stories.tsx
@@ -3,6 +3,7 @@ import type { MessagePart } from "@oakai/aila/src/protocol/jsonPatchProtocol";
 import type { Meta, StoryObj } from "@storybook/nextjs";
 
 import { chromaticParams } from "@/storybook/chromatic";
+import { MathJaxDecorator } from "@/storybook/decorators/MathJaxDecorator";
 
 import { ChatMessagePart } from "./ChatMessagePart";
 
@@ -10,6 +11,7 @@ const meta = {
   title: "Components/Chat/ChatMessagePart",
   component: ChatMessagePart,
   tags: ["autodocs"],
+  decorators: [MathJaxDecorator],
   args: {
     inspect: false,
   },
@@ -61,6 +63,47 @@ export const TextMessagePart: Story = {
         type: "text",
         value:
           "Are the learning outcome and learning cycles appropriate for your pupils? If not, suggest an edit. Otherwise, tap **Continue** to move on to the next step.",
+      },
+    },
+  },
+};
+
+export const TextMessagePartWithMaths: Story = {
+  args: {
+    part: {
+      ...basePart,
+      document: {
+        type: "text",
+        value: "The new value is \\(x = 6\\), so the area is $$36cm^2$$.",
+      },
+    },
+  },
+};
+
+export const TextMessagePartWithComplexMathsMarkdown: Story = {
+  args: {
+    part: {
+      ...basePart,
+      document: {
+        type: "text",
+        value: [
+          "Here is a worked example with mixed markdown and maths.",
+          "",
+          "- Start with \\(x_i + \\frac{1}{2}x^2 = 40\\).",
+          "- Rearrange to find \\[x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}\\]",
+          "- The final area is $$36cm^2$$.",
+          "",
+          "| Step | Expression |",
+          "| --- | --- |",
+          "| Substitute | \\(2x + 4 = 16\\) |",
+          "| Solve | \\(x = 6\\) |",
+          "",
+          "Inline code should stay literal: `\\(not maths\\)`",
+          "",
+          "```",
+          "\\[also not maths\\]",
+          "```",
+        ].join("\n"),
       },
     },
   },

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-message/ChatMessagePart.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-message/ChatMessagePart.tsx
@@ -7,6 +7,7 @@ import type {
 import { aiLogger } from "@oakai/logger";
 
 import { MemoizedReactMarkdownWithStyles } from "@/components/AppComponents/Chat/markdown";
+import { MathJaxWrap } from "@/components/MathJax";
 
 const log = aiLogger("chat");
 
@@ -60,7 +61,7 @@ function NonRenderedPart() {
 }
 
 function PromptMessagePart({ part }: Readonly<{ part: PromptDocument }>) {
-  return <MemoizedReactMarkdownWithStyles markdown={part.message} />;
+  return <MarkdownMessage markdown={part.message} />;
 }
 
 function ErrorMessagePart({
@@ -69,11 +70,19 @@ function ErrorMessagePart({
   part: ErrorDocument;
 }>) {
   const markdown = part.message ?? "Sorry, an error has occurred";
-  return <MemoizedReactMarkdownWithStyles markdown={markdown} />;
+  return <MarkdownMessage markdown={markdown} />;
 }
 
 function TextMessagePart({ part }: Readonly<{ part: TextDocument }>) {
-  return <MemoizedReactMarkdownWithStyles markdown={part.value} />;
+  return <MarkdownMessage markdown={part.value} />;
+}
+
+function MarkdownMessage({ markdown }: Readonly<{ markdown: string }>) {
+  return (
+    <MathJaxWrap>
+      <MemoizedReactMarkdownWithStyles markdown={markdown} />
+    </MathJaxWrap>
+  );
 }
 
 function PartInspector({ part }: Readonly<{ part: MessagePart }>) {

--- a/apps/nextjs/src/components/AppComponents/Chat/markdown.test.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/markdown.test.tsx
@@ -118,4 +118,26 @@ describe("preserveMathJaxDelimiters", () => {
       "text `\\\\( x \\\\) end`` after",
     );
   });
+
+  it("converts [math]...[/math] to MathJax inline delimiters", () => {
+    const markdown = String.raw`Explain roots such as [math]x^{1/2}[/math] for square roots.`;
+
+    expect(preserveMathJaxDelimiters(markdown)).toBe(
+      String.raw`Explain roots such as \\(x^{1/2}\\) for square roots.`,
+    );
+  });
+
+  it("converts multiple [math]...[/math] occurrences on one line", () => {
+    const markdown = String.raw`Use [math]x^{1/2}[/math] and [math]x^{1/3}[/math].`;
+
+    expect(preserveMathJaxDelimiters(markdown)).toBe(
+      String.raw`Use \\(x^{1/2}\\) and \\(x^{1/3}\\).`,
+    );
+  });
+
+  it("converts [math]...[/math] spanning multiple lines", () => {
+    const markdown = "[math]x =\n1[/math]";
+
+    expect(preserveMathJaxDelimiters(markdown)).toBe("\\\\(x =\n1\\\\)");
+  });
 });

--- a/apps/nextjs/src/components/AppComponents/Chat/markdown.test.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/markdown.test.tsx
@@ -1,0 +1,121 @@
+import { preserveMathJaxDelimiters } from "./mathjaxMarkdown";
+
+describe("preserveMathJaxDelimiters", () => {
+  it("escapes inline MathJax delimiters for markdown parsing", () => {
+    const markdown = String.raw`\( x + \frac{1}{2}x^2 = 40 \)`;
+
+    expect(preserveMathJaxDelimiters(markdown)).toBe(
+      String.raw`\\( x + \frac{1}{2}x^2 = 40 \\)`,
+    );
+  });
+
+  it("escapes display MathJax delimiters for markdown parsing", () => {
+    const markdown = String.raw`\[ x_i + y_j \]`;
+
+    expect(preserveMathJaxDelimiters(markdown)).toBe(
+      String.raw`\\[ x_i + y_j \\]`,
+    );
+  });
+
+  it("leaves dollar-delimited maths and LaTeX commands unchanged", () => {
+    const markdown = String.raw`$$ x + \frac{1}{2}x^2 = 40 $$`;
+
+    expect(preserveMathJaxDelimiters(markdown)).toBe(markdown);
+  });
+
+  it("does not double-escape delimiters that are already escaped for markdown", () => {
+    const markdown = String.raw`\\( x \\)`;
+
+    expect(preserveMathJaxDelimiters(markdown)).toBe(markdown);
+  });
+
+  it("escapes multiple MathJax expressions on the same line", () => {
+    const markdown = String.raw`Use \( x \) and \[ y \].`;
+
+    expect(preserveMathJaxDelimiters(markdown)).toBe(
+      String.raw`Use \\( x \\) and \\[ y \\].`,
+    );
+  });
+
+  it("leaves inline code spans unchanged", () => {
+    const markdown = "Use \\(\\) for maths, not `\\(\\)`";
+
+    expect(preserveMathJaxDelimiters(markdown)).toBe(
+      "Use \\\\(\\\\) for maths, not `\\(\\)`",
+    );
+  });
+
+  it("leaves backtick fenced code blocks unchanged", () => {
+    const markdown = [
+      "Before \\( x \\)",
+      "```ts",
+      "\\( code \\)",
+      "```not-a-closing-fence",
+      "\\( more code \\)",
+      "```",
+      "After \\( y \\)",
+    ].join("\n");
+
+    expect(preserveMathJaxDelimiters(markdown)).toBe(
+      [
+        "Before \\\\( x \\\\)",
+        "```ts",
+        "\\( code \\)",
+        "```not-a-closing-fence",
+        "\\( more code \\)",
+        "```",
+        "After \\\\( y \\\\)",
+      ].join("\n"),
+    );
+  });
+
+  it("leaves tilde fenced code blocks unchanged", () => {
+    const markdown = [
+      "Before \\( x \\)",
+      "~~~",
+      "\\[ code \\]",
+      "~~~",
+      "After \\[ y \\]",
+    ].join("\n");
+
+    expect(preserveMathJaxDelimiters(markdown)).toBe(
+      [
+        "Before \\\\( x \\\\)",
+        "~~~",
+        "\\[ code \\]",
+        "~~~",
+        "After \\\\[ y \\\\]",
+      ].join("\n"),
+    );
+  });
+
+  it("leaves plain prose unchanged", () => {
+    const markdown = "The answer is 42, not (x + y).";
+
+    expect(preserveMathJaxDelimiters(markdown)).toBe(markdown);
+  });
+
+  it("does not escape LaTeX commands like \\left( and \\right) inside math", () => {
+    const markdown = String.raw`\( \left(\frac{x}{2}\right) = 1 \)`;
+
+    expect(preserveMathJaxDelimiters(markdown)).toBe(
+      String.raw`\\( \left(\frac{x}{2}\right) = 1 \\)`,
+    );
+  });
+
+  it("escapes math inside markdown table cells", () => {
+    const markdown = String.raw`| Step | \( x = 6 \) |`;
+
+    expect(preserveMathJaxDelimiters(markdown)).toBe(
+      String.raw`| Step | \\( x = 6 \\) |`,
+    );
+  });
+
+  it("leaves inline code spans with no valid close unchanged", () => {
+    const markdown = "text `\\( x \\) end`` after";
+
+    expect(preserveMathJaxDelimiters(markdown)).toBe(
+      "text `\\\\( x \\\\) end`` after",
+    );
+  });
+});

--- a/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
@@ -7,6 +7,7 @@ import remarkGfm from "remark-gfm";
 
 import { cn } from "@/lib/utils";
 
+import { preserveMathJaxDelimiters } from "./mathjaxMarkdown";
 import { wrapWithUrlSafety } from "./markdown-url-safety";
 import { CodeBlock } from "./ui/codeblock";
 
@@ -39,15 +40,17 @@ const createComponents = (className?: string): Partial<Components> => ({
   blockquote: ({ children }) => <>{children}</>,
   code: (props) => {
     const {
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
       node,
       className,
       children,
-      inline,
       ...restProps
     } = props as {
-      node?: React.ReactNode;
-      inline?: boolean;
+      node?: {
+        position?: {
+          start?: { line?: number };
+          end?: { line?: number };
+        };
+      };
       className?: string;
       children?: React.ReactNode;
     };
@@ -60,10 +63,24 @@ const createComponents = (className?: string): Partial<Components> => ({
     }
 
     const match = /language-(\w+)/.exec(className ?? "");
+    const isCodeBlock =
+      Boolean(match) ||
+      node?.position?.start?.line !== node?.position?.end?.line;
 
-    if (inline) {
+    if (!isCodeBlock) {
       return (
-        <code className={className} {...restProps}>
+        <code
+          className={cn(
+            "not-prose rounded px-4 py-1 font-mono text-[0.9em]",
+            className,
+          )}
+          {...restProps}
+          style={{
+            backgroundColor: "#f2f2f2",
+            color: "#1a1a1a",
+            colorScheme: "light",
+          }}
+        >
           {children}
         </code>
       );
@@ -113,13 +130,17 @@ export const MemoizedReactMarkdownWithStyles = ({
       : defaultComponents;
     return wrapWithUrlSafety(merged);
   }, [className, customComponents]);
+  const processedMarkdown = useMemo(
+    () => preserveMathJaxDelimiters(markdown),
+    [markdown],
+  );
   return (
     <div className="prose break-words dark:prose-invert prose-p:leading-relaxed prose-pre:p-0">
       <MemoizedReactMarkdown
         remarkPlugins={[remarkGfm]}
         components={components}
       >
-        {markdown}
+        {processedMarkdown}
       </MemoizedReactMarkdown>
     </div>
   );

--- a/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/markdown.tsx
@@ -7,8 +7,8 @@ import remarkGfm from "remark-gfm";
 
 import { cn } from "@/lib/utils";
 
-import { preserveMathJaxDelimiters } from "./mathjaxMarkdown";
 import { wrapWithUrlSafety } from "./markdown-url-safety";
+import { preserveMathJaxDelimiters } from "./mathjaxMarkdown";
 import { CodeBlock } from "./ui/codeblock";
 
 const MemoizedReactMarkdown: FC<Options> = memo(
@@ -39,12 +39,7 @@ const createComponents = (className?: string): Partial<Components> => ({
   // Disable blockquote rendering to prevent answers like "> 90 degrees" from being styled as quotes
   blockquote: ({ children }) => <>{children}</>,
   code: (props) => {
-    const {
-      node,
-      className,
-      children,
-      ...restProps
-    } = props as {
+    const { node, className, children, ...restProps } = props as {
       node?: {
         position?: {
           start?: { line?: number };

--- a/apps/nextjs/src/components/AppComponents/Chat/mathjaxMarkdown.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/mathjaxMarkdown.ts
@@ -1,0 +1,115 @@
+const fencedCodeBlockPattern = /^( {0,3})(`{3,}|~{3,})(.*)$/;
+const mathJaxDelimiterChars = new Set(["(", ")", "[", "]"]);
+
+export const preserveMathJaxDelimiters = (markdown: string) => {
+  const lines = markdown.match(/[^\r\n]*(?:\r\n|\n|\r|$)/g) ?? [];
+  const chunks = lines.at(-1) === "" ? lines.slice(0, -1) : lines;
+  let fence: { marker: "`" | "~"; length: number } | null = null;
+
+  return chunks
+    .map((line) => {
+      const fenceMatch = getFenceMatch(line);
+
+      if (fence) {
+        if (isClosingFence(fenceMatch, fence)) {
+          fence = null;
+        }
+        return line;
+      }
+
+      if (fenceMatch) {
+        const delimiter = fenceMatch[2] ?? "";
+        fence = {
+          marker: delimiter[0] as "`" | "~",
+          length: delimiter.length,
+        };
+        return line;
+      }
+
+      return preserveInlineMathJaxDelimiters(line);
+    })
+    .join("");
+};
+
+const getFenceMatch = (line: string) =>
+  line.replace(/\r\n$|\n$|\r$/, "").match(fencedCodeBlockPattern);
+
+const isClosingFence = (
+  match: RegExpMatchArray | null,
+  fence: { marker: "`" | "~"; length: number },
+) => {
+  const delimiter = match?.[2] ?? "";
+  const suffix = match?.[3] ?? "";
+  return (
+    delimiter.startsWith(fence.marker) &&
+    delimiter.length >= fence.length &&
+    suffix.trim() === ""
+  );
+};
+
+const preserveInlineMathJaxDelimiters = (markdown: string) => {
+  let result = "";
+  let index = 0;
+
+  while (index < markdown.length) {
+    const openingBackticks = /`+/.exec(markdown.slice(index));
+
+    if (!openingBackticks) {
+      result += escapeMathJaxDelimiters(markdown.slice(index));
+      break;
+    }
+
+    const codeStart = index + openingBackticks.index;
+    const delimiter = openingBackticks[0];
+    // Find a closing delimiter that is a maximal backtick run (not adjacent to
+    // more backticks), matching the CommonMark spec for inline code spans.
+    let searchFrom = codeStart + delimiter.length;
+    let codeEnd = -1;
+    while (true) {
+      const candidate = markdown.indexOf(delimiter, searchFrom);
+      if (candidate === -1) break;
+      const prevChar = markdown[candidate - 1];
+      const nextChar = markdown[candidate + delimiter.length];
+      if (prevChar !== "`" && nextChar !== "`") {
+        codeEnd = candidate;
+        break;
+      }
+      searchFrom = candidate + 1;
+    }
+
+    if (codeEnd === -1) {
+      result += escapeMathJaxDelimiters(markdown.slice(index));
+      break;
+    }
+
+    result += escapeMathJaxDelimiters(markdown.slice(index, codeStart));
+    result += markdown.slice(codeStart, codeEnd + delimiter.length);
+    index = codeEnd + delimiter.length;
+  }
+
+  return result;
+};
+
+const escapeMathJaxDelimiters = (markdown: string) => {
+  let result = "";
+
+  for (let index = 0; index < markdown.length; index++) {
+    const character = markdown[index];
+    const nextCharacter = markdown[index + 1];
+
+    if (
+      character === "\\" &&
+      markdown[index - 1] !== "\\" &&
+      nextCharacter &&
+      mathJaxDelimiterChars.has(nextCharacter)
+    ) {
+      result += `\\\\${nextCharacter}`;
+      index++;
+      continue;
+    }
+
+    result += character;
+  }
+
+  return result;
+};

--- a/apps/nextjs/src/components/AppComponents/Chat/mathjaxMarkdown.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/mathjaxMarkdown.ts
@@ -1,8 +1,12 @@
 const fencedCodeBlockPattern = /^( {0,3})(`{3,}|~{3,})(.*)$/;
 const mathJaxDelimiterChars = new Set(["(", ")", "[", "]"]);
 
+const normalizeMathDelimiters = (markdown: string) =>
+  markdown.replace(/\[math\]([\s\S]*?)\[\/math\]/g, "\\($1\\)");
+
 export const preserveMathJaxDelimiters = (markdown: string) => {
-  const lines = markdown.match(/[^\r\n]*(?:\r\n|\n|\r|$)/g) ?? [];
+  const normalized = normalizeMathDelimiters(markdown);
+  const lines = normalized.match(/[^\r\n]*(?:\r\n|\n|\r|$)/g) ?? [];
   const chunks = lines.at(-1) === "" ? lines.slice(0, -1) : lines;
   let fence: { marker: "`" | "~"; length: number } | null = null;
 


### PR DESCRIPTION
## Description

This PR fixes a reported bug in which MathJax was being presented to users without proper formatting.

## How to test

1. Go to <!-- vercel-preview -->https://oak-ai-lesson-assistant-website-ht285fagh.vercel.thenational.academy<!-- /vercel-preview -->
2. Prompt Aila to generate lessons which contain MathJax output
3. You should see correctly formatted MathJax
4. Other lessons should be unaffected - check any other unusual outputs Aila generates to ensure they aren't broken by this change
