### PR TITLE
fix: [AI-2313] only show content guidance when categories change

### DIFF
--- a/apps/nextjs/src/components/AppComponents/Chat/chat-list/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-list/index.tsx
@@ -1,12 +1,16 @@
 "use client";
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import type { PersistedModerationBase } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
 
 import scrollIntoView from "scroll-into-view-if-needed";
 
 import { ChatMessage } from "@/components/AppComponents/Chat/chat-message";
+import { getModerationsToDisplay } from "@/components/AppComponents/Chat/chat-message/ModerationMessage";
 import { Message } from "@/components/AppComponents/Chat/chat-message/layout";
-import { useChatStore } from "@/stores/AilaStoresProvider";
+import { useChatStore, useModerationStore } from "@/stores/AilaStoresProvider";
+import type { ParsedMessage } from "@/stores/chatStore/types";
 
 import { DemoLimitMessage } from "./demo-limit-message";
 import {
@@ -91,12 +95,20 @@ export function ChatList({
 
 const StableMessages = () => {
   const stableMessages = useChatStore((state) => state.stableMessages);
+  const persistedModerations = useModerationStore((state) => state.moderations);
+  const moderationsToDisplay = useMemo(
+    () => getModerationsToDisplay(stableMessages, persistedModerations),
+    [stableMessages, persistedModerations],
+  );
 
   return (
     <>
       {stableMessages.map((message) => (
         <Message.Spacing key={message.id}>
-          <ChatMessage message={message} />
+          <ChatMessage
+            message={message}
+            moderation={moderationsToDisplay.get(message.id) ?? null}
+          />
         </Message.Spacing>
       ))}
     </>
@@ -106,6 +118,8 @@ const StableMessages = () => {
 // NOTE: We isolate streamingMessage to reduce rerenders in other components during streaming
 const StreamingMessage = () => {
   const message = useChatStore((state) => state.streamingMessage);
+  const stableMessages = useChatStore((state) => state.stableMessages);
+  const persistedModerations = useModerationStore((state) => state.moderations);
   const ailaStreamingStatus = useChatStore(
     (state) => state.ailaStreamingStatus,
   );
@@ -128,8 +142,39 @@ const StreamingMessage = () => {
   }
 
   return (
-    <Message.Spacing>
-      <ChatMessage key={message.id} message={message} />
-    </Message.Spacing>
+    <StreamingChatMessage
+      message={message}
+      stableMessages={stableMessages}
+      persistedModerations={persistedModerations}
+    />
   );
 };
+
+function StreamingChatMessage({
+  message,
+  stableMessages,
+  persistedModerations,
+}: Readonly<{
+  message: ParsedMessage;
+  stableMessages: ParsedMessage[];
+  persistedModerations: PersistedModerationBase[];
+}>) {
+  const moderationsToDisplay = useMemo(
+    () =>
+      getModerationsToDisplay(
+        [...stableMessages, message],
+        persistedModerations,
+      ),
+    [message, stableMessages, persistedModerations],
+  );
+
+  return (
+    <Message.Spacing>
+      <ChatMessage
+        key={message.id}
+        message={message}
+        moderation={moderationsToDisplay.get(message.id) ?? null}
+      />
+    </Message.Spacing>
+  );
+}

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-message/ModerationMessage.test.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-message/ModerationMessage.test.ts
@@ -1,0 +1,156 @@
+import type {
+  ModerationResult,
+  PersistedModerationBase,
+} from "@oakai/core/src/utils/ailaModeration/moderationSchema";
+
+import type { MessagePart } from "@oakai/aila/src/protocol/jsonPatchProtocol";
+
+import type { ParsedMessage } from "@/stores/chatStore/types";
+
+import { getModerationsToDisplay } from "./ModerationMessage";
+
+type ModerationCategory = ModerationResult["categories"][number];
+
+const textPart: MessagePart = {
+  type: "message-part",
+  id: "text-part",
+  isPartial: false,
+  document: {
+    type: "text",
+    value: "Message content",
+  },
+};
+
+function message(
+  id: string,
+  parts: MessagePart[] = [textPart],
+): ParsedMessage {
+  return {
+    id,
+    role: "assistant",
+    content: "",
+    parts,
+    hasError: false,
+    isEditing: false,
+  };
+}
+
+function moderation(
+  id: string,
+  messageId: string,
+  categories: ModerationCategory[],
+): PersistedModerationBase {
+  return {
+    id,
+    messageId,
+    categories,
+  };
+}
+
+function embeddedModerationPart(
+  id: string,
+  categories: ModerationCategory[],
+): MessagePart {
+  return {
+    type: "message-part",
+    id: `${id}-part`,
+    isPartial: false,
+    document: {
+      type: "moderation",
+      id,
+      categories,
+    },
+  };
+}
+
+describe("getModerationsToDisplay", () => {
+  test("does not display safe moderations", () => {
+    const messages = [message("m1")];
+    const moderations = [moderation("safe", "m1", [])];
+
+    expect(getModerationsToDisplay(messages, moderations).size).toBe(0);
+  });
+
+  test("displays the first non-safe moderation", () => {
+    const messages = [message("m1")];
+    const moderations = [moderation("mod-1", "m1", ["p/external-content"])];
+
+    expect(getModerationsToDisplay(messages, moderations).get("m1")?.id).toBe(
+      "mod-1",
+    );
+  });
+
+  test("suppresses repeated identical category sets", () => {
+    const messages = [message("m1"), message("m2"), message("m3")];
+    const moderations = [
+      moderation("mod-1", "m1", ["p/external-content", "l/strong-language"]),
+      moderation("mod-2", "m2", ["l/strong-language", "p/external-content"]),
+      moderation("mod-3", "m3", ["l/strong-language"]),
+    ];
+
+    const displayed = getModerationsToDisplay(messages, moderations);
+
+    expect([...displayed.keys()]).toEqual(["m1", "m3"]);
+  });
+
+  test("displays additions, removals, and changed category sets", () => {
+    const messages = [
+      message("m1"),
+      message("m2"),
+      message("m3"),
+      message("m4"),
+    ];
+    const moderations = [
+      moderation("mod-1", "m1", ["p/external-content"]),
+      moderation("mod-2", "m2", ["p/external-content", "l/strong-language"]),
+      moderation("mod-3", "m3", ["p/external-content"]),
+      moderation("mod-4", "m4", ["l/strong-language"]),
+    ];
+
+    const displayed = getModerationsToDisplay(messages, moderations);
+
+    expect([...displayed.keys()]).toEqual(["m1", "m2", "m3", "m4"]);
+  });
+
+  test("displays a repeated category set after a safe moderation", () => {
+    const messages = [message("m1"), message("m2"), message("m3")];
+    const moderations = [
+      moderation("mod-1", "m1", ["p/external-content"]),
+      moderation("mod-2", "m2", []),
+      moderation("mod-3", "m3", ["p/external-content"]),
+    ];
+
+    const displayed = getModerationsToDisplay(messages, moderations);
+
+    expect([...displayed.keys()]).toEqual(["m1", "m3"]);
+  });
+
+  test("uses embedded moderation parts when persisted moderation is unavailable", () => {
+    const messages = [
+      message("m1", [
+        textPart,
+        embeddedModerationPart("embedded-1", ["p/external-content"]),
+      ]),
+    ];
+
+    expect(getModerationsToDisplay(messages, []).get("m1")?.id).toBe(
+      "embedded-1",
+    );
+  });
+
+  test("prefers persisted moderation over embedded moderation parts", () => {
+    const messages = [
+      message("m1", [
+        textPart,
+        embeddedModerationPart("embedded-1", ["p/external-content"]),
+      ]),
+    ];
+    const persistedModeration = moderation("persisted-1", "m1", [
+      "l/strong-language",
+    ]);
+
+    expect(
+      getModerationsToDisplay(messages, [persistedModeration]).get("m1"),
+    ).toEqual(persistedModeration);
+  });
+});

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-message/ModerationMessage.test.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-message/ModerationMessage.test.ts
@@ -1,9 +1,8 @@
+import type { MessagePart } from "@oakai/aila/src/protocol/jsonPatchProtocol";
 import type {
   ModerationResult,
   PersistedModerationBase,
 } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
-
-import type { MessagePart } from "@oakai/aila/src/protocol/jsonPatchProtocol";
 
 import type { ParsedMessage } from "@/stores/chatStore/types";
 
@@ -21,10 +20,7 @@ const textPart: MessagePart = {
   },
 };
 
-function message(
-  id: string,
-  parts: MessagePart[] = [textPart],
-): ParsedMessage {
+function message(id: string, parts: MessagePart[] = [textPart]): ParsedMessage {
   return {
     id,
     role: "assistant",

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-message/ModerationMessage.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-message/ModerationMessage.tsx
@@ -28,7 +28,7 @@ function getMessageModeration(
 function moderationSignature(moderation: PersistedModerationBase): string {
   return getDisplayCategories(moderation)
     .map((category) => category.code)
-    .sort()
+    .sort((a, b) => a.localeCompare(b))
     .join("|");
 }
 

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-message/ModerationMessage.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-message/ModerationMessage.tsx
@@ -5,12 +5,11 @@ import { getDisplayCategories } from "@oakai/core/src/utils/ailaModeration/sever
 import { OakBox, type OakBoxProps } from "@oaknational/oak-components";
 
 import { ContentGuidanceBanner } from "@/components/AppComponents/Moderation/ContentGuidanceBanner";
-import { useModerationStore } from "@/stores/AilaStoresProvider";
 import type { ParsedMessage } from "@/stores/chatStore/types";
 
 import { isModeration } from "./protocol";
 
-export function getModeration(
+function getMessageModeration(
   message: ParsedMessage,
   persistedModerations: PersistedModerationBase[],
 ) {
@@ -23,20 +22,48 @@ export function getModeration(
   const matchingPersistedModeration: PersistedModerationBase | undefined =
     persistedModerations.find((m) => m.messageId === messageId);
 
-  const moderation = matchingPersistedModeration ?? moderationMessagePart;
-  if (moderation && !isSafe(moderation)) {
-    return moderation;
+  return matchingPersistedModeration ?? moderationMessagePart ?? null;
+}
+
+function moderationSignature(moderation: PersistedModerationBase): string {
+  return getDisplayCategories(moderation)
+    .map((category) => category.code)
+    .sort()
+    .join("|");
+}
+
+export function getModerationsToDisplay(
+  messages: ParsedMessage[],
+  persistedModerations: PersistedModerationBase[],
+): Map<string, PersistedModerationBase> {
+  const moderationsToDisplay = new Map<string, PersistedModerationBase>();
+  let previousSignature: string | null = null;
+
+  for (const message of messages) {
+    const moderation = getMessageModeration(message, persistedModerations);
+    if (!moderation) {
+      continue;
+    }
+
+    if (isSafe(moderation)) {
+      previousSignature = null;
+      continue;
+    }
+
+    const signature = moderationSignature(moderation);
+    if (signature !== previousSignature) {
+      moderationsToDisplay.set(message.id, moderation);
+    }
+    previousSignature = signature;
   }
-  return null;
+
+  return moderationsToDisplay;
 }
 
 export function Moderation({
-  forMessage,
+  moderation,
   ...boxProps
-}: Readonly<{ forMessage: ParsedMessage } & OakBoxProps>) {
-  const persistedModerations = useModerationStore((state) => state.moderations);
-  const moderation = getModeration(forMessage, persistedModerations);
-
+}: Readonly<{ moderation: PersistedModerationBase | null } & OakBoxProps>) {
   if (!moderation) {
     return null;
   }

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-message/index.stories.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-message/index.stories.tsx
@@ -21,6 +21,7 @@ type Story = StoryObj<typeof meta>;
 
 export const UserMessage: Story = {
   args: {
+    moderation: null,
     message: {
       id: "test-chat-id",
       content:
@@ -46,6 +47,7 @@ export const UserMessage: Story = {
 
 export const LlmMessage: Story = {
   args: {
+    moderation: null,
     message: {
       id: "test-chat-id",
       content:
@@ -108,6 +110,7 @@ export const LlmMessage: Story = {
 
 export const ErrorMessage: Story = {
   args: {
+    moderation: null,
     message: {
       id: "test-chat-id",
       role: "assistant",

--- a/apps/nextjs/src/components/AppComponents/Chat/chat-message/index.tsx
+++ b/apps/nextjs/src/components/AppComponents/Chat/chat-message/index.tsx
@@ -1,5 +1,7 @@
 import { useState } from "react";
 
+import type { PersistedModerationBase } from "@oakai/core/src/utils/ailaModeration/moderationSchema";
+
 import type { ParsedMessage } from "@/stores/chatStore/types";
 
 import { ChatMessagePart } from "./ChatMessagePart";
@@ -8,13 +10,17 @@ import { Message } from "./layout";
 
 export interface ChatMessageProps {
   message: ParsedMessage;
+  moderation: PersistedModerationBase | null;
 }
 
 function isActionMessage(message: ParsedMessage) {
   return message.parts.every((part) => part.document.type === "action");
 }
 
-export function ChatMessage({ message }: Readonly<ChatMessageProps>) {
+export function ChatMessage({
+  message,
+  moderation,
+}: Readonly<ChatMessageProps>) {
   const [inspect, setInspect] = useState(false);
 
   const normalParts = message.parts.filter(
@@ -30,7 +36,7 @@ export function ChatMessage({ message }: Readonly<ChatMessageProps>) {
 
   return (
     <>
-      <Moderation forMessage={message} $mt="spacing-48" />
+      <Moderation moderation={moderation} $mt="spacing-48" />
       {normalParts.length > 0 && (
         <Message.Container roleType={message.role === "user" ? "user" : "aila"}>
           <button

--- a/apps/nextjs/src/stores/moderationStore/actionFunctions/handleUpdateModerationState.test.ts
+++ b/apps/nextjs/src/stores/moderationStore/actionFunctions/handleUpdateModerationState.test.ts
@@ -1,0 +1,52 @@
+import type { Moderation } from "@prisma/client";
+
+import type { ModerationGetter, ModerationSetter } from "../types";
+import { handleUpdateModerationState } from "./handleUpdateModerationState";
+
+function moderation(
+  id: string,
+  categories: string[],
+): Moderation {
+  return {
+    id,
+    categories,
+    messageId: id,
+    userId: "user-id",
+    appSessionId: "chat-id",
+    scores: null,
+    justification: null,
+    lessonSnapshotId: null,
+    userComment: null,
+    invalidatedAt: null,
+    invalidatedBy: null,
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  };
+}
+
+describe("handleUpdateModerationState", () => {
+  test("uses the newest fetched moderation as lastModeration and locks on the locking moderation", () => {
+    const set = jest.fn() as unknown as ModerationSetter;
+    const updateLockingModeration = jest.fn();
+    const get = jest.fn(() => ({
+      actions: { updateLockingModeration },
+    })) as unknown as ModerationGetter;
+    const olderLockingModeration = moderation("older-locking", [
+      "t/encouragement-violence",
+    ]);
+    const newestModeration = moderation("newest", ["p/external-content"]);
+
+    handleUpdateModerationState(set, get)([
+      olderLockingModeration,
+      newestModeration,
+    ]);
+
+    expect(set).toHaveBeenCalledWith({
+      moderations: [olderLockingModeration, newestModeration],
+      lastModeration: newestModeration,
+    });
+    expect(updateLockingModeration).toHaveBeenCalledWith(
+      olderLockingModeration,
+    );
+  });
+});

--- a/apps/nextjs/src/stores/moderationStore/actionFunctions/handleUpdateModerationState.test.ts
+++ b/apps/nextjs/src/stores/moderationStore/actionFunctions/handleUpdateModerationState.test.ts
@@ -3,10 +3,7 @@ import type { Moderation } from "@prisma/client";
 import type { ModerationGetter, ModerationSetter } from "../types";
 import { handleUpdateModerationState } from "./handleUpdateModerationState";
 
-function moderation(
-  id: string,
-  categories: string[],
-): Moderation {
+function moderation(id: string, categories: string[]): Moderation {
   return {
     id,
     categories,
@@ -36,10 +33,10 @@ describe("handleUpdateModerationState", () => {
     ]);
     const newestModeration = moderation("newest", ["p/external-content"]);
 
-    handleUpdateModerationState(set, get)([
-      olderLockingModeration,
-      newestModeration,
-    ]);
+    handleUpdateModerationState(
+      set,
+      get,
+    )([olderLockingModeration, newestModeration]);
 
     expect(set).toHaveBeenCalledWith({
       moderations: [olderLockingModeration, newestModeration],

--- a/apps/nextjs/src/stores/moderationStore/actionFunctions/handleUpdateModerationState.tsx
+++ b/apps/nextjs/src/stores/moderationStore/actionFunctions/handleUpdateModerationState.tsx
@@ -25,7 +25,7 @@ export const handleUpdateModerationState = (
     });
 
     if (lockingMod) {
-      get().actions.updateLockingModeration(lastMod);
+      get().actions.updateLockingModeration(lockingMod);
     }
   };
 };


### PR DESCRIPTION
## Description

This PR fixes repeated Aila content-guidance banners by only showing a warning when the visible guidance category set changes.

## Issue(s)

Fixes #AI-2313

## How to test

1. Go to <!-- vercel-preview -->https://oak-ai-lesson-assistant-website-faps4bek4.vercel.thenational.academy<!-- /vercel-preview -->
2. Generate a lesson in Aila chat which requires content guidance - you should see it as normal.
3. Further messages should not show the banner again, unless/until the categories change.
4. In more detail:

#### Scenarios to Verify

1. First content-guidance result shows a banner.
2. Repeated messages with the same guidance categories do not show another banner.
3. A later message with added, removed, or different guidance categories shows a new banner.
4. If a safe moderation happens between guidance results, the next guidance result shows a banner again - this is a rare situation in real usage, but something like "generate a lesson with a practical activity, so the `practical-activities` guidance appears, then remove the activity, then add it back again - the content guidance should reappear. 
5. Locking moderation (toxic or highly sensitive content) should still opens the blocking modal as before - no changes are expected for this behaviour.
