### PR TITLE
feat(aila): enforce quiz option and question counts in schema

### DIFF
--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/exitQuizAgent/exitQuiz.instructions.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/exitQuizAgent/exitQuiz.instructions.test.ts
@@ -1,0 +1,16 @@
+import { exitQuizInstructions } from "./exitQuiz.instructions";
+
+describe("exitQuiz instructions", () => {
+  describe("exitQuizInstructions", () => {
+    it("asks for exactly 6 questions", () => {
+      expect(exitQuizInstructions("ks2")).toMatch(/exactly 6 questions/i);
+    });
+
+    it("asks for exactly 1 correct answer and exactly 2 distractors", () => {
+      expect(exitQuizInstructions("ks2")).toMatch(/exactly 1 correct answer/i);
+      expect(exitQuizInstructions("ks2")).toMatch(
+        /exactly 2 high-quality distractors/i,
+      );
+    });
+  });
+});

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/exitQuizAgent/exitQuiz.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/exitQuizAgent/exitQuiz.instructions.ts
@@ -3,7 +3,7 @@ import { quizQuestionDesignInstructions } from "../shared/quizQuestionDesign.ins
 export function exitQuizInstructions(keyStage: string): string {
   return `# Task
 
-Create a 6-question multiple-choice quiz to assess pupil understanding of the lesson content.
+Create a multiple-choice quiz with exactly 6 questions to assess pupil understanding of the lesson content.
 
 ## Content Scope
 

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/exitQuizAgent/exitQuiz.schema.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/exitQuizAgent/exitQuiz.schema.ts
@@ -1,1 +1,1 @@
-export { LatestQuizSchema as ExitQuizSchema } from "../../../../../protocol/schema";
+export { LatestQuizMultipleChoiceOnlyStrictMax6Schema as ExitQuizSchema } from "../../../../../protocol/schema";

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/sectionAgentRegistry.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/sectionAgentRegistry.ts
@@ -5,6 +5,7 @@ import type {
   LatestQuiz,
   PartialLessonPlan,
 } from "../../../../protocol/schema";
+import { toMultipleChoiceOnlyQuiz } from "../../quizOperations/toMultipleChoiceOnlyQuiz";
 import type {
   AilaExecutionContext,
   SectionAgent,
@@ -101,7 +102,9 @@ export const createSectionAgentRegistry = ({
     description: "Generates starter quiz questions",
     openai,
     contentFromDocument: (document) =>
-      "starterQuiz" in document ? document.starterQuiz : undefined,
+      toMultipleChoiceOnlyQuiz(
+        "starterQuiz" in document ? document.starterQuiz : undefined,
+      ),
   }),
   "starterQuiz--maths": {
     id: "starterQuiz--maths",
@@ -119,7 +122,9 @@ export const createSectionAgentRegistry = ({
     description: "Generates exit quiz questions",
     openai,
     contentFromDocument: (document) =>
-      "exitQuiz" in document ? document.exitQuiz : undefined,
+      toMultipleChoiceOnlyQuiz(
+        "exitQuiz" in document ? document.exitQuiz : undefined,
+      ),
   }),
   "exitQuiz--maths": {
     id: "exitQuiz--maths",

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/shared/quizQuestionDesign.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/shared/quizQuestionDesign.instructions.ts
@@ -16,7 +16,7 @@ export function quizQuestionDesignInstructions(keyStage: string): string {
 ${getKeyStageLanguageGuidance(keyStage)}
 
 ## Answers
-- Include 1 correct answer + 2 high-quality distractors.
+- Every question must have exactly 3 answer options: exactly 1 correct answer + exactly 2 high-quality distractors. Never include more.
 - Mutually exclusive (i.e. only one answer is correct)
 - Do not include 'all/none of the above' as an answer option.
 - Not include words from the question in the answers which may give away the correct answer.

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.test.ts
@@ -5,7 +5,31 @@ import {
 } from "./starterQuiz.instructions";
 
 describe("starterQuiz instructions", () => {
+  describe("starterQuizInstructions", () => {
+    it("asks for exactly 6 questions", () => {
+      expect(starterQuizInstructions("ks2")).toMatch(/exactly 6 questions/i);
+    });
+
+    it("asks for exactly 1 correct answer and exactly 2 distractors", () => {
+      expect(starterQuizInstructions("ks2")).toMatch(
+        /exactly 1 correct answer/i,
+      );
+      expect(starterQuizInstructions("ks2")).toMatch(
+        /exactly 2 high-quality distractors/i,
+      );
+    });
+  });
+
   describe("addOneQuizInstructions", () => {
+    it("asks for exactly 1 correct answer and exactly 2 distractors", () => {
+      expect(addOneQuizInstructions("ks2")).toMatch(
+        /exactly 1 correct answer/i,
+      );
+      expect(addOneQuizInstructions("ks2")).toMatch(
+        /exactly 2 high-quality distractors/i,
+      );
+    });
+
     it("directs the LLM to generate exactly one question", () => {
       expect(addOneQuizInstructions("ks2")).toMatch(/exactly one/i);
     });

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.ts
@@ -3,7 +3,7 @@ import { quizQuestionDesignInstructions } from "../shared/quizQuestionDesign.ins
 export function starterQuizInstructions(keyStage: string): string {
   return `# Task
 
-Create a 6-question multiple-choice quiz to assess PRIOR KNOWLEDGE ONLY — do not include or hint at new lesson content.
+Create a multiple-choice quiz with exactly 6 questions to assess PRIOR KNOWLEDGE ONLY — do not include or hint at new lesson content.
 
 ## Content Scope:
 

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.schema.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.schema.ts
@@ -1,1 +1,1 @@
-export { LatestQuizSchema as StarterQuizSchema } from "../../../../../protocol/schema";
+export { LatestQuizMultipleChoiceOnlyStrictMax6Schema as StarterQuizSchema } from "../../../../../protocol/schema";

--- a/packages/aila/src/lib/agentic-system/execution/executePlanSteps.quiz.test.ts
+++ b/packages/aila/src/lib/agentic-system/execution/executePlanSteps.quiz.test.ts
@@ -487,6 +487,152 @@ describe("executePlanSteps — quiz dispatch intercept", () => {
         britishQuestion,
       ]);
     });
+
+    it("falls back to the uncorrected question when the corrector adds extra options", async () => {
+      const americanQuestion = makeQuestion("What color is a healthy leaf?");
+      const overOptioned = {
+        ...americanQuestion,
+        question: "What colour is a healthy leaf?",
+        distractors: ["Wrong A", "Wrong B", "Wrong C"],
+      };
+      const sectionAgent = jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          version: "v3",
+          questions: [americanQuestion],
+          imageMetadata: [],
+        },
+      });
+      const corrector = jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          version: "v3",
+          questions: [overOptioned],
+          imageMetadata: [],
+        },
+      });
+      const callbacks = makeCallbacks();
+
+      const runtime = makeRuntime({
+        plannerAgent: jest.fn().mockResolvedValue({
+          error: null,
+          data: {
+            decision: "plan",
+            parsedUserMessage: "Add a question about colour",
+            plan: [
+              {
+                type: "section",
+                sectionKey: "starterQuiz",
+                action: "generate",
+                sectionInstructions: null,
+                itemIntent: {
+                  action: "ADD_ITEM",
+                  position: null,
+                },
+              },
+            ],
+          },
+        }),
+        sectionAgents: {
+          "starterQuiz--default": {
+            id: "starterQuiz--default",
+            description: "starter quiz",
+            handler: sectionAgent,
+          },
+        } as unknown as SectionAgentRegistry,
+        britishEnglishCorrectorAgent: corrector,
+      });
+
+      await ailaTurn({
+        persistedState: makePersistedState(),
+        runtime,
+        callbacks,
+      });
+
+      expect(corrector).toHaveBeenCalledTimes(1);
+      expect(getUpdatedStarterQuiz(callbacks)?.questions).toEqual([
+        q1,
+        q2,
+        q3,
+        americanQuestion,
+      ]);
+    });
+
+    it("keeps the permissive schema for maths quiz corrections", async () => {
+      const americanQuestion: LatestQuizQuestion = {
+        questionType: "short-answer",
+        question: "What color is a healthy leaf?",
+        hint: null,
+        answers: ["green"],
+      };
+      const britishQuestion = {
+        ...americanQuestion,
+        question: "What colour is a healthy leaf?",
+      };
+      const mathsAgent = jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          version: "v3",
+          questions: [americanQuestion],
+          imageMetadata: [],
+        },
+      });
+      const corrector = jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          version: "v3",
+          questions: [britishQuestion],
+          imageMetadata: [],
+        },
+      });
+      const callbacks = makeCallbacks();
+
+      const mathsState: AilaPersistedState = {
+        ...makePersistedState(),
+        initialDocument: { subject: "maths", starterQuiz },
+      };
+
+      const runtime = makeRuntime({
+        config: { mathsQuizEnabled: true },
+        plannerAgent: jest.fn().mockResolvedValue({
+          error: null,
+          data: {
+            decision: "plan",
+            parsedUserMessage: "Add a question about colour",
+            plan: [
+              {
+                type: "section",
+                sectionKey: "starterQuiz",
+                action: "generate",
+                sectionInstructions: null,
+                itemIntent: {
+                  action: "ADD_ITEM",
+                  position: null,
+                },
+              },
+            ],
+          },
+        }),
+        sectionAgents: {
+          "starterQuiz--maths": {
+            id: "starterQuiz--maths",
+            description: "maths starter quiz",
+            handler: mathsAgent,
+          },
+        } as unknown as SectionAgentRegistry,
+        britishEnglishCorrectorAgent: corrector,
+      });
+
+      await ailaTurn({ persistedState: mathsState, runtime, callbacks });
+
+      expect(corrector).toHaveBeenCalledTimes(1);
+      expect(getUpdatedStarterQuiz(callbacks)?.questions).toEqual([
+        q1,
+        q2,
+        q3,
+        britishQuestion,
+      ]);
+    });
   });
 
   describe("REMOVE_ITEM", () => {

--- a/packages/aila/src/lib/agentic-system/execution/executePlanSteps.ts
+++ b/packages/aila/src/lib/agentic-system/execution/executePlanSteps.ts
@@ -218,10 +218,9 @@ async function executeGenerateStep(
 }
 
 /**
- * Default-agent quizzes are corrected against the strict LLM schema, so the
- * corrector cannot re-introduce extra answer options or questions; its output
- * fails validation and falls back to the original content instead. Maths-bank
- * quizzes and all other sections keep the permissive section schema.
+ * The corrector validates its output against this schema. Strict for
+ * default-agent quizzes so it cannot re-introduce extra options or questions;
+ * permissive for maths-bank quizzes and every other section.
  */
 function correctorResponseSchema(
   context: AilaExecutionContext,

--- a/packages/aila/src/lib/agentic-system/execution/executePlanSteps.ts
+++ b/packages/aila/src/lib/agentic-system/execution/executePlanSteps.ts
@@ -12,6 +12,7 @@ import type {
 import {
   CompletedLessonPlanSchema,
   KeywordsSchema,
+  LatestQuizMultipleChoiceOnlyStrictMax6Schema,
   LatestQuizSchema,
   MisconceptionsSchema,
 } from "../../../protocol/schema";
@@ -198,7 +199,7 @@ async function executeGenerateStep(
     context,
     sectionKey: step.sectionKey,
     content: result.data,
-    responseSchema: sectionSchema,
+    responseSchema: correctorResponseSchema(context, step),
   });
 
   const validated = corrected ?? sectionSchema.parse(result.data);
@@ -214,6 +215,29 @@ async function executeGenerateStep(
   });
 
   return { status: "continue" };
+}
+
+/**
+ * Default-agent quizzes are corrected against the strict LLM schema, so the
+ * corrector cannot re-introduce extra answer options or questions; its output
+ * fails validation and falls back to the original content instead. Maths-bank
+ * quizzes and all other sections keep the permissive section schema.
+ */
+function correctorResponseSchema(
+  context: AilaExecutionContext,
+  step: PlanStep,
+) {
+  const { sectionKey } = step;
+  if (sectionKey === "starterQuiz" || sectionKey === "exitQuiz") {
+    const agentId = sectionStepToAgentId(step, {
+      config: context.runtime.config,
+      document: context.currentTurn.document,
+    });
+    if (agentId === `${sectionKey}--default`) {
+      return LatestQuizMultipleChoiceOnlyStrictMax6Schema;
+    }
+  }
+  return CompletedLessonPlanSchema.shape[sectionKey];
 }
 
 function getMissingCycleOutcomeMessage(
@@ -265,11 +289,15 @@ async function executeQuizDispatchStep(
       if (!validateSingleQuestion(question)) return null;
       // Correct only this new question, wrapped as a single-question quiz, so
       // existing questions are never sent to the corrector and stay untouched.
+      // Strict schema for default agents, as in correctorResponseSchema.
       const correctedQuiz = await applyBritishEnglishCorrection({
         context,
         sectionKey,
         content: { ...currentQuiz, questions: [question] },
-        responseSchema: CompletedLessonPlanSchema.shape[sectionKey],
+        responseSchema:
+          agentId === `${sectionKey}--default`
+            ? LatestQuizMultipleChoiceOnlyStrictMax6Schema
+            : CompletedLessonPlanSchema.shape[sectionKey],
       });
       return correctedQuiz?.questions[0] ?? question ?? null;
     },

--- a/packages/aila/src/lib/agentic-system/quizOperations/quizOperationDispatcher.test.ts
+++ b/packages/aila/src/lib/agentic-system/quizOperations/quizOperationDispatcher.test.ts
@@ -1,4 +1,5 @@
 import type { LatestQuiz, LatestQuizQuestion } from "../../../protocol/schema";
+import { QUIZ_MAX_QUESTIONS } from "../../../protocol/schemas/quiz/quizV3";
 import type { StructuralItemIntent } from "../schema";
 import { quizOperationDispatcher } from "./quizOperationDispatcher";
 import type { RunSingleQuestionFn } from "./quizOperationDispatcher";
@@ -119,7 +120,9 @@ describe("quizOperationDispatcher", () => {
     });
     it("returns the quiz unchanged with a note when the quiz is already at the maximum size", async () => {
       const quiz = makeQuiz(
-        Array.from({ length: 50 }, (_, i) => makeQuestion(`Question ${i + 1}`)),
+        Array.from({ length: QUIZ_MAX_QUESTIONS }, (_, i) =>
+          makeQuestion(`Question ${i + 1}`),
+        ),
       );
       const agent = jest.fn() as jest.MockedFunction<RunSingleQuestionFn>;
 

--- a/packages/aila/src/lib/agentic-system/quizOperations/quizOperationDispatcher.ts
+++ b/packages/aila/src/lib/agentic-system/quizOperations/quizOperationDispatcher.ts
@@ -1,4 +1,5 @@
 import type { LatestQuiz, LatestQuizQuestion } from "../../../protocol/schema";
+import { QUIZ_MAX_QUESTIONS } from "../../../protocol/schemas/quiz/quizV3";
 import type { StructuralItemIntent } from "../schema";
 import {
   type RunSingleItemFn,
@@ -6,9 +7,6 @@ import {
 } from "./sectionListOperationDispatcher";
 
 export type RunSingleQuestionFn = RunSingleItemFn<LatestQuizQuestion>;
-
-// Sanity cap, not a pedagogical limit; far above any practical quiz size.
-const MAX_QUIZ_QUESTIONS = 50;
 
 export type QuizDispatchResult = {
   data: LatestQuiz;
@@ -31,7 +29,7 @@ export async function quizOperationDispatcher(
     {
       itemNoun: "question",
       min: 0,
-      max: MAX_QUIZ_QUESTIONS,
+      max: QUIZ_MAX_QUESTIONS,
       regenerateSuggestion: "Generate a new quiz",
     },
   );

--- a/packages/aila/src/lib/agentic-system/quizOperations/toMultipleChoiceOnlyQuiz.test.ts
+++ b/packages/aila/src/lib/agentic-system/quizOperations/toMultipleChoiceOnlyQuiz.test.ts
@@ -1,0 +1,93 @@
+import type { LatestQuiz, LatestQuizQuestion } from "../../../protocol/schema";
+import { toMultipleChoiceOnlyQuiz } from "./toMultipleChoiceOnlyQuiz";
+
+const mcQuestion = (
+  overrides: Partial<
+    Extract<LatestQuizQuestion, { questionType: "multiple-choice" }>
+  > = {},
+): LatestQuizQuestion => ({
+  questionType: "multiple-choice",
+  question: "What is 1+1?",
+  hint: null,
+  answers: ["2"],
+  distractors: ["1", "3"],
+  ...overrides,
+});
+
+const makeQuiz = (questions: LatestQuizQuestion[]): LatestQuiz => ({
+  version: "v3",
+  questions,
+  imageMetadata: [],
+});
+
+describe("toMultipleChoiceOnlyQuiz", () => {
+  it("returns undefined when there is no quiz", () => {
+    expect(toMultipleChoiceOnlyQuiz(undefined)).toBeUndefined();
+  });
+
+  it("keeps a conforming quiz's questions unchanged", () => {
+    const quiz = makeQuiz([mcQuestion()]);
+
+    expect(toMultipleChoiceOnlyQuiz(quiz)?.questions).toEqual(quiz.questions);
+  });
+
+  it("filters out non-multiple-choice questions", () => {
+    const quiz = makeQuiz([
+      mcQuestion(),
+      {
+        questionType: "short-answer",
+        question: "Name a prime number.",
+        hint: null,
+        answers: ["2", "3"],
+      },
+      {
+        questionType: "order",
+        question: "Order these numbers.",
+        hint: null,
+        items: ["1", "2", "3"],
+      },
+    ]);
+
+    expect(toMultipleChoiceOnlyQuiz(quiz)?.questions).toEqual([mcQuestion()]);
+  });
+
+  it("keeps only the first correct answer when there are several", () => {
+    const quiz = makeQuiz([mcQuestion({ answers: ["2", "two"] })]);
+
+    expect(toMultipleChoiceOnlyQuiz(quiz)?.questions[0]?.answers).toEqual([
+      "2",
+    ]);
+  });
+
+  it("trims distractors to two when there are more", () => {
+    const quiz = makeQuiz([mcQuestion({ distractors: ["1", "3", "4", "5"] })]);
+
+    expect(toMultipleChoiceOnlyQuiz(quiz)?.questions[0]?.distractors).toEqual([
+      "1",
+      "3",
+    ]);
+  });
+
+  it("preserves imageMetadata", () => {
+    const imageMetadata = [
+      {
+        imageUrl: "https://example.com/image.png",
+        attribution: "Example",
+        width: 100,
+        height: 100,
+        aiDescription: "An example image",
+      },
+    ];
+    const quiz: LatestQuiz = { ...makeQuiz([mcQuestion()]), imageMetadata };
+
+    expect(toMultipleChoiceOnlyQuiz(quiz)?.imageMetadata).toEqual(
+      imageMetadata,
+    );
+  });
+
+  it("drops reportId", () => {
+    const quiz: LatestQuiz = { ...makeQuiz([mcQuestion()]), reportId: "abc" };
+
+    expect(toMultipleChoiceOnlyQuiz(quiz)).not.toHaveProperty("reportId");
+  });
+});

--- a/packages/aila/src/lib/agentic-system/quizOperations/toMultipleChoiceOnlyQuiz.test.ts
+++ b/packages/aila/src/lib/agentic-system/quizOperations/toMultipleChoiceOnlyQuiz.test.ts
@@ -21,6 +21,9 @@ const makeQuiz = (questions: LatestQuizQuestion[]): LatestQuiz => ({
 });
 
 describe("toMultipleChoiceOnlyQuiz", () => {
+  // A quiz may be missing because the lesson hasn't reached that section yet,
+  // or an exemplar lesson lacks it. Missing quizzes should be undefined and
+  // not become an empty quiz that would be shown to the LLM as a real example.
   it("returns undefined when there is no quiz", () => {
     expect(toMultipleChoiceOnlyQuiz(undefined)).toBeUndefined();
   });
@@ -85,6 +88,8 @@ describe("toMultipleChoiceOnlyQuiz", () => {
     );
   });
 
+  // reportId points at a maths pipeline generation report. It should be
+  // dropped because the LLM shouldn't see it.
   it("drops reportId", () => {
     const quiz: LatestQuiz = { ...makeQuiz([mcQuestion()]), reportId: "abc" };
 

--- a/packages/aila/src/lib/agentic-system/quizOperations/toMultipleChoiceOnlyQuiz.ts
+++ b/packages/aila/src/lib/agentic-system/quizOperations/toMultipleChoiceOnlyQuiz.ts
@@ -1,0 +1,33 @@
+import type { LatestQuiz } from "../../../protocol/schema";
+import {
+  QUIZ_MC_ANSWER_COUNT,
+  QUIZ_MC_DISTRACTOR_COUNT,
+  type QuizV3MultipleChoiceOnly,
+  type QuizV3QuestionMultipleChoice,
+} from "../../../protocol/schemas/quiz/quizV3";
+
+/**
+ * Shapes a persisted quiz for the LLM-facing multiple-choice-only schema.
+ * Persisted quizzes (RAG exemplars, basedOn lessons, maths-bank quizzes) may
+ * contain other question types or extra answer options; the LLM should only
+ * ever see examples in the exact shape it is asked to produce.
+ */
+export function toMultipleChoiceOnlyQuiz(
+  quiz: LatestQuiz | undefined,
+): QuizV3MultipleChoiceOnly | undefined {
+  if (!quiz) return undefined;
+  return {
+    version: "v3",
+    questions: quiz.questions
+      .filter(
+        (q): q is QuizV3QuestionMultipleChoice =>
+          q.questionType === "multiple-choice",
+      )
+      .map((q) => ({
+        ...q,
+        answers: q.answers.slice(0, QUIZ_MC_ANSWER_COUNT),
+        distractors: q.distractors.slice(0, QUIZ_MC_DISTRACTOR_COUNT),
+      })),
+    imageMetadata: quiz.imageMetadata,
+  };
+}

--- a/packages/aila/src/lib/agentic-system/quizOperations/toMultipleChoiceOnlyQuiz.ts
+++ b/packages/aila/src/lib/agentic-system/quizOperations/toMultipleChoiceOnlyQuiz.ts
@@ -7,10 +7,9 @@ import {
 } from "../../../protocol/schemas/quiz/quizV3";
 
 /**
- * Shapes a persisted quiz for the LLM-facing multiple-choice-only schema.
- * Persisted quizzes (RAG exemplars, basedOn lessons, maths-bank quizzes) may
- * contain other question types or extra answer options; the LLM should only
- * ever see examples in the exact shape it is asked to produce.
+ * Best-effort shaping of a persisted quiz towards the multiple-choice-only
+ * LLM schema: drops other question types and trims extra answer options.
+ * Prompt context only; never validated against the strict schema.
  */
 export function toMultipleChoiceOnlyQuiz(
   quiz: LatestQuiz | undefined,

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
-codeHash: 3d0b0345ad18db9c639ebd016fb2a4bb32e1d819b4d1b2d9b4c7456cab24943e
-generated: 2026-07-02T16:15:25.302Z
+codeHash: b04d544b08f6b9a20451bfdfee5d7fde9954572f6926208dbd113acdcad0fc35
+generated: 2026-07-06T11:33:22.524Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -30,7 +30,7 @@ summary:
       correction_rate: 3.0%
       correction_failure_rate: 0.0%
       corrections_by_section:
-        starterQuiz: 1
+        cycle1: 1
   no-rag-lesson:
     generation-complete:
       pass: 3
@@ -55,9 +55,10 @@ summary:
     quiz-question-count:
       pass: 3
     americanisms_corrector:
-      corrections_attempted: 0
-      corrections_not_needed: 33
+      corrections_attempted: 1
+      corrections_not_needed: 32
       corrections_failed: 0
-      correction_rate: 0.0%
+      correction_rate: 3.0%
       correction_failure_rate: 0.0%
-      corrections_by_section: {}
+      corrections_by_section:
+        starterQuiz: 1

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
-codeHash: b04d544b08f6b9a20451bfdfee5d7fde9954572f6926208dbd113acdcad0fc35
-generated: 2026-07-06T11:33:22.524Z
+codeHash: 78da7dd00cfc96d2614c475ca91c6824e9fdb6c1d7ab4b683f297828e3ac43f3
+generated: 2026-07-07T13:42:59.252Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -24,13 +24,12 @@ summary:
     quiz-question-count:
       pass: 3
     americanisms_corrector:
-      corrections_attempted: 1
-      corrections_not_needed: 32
+      corrections_attempted: 0
+      corrections_not_needed: 33
       corrections_failed: 0
-      correction_rate: 3.0%
+      correction_rate: 0.0%
       correction_failure_rate: 0.0%
-      corrections_by_section:
-        cycle1: 1
+      corrections_by_section: {}
   no-rag-lesson:
     generation-complete:
       pass: 3
@@ -55,10 +54,11 @@ summary:
     quiz-question-count:
       pass: 3
     americanisms_corrector:
-      corrections_attempted: 1
-      corrections_not_needed: 32
+      corrections_attempted: 2
+      corrections_not_needed: 31
       corrections_failed: 0
-      correction_rate: 3.0%
+      correction_rate: 6.1%
       correction_failure_rate: 0.0%
       corrections_by_section:
-        starterQuiz: 1
+        exitQuiz: 1
+        cycle2: 1

--- a/packages/aila/src/protocol/schemas/quiz/quizV3.test.ts
+++ b/packages/aila/src/protocol/schemas/quiz/quizV3.test.ts
@@ -1,0 +1,109 @@
+import {
+  QUIZ_MAX_QUESTIONS,
+  QuizV3MultipleChoiceOnlyStrictMax6Schema,
+  QuizV3Schema,
+} from "./quizV3";
+
+const mcQuestion = (overrides: Record<string, unknown> = {}) => ({
+  questionType: "multiple-choice",
+  question: "What is 1+1?",
+  hint: null,
+  answers: ["2"],
+  distractors: ["1", "3"],
+  ...overrides,
+});
+
+const strictQuiz = (questions: unknown[]) => ({
+  version: "v3",
+  questions,
+  imageMetadata: [],
+});
+
+describe("QuizV3MultipleChoiceOnlyStrictMax6Schema", () => {
+  it("accepts a full quiz of questions with one answer and two distractors", () => {
+    const quiz = strictQuiz(
+      Array.from({ length: QUIZ_MAX_QUESTIONS }, () => mcQuestion()),
+    );
+
+    expect(
+      QuizV3MultipleChoiceOnlyStrictMax6Schema.safeParse(quiz).success,
+    ).toBe(true);
+  });
+
+  it("rejects a question with a third distractor", () => {
+    const quiz = strictQuiz([mcQuestion({ distractors: ["1", "3", "4"] })]);
+
+    expect(
+      QuizV3MultipleChoiceOnlyStrictMax6Schema.safeParse(quiz).success,
+    ).toBe(false);
+  });
+
+  it("rejects a question with two correct answers", () => {
+    const quiz = strictQuiz([mcQuestion({ answers: ["2", "two"] })]);
+
+    expect(
+      QuizV3MultipleChoiceOnlyStrictMax6Schema.safeParse(quiz).success,
+    ).toBe(false);
+  });
+
+  it("rejects a question with a single distractor", () => {
+    const quiz = strictQuiz([mcQuestion({ distractors: ["1"] })]);
+
+    expect(
+      QuizV3MultipleChoiceOnlyStrictMax6Schema.safeParse(quiz).success,
+    ).toBe(false);
+  });
+
+  it("rejects a quiz with more questions than the maximum", () => {
+    const quiz = strictQuiz(
+      Array.from({ length: QUIZ_MAX_QUESTIONS + 1 }, () => mcQuestion()),
+    );
+
+    expect(
+      QuizV3MultipleChoiceOnlyStrictMax6Schema.safeParse(quiz).success,
+    ).toBe(false);
+  });
+
+  it("rejects an empty quiz", () => {
+    expect(
+      QuizV3MultipleChoiceOnlyStrictMax6Schema.safeParse(strictQuiz([]))
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects non-multiple-choice question types", () => {
+    const quiz = strictQuiz([
+      {
+        questionType: "short-answer",
+        question: "Name a prime number.",
+        hint: null,
+        answers: ["2"],
+      },
+    ]);
+
+    expect(
+      QuizV3MultipleChoiceOnlyStrictMax6Schema.safeParse(quiz).success,
+    ).toBe(false);
+  });
+});
+
+describe("QuizV3Schema (persisted)", () => {
+  it("still accepts questions with four answer options", () => {
+    const quiz = strictQuiz([mcQuestion({ distractors: ["1", "3", "4"] })]);
+
+    expect(QuizV3Schema.safeParse(quiz).success).toBe(true);
+  });
+
+  it("still accepts non-multiple-choice question types", () => {
+    const quiz = strictQuiz([
+      {
+        questionType: "match",
+        question: "Match the halves.",
+        hint: null,
+        pairs: [{ left: "1/2", right: "0.5" }],
+      },
+    ]);
+
+    expect(QuizV3Schema.safeParse(quiz).success).toBe(true);
+  });
+});

--- a/packages/aila/src/protocol/schemas/quiz/quizV3.test.ts
+++ b/packages/aila/src/protocol/schemas/quiz/quizV3.test.ts
@@ -87,6 +87,9 @@ describe("QuizV3MultipleChoiceOnlyStrictMax6Schema", () => {
   });
 });
 
+// This tests the schema for persisted quizzes we already hold: lessons saved
+// in the database, basedOn/RAG quizzes and maths-bank questions. These can
+// have shapes the LLM is not allowed to produce, so it must keep accepting them.
 describe("QuizV3Schema (persisted)", () => {
   it("still accepts questions with four answer options", () => {
     const quiz = strictQuiz([mcQuestion({ distractors: ["1", "3", "4"] })]);

--- a/packages/aila/src/protocol/schemas/quiz/quizV3.ts
+++ b/packages/aila/src/protocol/schemas/quiz/quizV3.ts
@@ -107,9 +107,31 @@ export type QuizV3QuestionOrder = z.infer<typeof QuizV3QuestionOrderSchema>;
 
 // ********** LLM-SPECIFIC SCHEMAS (MULTIPLE CHOICE ONLY) **********
 
-// LLM can only generate multiple choice questions, so we create specific schemas for that
+// Export templates (Google Slides) have fixed placeholders per quiz: 6 questions,
+// each with 1 correct answer + 2 distractors. Adjust these if the templates change.
+export const QUIZ_MAX_QUESTIONS = 6;
+export const QUIZ_MC_ANSWER_COUNT = 1;
+export const QUIZ_MC_DISTRACTOR_COUNT = 2;
+
+// LLM can only generate multiple choice questions, so we create specific schemas for that.
+// Answer option counts are hard bounds so exports never receive extra options.
 export const QuizV3MultipleChoiceOnlyQuestionSchema =
-  QuizV3QuestionMultipleChoiceSchema;
+  QuizV3QuestionMultipleChoiceSchema.extend({
+    answers: z
+      .array(z.string())
+      .min(QUIZ_MC_ANSWER_COUNT)
+      .max(QUIZ_MC_ANSWER_COUNT)
+      .describe(
+        `Correct answers as markdown. ${minMaxText({ min: QUIZ_MC_ANSWER_COUNT, max: QUIZ_MC_ANSWER_COUNT })}`,
+      ),
+    distractors: z
+      .array(z.string())
+      .min(QUIZ_MC_DISTRACTOR_COUNT)
+      .max(QUIZ_MC_DISTRACTOR_COUNT)
+      .describe(
+        `Incorrect answer options as markdown. ${minMaxText({ min: QUIZ_MC_DISTRACTOR_COUNT, max: QUIZ_MC_DISTRACTOR_COUNT })}`,
+      ),
+  });
 
 export const QuizV3MultipleChoiceOnlySchema = z.object({
   version: z.literal("v3").describe("Schema version identifier"),
@@ -131,7 +153,13 @@ export const QuizV3MultipleChoiceOnlyOptionalSchema =
 
 export const QuizV3MultipleChoiceOnlyStrictMax6Schema =
   QuizV3MultipleChoiceOnlySchema.extend({
-    questions: z.array(QuizV3MultipleChoiceOnlyQuestionSchema).min(1).max(6),
+    questions: z
+      .array(QuizV3MultipleChoiceOnlyQuestionSchema)
+      .min(1)
+      .max(QUIZ_MAX_QUESTIONS)
+      .describe(
+        `Array of multiple choice quiz questions. ${minMaxText({ min: 1, max: QUIZ_MAX_QUESTIONS })}`,
+      ),
   });
 
 // Type exports for LLM-specific schemas


### PR DESCRIPTION
## Description

Aila sometimes generated quiz questions with more than 3 answer options, which the slides export cannot show, so extra options were silently lost and sometimes the correct answer disappeared. The quiz schema sent to the LLM now enforces exactly 1 correct answer, 2 distractors and at most 6 questions per quiz. Asking to add a question to a quiz that already has 6 questions is now politely declined. Maths quizzes and existing stored lessons are unaffected.

The starter quiz being dependent on pre-existing knowledge will be addressed in a follow-up PR.

## Issue(s)

Fixes #[AI-2312](https://app.notion.com/p/oaknationalacademy/Review-Quiz-output-in-Agentic-Aila-38a26cc4e1b18047b6f5ce2f7a1f55df?source=copy_link)

## How to test

1. Go to <!-- vercel-preview -->https://oak-ai-lesson-assistant-website-gi7uftzl0.vercel.thenational.academy<!-- /vercel-preview -->
2. Generate a full lesson and open the starter and exit quizzes: each should have exactly 6 questions with exactly 3 answer options (1 correct + 2 distractors)
3. Ask Aila to "add another question to the starter quiz": it should decline with a note that 6 is the most the section can hold
4. Ask it to rewrite one quiz question: only that question changes, still 3 options
5. Export to slides: all 6 questions render with 3 options each and a tick on the correct answer
6. Generate a maths lesson (with the maths quiz flag on) and confirm quizzes still generate from the question bank unchanged

## Screenshots

n/a (no UI change; quiz shape only)

## Checklist

- [x] ~~Manually tested across browsers / devices~~ (no UI change)
- [ ] ~~Considered impact on accessibility~~ (no UI change)
- [ ] ~~Does this PR update a package with a breaking change~~
