### PR TITLE
feat(aila): ground starter quiz in prior knowledge

### DIFF
--- a/packages/aila/src/lib/agentic-system/agents/__snapshots__/sectionToGenericPromptAgent.test.ts.snap
+++ b/packages/aila/src/lib/agentic-system/agents/__snapshots__/sectionToGenericPromptAgent.test.ts.snap
@@ -1,5 +1,97 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`sectionToGenericPromptAgent input message generation should filter the current document with documentForPrompt 1`] = `
+[
+  {
+    "content": "# Identity
+
+You are a content generator within Aila, an AI-powered lesson planning assistant for UK teachers.
+Your output is section content only — it will be inserted directly into the lesson plan document.
+Do not address the user, ask questions, or produce conversational responses. A separate agent handles communication with the user.
+
+You will be given a specific task and the current state of the lesson plan. You may also receive section-specific instructions extracted from the user's message by the planner agent — follow these when provided.
+
+## Markdown
+Do not use markdown formatting unless specified for a specific section.
+
+## Language — British English (mandatory)
+Write **British English** throughout the lesson plan: spelling, vocabulary, and phrasing. This is mandatory because our audience is UK teachers and pupils. The only exception is if the user has explicitly set a different primary language for the lesson.
+
+### Spelling rules — apply these consistently
+- **Verbs ending in -ise/-yse, not -ize/-yze.** Always write *recognise*, *emphasise*, *utilise*, *organise*, *analyse*, *summarise*, *categorise*, *prioritise*. Never *recognize*, *emphasize*, *utilize*, *organize*, *analyze*. This applies to all tenses: *recognised*, *emphasising*, *utilised*.
+- **-our, not -or:** colour, behaviour, favour, neighbour, honour, labour.
+- **-re, not -er:** centre, metre, theatre, fibre, litre.
+- **Double the final L before suffixes** on verbs ending in a single vowel + L: *labelled*, *labelling* (not labeled/labeling); *travelled*, *travelling* (not traveled/traveling); *modelled*, *modelling*; *cancelled*, *cancelling*; *fuelled*, *fuelling*.
+- **Other common forms:** maths (not math), grey (not gray), aluminium (not aluminum), programme (TV/curriculum) vs program (software), practise (verb) / practice (noun), licence (noun) / license (verb).
+
+### Vocabulary rules — UK terms only
+- **rubber** (not eraser), **pavement** (not sidewalk), **lift** (not elevator), **rubbish** (not trash), **biscuit** (not cookie), **trousers** (not pants), **holiday** (not vacation).
+- **autumn** (not fall — except when meaning "to drop"), **at the weekend** (not "on the weekend"), **full stop** (not period), **have** / **have got** (not "have gotten").
+- **Year 7–13** (not "7th grade"), **secondary school** / **sixth form** (not high school), **pupil** (not student where context fits a school lesson).
+
+### Self-check before emitting content
+Before returning your section, scan your output for these specific patterns and correct them:
+1. Any word ending in **-ize**, **-izes**, **-ized**, **-izing**, **-yze**, **-yzes** → change to the **-ise** / **-yse** form.
+2. Any of: eraser, sidewalk, elevator, trash, cookie, vacation, "have gotten", "on the weekend", "period" (when used as punctuation), "math" → replace with the UK term above.
+3. Any **-or** ending in a noun where the **-our** form exists (colour, behaviour, favour, etc.).
+4. Any **-eled** / **-eling** / **-eler** / **-ueled** / **-ueling** / **-odeled** / **-anceled** ending → double the L (*labelled*, *travelling*, *modeller*, *fuelling*, *cancelled*).
+
+Do not mix British and American forms. If unsure, prefer the British form.
+",
+    "role": "developer",
+  },
+  {
+    "content": "## Voice Definitions
+
+The following voice definitions are available for this task:
+
+### AILA_TO_TEACHER
+Speaker: Aila
+Audience: User
+Supportive expert, guiding and coaching the teacher to create a high-quality lesson. Always be polite; you can ask the teacher to clarify if needed.",
+    "role": "developer",
+  },
+  {
+    "content": "## Voice guidance
+
+Unless otherwise specified, use AILA_TO_TEACHER.",
+    "role": "developer",
+  },
+  {
+    "content": "Generate key learning points for a science lesson about photosynthesis.",
+    "role": "developer",
+  },
+  {
+    "content": "CURRENT DOCUMENT
+
+This is the document in its current state.
+
+{
+  "title": "Introduction to Photosynthesis",
+  "keyStage": "ks3"
+}",
+    "role": "developer",
+  },
+  {
+    "content": "MESSAGE HISTORY
+
+These are the previous messages in the current conversation with the user.
+
+- user: Can you help me create a lesson about photosynthesis for Year 7 students?
+- assistant: I'd be happy to help you create a lesson about photosynthesis for Year 7 students.",
+    "role": "developer",
+  },
+  {
+    "content": "USER's MESSAGE
+
+This is the most recent message from the user that we've been attempting to process.
+
+Please make sure to include the key learning points about chlorophyll and glucose production.",
+    "role": "user",
+  },
+]
+`;
+
 exports[`sectionToGenericPromptAgent input message generation should generate consistent input messages with minimal props 1`] = `
 [
   {

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/createSectionAgent.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/createSectionAgent.ts
@@ -21,6 +21,7 @@ export function createSectionAgent<ResponseType>({
   instructions,
   contentToString = defaultContentToString,
   extraInputFromCtx,
+  documentForPrompt,
   defaultVoice,
   voices,
   modelParams,
@@ -31,6 +32,7 @@ export function createSectionAgent<ResponseType>({
   extraInputFromCtx?: (
     state: AilaExecutionContext,
   ) => { role: "user" | "developer"; content: string }[];
+  documentForPrompt?: (document: PartialLessonPlan) => object;
   defaultVoice?: VoiceId;
   voices?: VoiceId[];
   modelParams: Omit<
@@ -76,6 +78,7 @@ export function createSectionAgent<ResponseType>({
           currentValue,
           ctx,
           extraInputFromCtx,
+          documentForPrompt,
           defaultVoice,
           voices,
         },

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/createSectionAgent.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/createSectionAgent.ts
@@ -32,7 +32,7 @@ export function createSectionAgent<ResponseType>({
   extraInputFromCtx?: (
     state: AilaExecutionContext,
   ) => { role: "user" | "developer"; content: string }[];
-  documentForPrompt?: (document: PartialLessonPlan) => object;
+  documentForPrompt?: (document: PartialLessonPlan) => PartialLessonPlan;
   defaultVoice?: VoiceId;
   voices?: VoiceId[];
   modelParams: Omit<

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/index.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/index.test.ts
@@ -1,0 +1,126 @@
+import type OpenAI from "openai";
+
+import { starterQuizAgent } from ".";
+import type { PartialLessonPlan } from "../../../../../protocol/schema";
+import type {
+  AilaExecutionContext,
+  SectionAgentRegistry,
+} from "../../../types";
+import { executeGenericPromptAgent } from "../../executeGenericPromptAgent";
+
+jest.mock("../../executeGenericPromptAgent", () => ({
+  executeGenericPromptAgent: jest.fn().mockResolvedValue({ data: {} }),
+}));
+
+const document: PartialLessonPlan = {
+  title: "Comparing fractions",
+  keyStage: "ks2",
+  priorKnowledge: ["Pupils can halve shapes"],
+  keyLearningPoints: ["A fraction shows parts of a whole"],
+  cycle1: {
+    title: "Compare unit fractions",
+    durationInMinutes: 10,
+    explanation: {
+      spokenExplanation: "Explain comparing unit fractions.",
+      accompanyingSlideDetails: "Two fraction bars",
+      imagePrompt: "fraction bars",
+      slideText: "Compare unit fractions",
+    },
+    checkForUnderstanding: [
+      {
+        question: "Which is larger, 1/2 or 1/4?",
+        answers: ["1/2"],
+        distractors: ["1/4", "They are equal"],
+      },
+      {
+        question: "Which is smaller, 1/3 or 1/5?",
+        answers: ["1/5"],
+        distractors: ["1/3", "They are equal"],
+      },
+    ],
+    practice: "Sort fractions by size.",
+    feedback: "1/2 is the largest unit fraction.",
+  },
+};
+
+const buildCtx = (): AilaExecutionContext => ({
+  persistedState: {
+    messages: [],
+    initialDocument: {},
+    relevantLessons: [],
+    ragFetched: { status: "not_fetched", searchIdentity: null },
+  },
+  runtime: {
+    plannerAgent: jest.fn(),
+    // empty stub; the prompt-building path never reads the registry
+    sectionAgents: {} as SectionAgentRegistry,
+    messageToUserAgent: jest.fn(),
+    britishEnglishCorrectorAgent: jest.fn(),
+    fetchRelevantLessons: jest.fn(),
+    config: { mathsQuizEnabled: false },
+  },
+  currentTurn: {
+    document,
+    plannerOutput: null,
+    errors: [],
+    notes: [],
+    stepsExecuted: [],
+    relevantLessonsFetched: false,
+    relevantLessons: [],
+    currentStep: null,
+    correctorStats: { attempted: [], notNeeded: [], failed: [] },
+  },
+  callbacks: {
+    onPlannerComplete: jest.fn(),
+    onSectionComplete: jest.fn(),
+    onRagFetchedChange: jest.fn(),
+    onTurnComplete: jest.fn(),
+    onTurnFailed: jest.fn(),
+  },
+});
+
+const runAgentAndGetPromptContents = async (): Promise<string[]> => {
+  const agent = starterQuizAgent({
+    id: "starterQuiz--default",
+    description: "Generates starter quiz questions",
+    openai: {} as OpenAI,
+    contentFromDocument: (doc) =>
+      "starterQuiz" in doc ? doc.starterQuiz : undefined,
+  });
+
+  await agent.handler(buildCtx());
+
+  const { calls } = jest.mocked(executeGenericPromptAgent).mock;
+  const lastCall = calls[calls.length - 1];
+  if (!lastCall) throw new Error("executeGenericPromptAgent was not called");
+  return lastCall[0].agent.input.map((message) => message.content);
+};
+
+describe("starterQuizAgent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("adds the prior knowledge to assess section to the prompt", async () => {
+    const contents = await runAgentAndGetPromptContents();
+
+    const part = contents.find((content) =>
+      content.startsWith("## PRIOR KNOWLEDGE TO ASSESS"),
+    );
+    expect(part).toBeDefined();
+    expect(part).toContain("- Pupils can halve shapes");
+  });
+
+  it("hides the lesson's teaching content from the current document", async () => {
+    const contents = await runAgentAndGetPromptContents();
+
+    const currentDocument = contents.find((content) =>
+      content.startsWith("CURRENT DOCUMENT"),
+    );
+    expect(currentDocument).toBeDefined();
+    expect(currentDocument).toContain("Comparing fractions");
+    expect(currentDocument).toContain("Pupils can halve shapes");
+    expect(currentDocument).not.toContain("A fraction shows parts of a whole");
+    expect(currentDocument).not.toContain("Compare unit fractions");
+  });
+});

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/index.ts
@@ -1,5 +1,6 @@
 import { DEFAULT_AGENT_MODEL_PARAMS } from "../../../constants";
 import { deriveSectionBuildMode } from "../../../quizOperations/deriveSectionBuildMode";
+import { priorKnowledgeTargetPromptPart } from "../../sharedPromptParts/priorKnowledgeTarget.part";
 import { createSectionAgent } from "../createSectionAgent";
 import {
   addOneQuizInstructions,
@@ -7,6 +8,7 @@ import {
   starterQuizInstructions,
 } from "./starterQuiz.instructions";
 import { StarterQuizSchema } from "./starterQuiz.schema";
+import { starterQuizDocumentForPrompt } from "./starterQuizDocumentView";
 
 export const starterQuizAgent = createSectionAgent({
   responseSchema: StarterQuizSchema,
@@ -22,6 +24,10 @@ export const starterQuizAgent = createSectionAgent({
         return rewriteOneQuizInstructions(mode.position, keyStage);
     }
   },
+  extraInputFromCtx: (ctx) => [
+    { role: "developer", content: priorKnowledgeTargetPromptPart(ctx) },
+  ],
+  documentForPrompt: starterQuizDocumentForPrompt,
   defaultVoice: "TEACHER_TO_PUPIL_WRITTEN",
   modelParams: DEFAULT_AGENT_MODEL_PARAMS,
 });

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.test.ts
@@ -10,16 +10,16 @@ describe("starterQuiz instructions", () => {
       expect(starterQuizInstructions("ks2")).toMatch(
         /PRIOR KNOWLEDGE TO ASSESS/,
       );
-      expect(addOneQuizInstructions("ks2")).toMatch(
-        /PRIOR KNOWLEDGE TO ASSESS/,
-      );
-      expect(rewriteOneQuizInstructions(2, "ks2")).toMatch(
-        /PRIOR KNOWLEDGE TO ASSESS/,
-      );
     });
   });
 
   describe("addOneQuizInstructions", () => {
+    it("binds the new question to the prior knowledge to assess section", () => {
+      expect(addOneQuizInstructions("ks2")).toMatch(
+        /PRIOR KNOWLEDGE TO ASSESS/,
+      );
+    });
+
     it("directs the LLM to generate exactly one question", () => {
       expect(addOneQuizInstructions("ks2")).toMatch(/exactly one/i);
     });
@@ -42,6 +42,12 @@ describe("starterQuiz instructions", () => {
   });
 
   describe("rewriteOneQuizInstructions", () => {
+    it("binds the replacement question to the prior knowledge to assess section", () => {
+      expect(rewriteOneQuizInstructions(2, "ks2")).toMatch(
+        /PRIOR KNOWLEDGE TO ASSESS/,
+      );
+    });
+
     it("is a function that accepts a 1-indexed position", () => {
       expect(typeof rewriteOneQuizInstructions).toBe("function");
     });

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.test.ts
@@ -5,6 +5,20 @@ import {
 } from "./starterQuiz.instructions";
 
 describe("starterQuiz instructions", () => {
+  describe("starterQuizInstructions", () => {
+    it("binds questions to the prior knowledge to assess section", () => {
+      expect(starterQuizInstructions("ks2")).toMatch(
+        /PRIOR KNOWLEDGE TO ASSESS/,
+      );
+      expect(addOneQuizInstructions("ks2")).toMatch(
+        /PRIOR KNOWLEDGE TO ASSESS/,
+      );
+      expect(rewriteOneQuizInstructions(2, "ks2")).toMatch(
+        /PRIOR KNOWLEDGE TO ASSESS/,
+      );
+    });
+  });
+
   describe("addOneQuizInstructions", () => {
     it("directs the LLM to generate exactly one question", () => {
       expect(addOneQuizInstructions("ks2")).toMatch(/exactly one/i);

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.ts
@@ -7,8 +7,8 @@ Create a 6-question multiple-choice quiz to assess PRIOR KNOWLEDGE ONLY — do n
 
 ## Content Scope:
 
-- Use only content from the PRIOR KNOWLEDGE section
-- Do not test or mention any of this lessons key learning points
+- Base questions on the PRIOR KNOWLEDGE TO ASSESS section provided below
+- Do not test or mention any of this lesson's key learning points
 - Content should be age-appropriate
 - Questions should increase in difficulty
 - Designed so the average pupil scores 5 out of 6.
@@ -24,6 +24,11 @@ export function addOneQuizInstructions(keyStage: string): string {
 
 Generate exactly ONE new multiple-choice question to ADD to the existing quiz. Do not output, modify, or restate the existing questions — they will be preserved by the system.
 
+## Content Scope
+
+- The new question must assess prior knowledge from the PRIOR KNOWLEDGE TO ASSESS section provided below.
+- It must not overlap with the existing questions or test new lesson content.
+
 ## Question Design
 
 ${quizQuestionDesignInstructions(keyStage)}`;
@@ -36,6 +41,11 @@ export const rewriteOneQuizInstructions = (
   `# Task
 
 Rewrite question ${position} of the existing quiz. Return only the replacement question. Do not modify or output any of the other questions — they will be preserved by the system.
+
+## Content Scope
+
+- The replacement question must assess prior knowledge from the PRIOR KNOWLEDGE TO ASSESS section provided below.
+- It must not overlap with the other questions or test new lesson content.
 
 ## Question Design
 

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuizDocumentView.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuizDocumentView.test.ts
@@ -1,0 +1,33 @@
+import type { PartialLessonPlan } from "../../../../../protocol/schema";
+import { starterQuizDocumentForPrompt } from "./starterQuizDocumentView";
+
+describe("starterQuizDocumentForPrompt", () => {
+  it("keeps lesson context fields and prior knowledge only", () => {
+    const document: PartialLessonPlan = {
+      title: "Comparing fractions",
+      subject: "maths",
+      keyStage: "ks2",
+      topic: "Fractions",
+      learningOutcome: "I can compare fractions with the same denominator",
+      priorKnowledge: ["Pupils can halve shapes"],
+      keyLearningPoints: ["A fraction shows parts of a whole"],
+      keywords: [{ keyword: "denominator", definition: "The bottom number" }],
+      learningCycles: ["Compare unit fractions"],
+    };
+
+    expect(starterQuizDocumentForPrompt(document)).toEqual({
+      title: "Comparing fractions",
+      subject: "maths",
+      keyStage: "ks2",
+      topic: "Fractions",
+      learningOutcome: "I can compare fractions with the same denominator",
+      priorKnowledge: ["Pupils can halve shapes"],
+    });
+  });
+
+  it("handles a sparse document", () => {
+    expect(starterQuizDocumentForPrompt({ title: "New lesson" })).toEqual({
+      title: "New lesson",
+    });
+  });
+});

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuizDocumentView.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuizDocumentView.test.ts
@@ -10,9 +10,41 @@ describe("starterQuizDocumentForPrompt", () => {
       topic: "Fractions",
       learningOutcome: "I can compare fractions with the same denominator",
       priorKnowledge: ["Pupils can halve shapes"],
+      basedOn: { id: "lesson-1", title: "Fractions of shapes" },
       keyLearningPoints: ["A fraction shows parts of a whole"],
       keywords: [{ keyword: "denominator", definition: "The bottom number" }],
       learningCycles: ["Compare unit fractions"],
+      misconceptions: [
+        {
+          misconception: "Bigger denominators mean bigger fractions",
+          description: "Show that 1/8 is smaller than 1/4 using fraction bars.",
+        },
+      ],
+      cycle1: {
+        title: "Compare unit fractions",
+        durationInMinutes: 10,
+        explanation: {
+          spokenExplanation: "Explain comparing unit fractions.",
+          accompanyingSlideDetails: "Two fraction bars",
+          imagePrompt: "fraction bars",
+          slideText: "Compare unit fractions",
+        },
+        checkForUnderstanding: [
+          {
+            question: "Which is larger, 1/2 or 1/4?",
+            answers: ["1/2"],
+            distractors: ["1/4", "They are equal"],
+          },
+          {
+            question: "Which is smaller, 1/3 or 1/5?",
+            answers: ["1/5"],
+            distractors: ["1/3", "They are equal"],
+          },
+        ],
+        practice: "Sort fractions by size.",
+        feedback: "1/2 is the largest unit fraction.",
+      },
+      exitQuiz: { version: "v3", questions: [], imageMetadata: [] },
     };
 
     expect(starterQuizDocumentForPrompt(document)).toEqual({

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuizDocumentView.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuizDocumentView.ts
@@ -10,7 +10,7 @@ import type { PartialLessonPlan } from "../../../../../protocol/schema";
  */
 export function starterQuizDocumentForPrompt(
   document: PartialLessonPlan,
-): object {
+): PartialLessonPlan {
   return pick(document, [
     "title",
     "subject",

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuizDocumentView.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuizDocumentView.ts
@@ -1,0 +1,22 @@
+import { pick } from "remeda";
+
+import type { PartialLessonPlan } from "../../../../../protocol/schema";
+
+/**
+ * The starter quiz assesses prior knowledge only, so the agent must not see
+ * the lesson's own teaching content (key learning points, cycles, keywords,
+ * exit quiz); with it in view the model tends to test upcoming material.
+ * The learning outcome stays for topic anchoring and difficulty calibration.
+ */
+export function starterQuizDocumentForPrompt(
+  document: PartialLessonPlan,
+): object {
+  return pick(document, [
+    "title",
+    "subject",
+    "keyStage",
+    "topic",
+    "learningOutcome",
+    "priorKnowledge",
+  ]);
+}

--- a/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.test.ts
@@ -199,6 +199,20 @@ describe("sectionToGenericPromptAgent", () => {
       expect(agent.input).toMatchSnapshot();
     });
 
+    it("should filter the current document with documentForPrompt", () => {
+      const propsWithDocumentView: SectionPromptAgentProps<MockSchemaType> = {
+        ...baseProps,
+        documentForPrompt: (document) => ({
+          title: document.title,
+          keyStage: document.keyStage,
+        }),
+      };
+
+      const agent = createAgent(propsWithDocumentView);
+
+      expect(agent.input).toMatchSnapshot();
+    });
+
     it("should handle extra input from context", () => {
       const extraInputFromCtx = (_ctx: AilaExecutionContext) => [
         {

--- a/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.ts
@@ -28,6 +28,7 @@ export function sectionToGenericPromptAgent<SectionValueType>(
     contentToString,
     ctx,
     extraInputFromCtx,
+    documentForPrompt,
     defaultVoice = "AILA_TO_TEACHER",
     voices = [],
   }: SectionPromptAgentProps<SectionValueType>,
@@ -60,7 +61,10 @@ export function sectionToGenericPromptAgent<SectionValueType>(
       },
       {
         role: "developer" as const,
-        content: currentDocumentPromptPart(ctx.currentTurn.document),
+        content: currentDocumentPromptPart(
+          documentForPrompt?.(ctx.currentTurn.document) ??
+            ctx.currentTurn.document,
+        ),
       },
       currentValue && {
         role: "developer" as const,

--- a/packages/aila/src/lib/agentic-system/agents/sharedPromptParts/priorKnowledgeTarget.part.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sharedPromptParts/priorKnowledgeTarget.part.test.ts
@@ -1,0 +1,43 @@
+import type { PartialLessonPlan } from "../../../../protocol/schema";
+import type { AilaExecutionContext } from "../../types";
+import { priorKnowledgeTargetPromptPart } from "./priorKnowledgeTarget.part";
+
+const makeCtx = (document: PartialLessonPlan): AilaExecutionContext =>
+  ({ currentTurn: { document } }) as AilaExecutionContext;
+
+describe("priorKnowledgeTargetPromptPart", () => {
+  it("lists each prior knowledge statement as a bullet", () => {
+    const part = priorKnowledgeTargetPromptPart(
+      makeCtx({
+        priorKnowledge: ["Pupils can count to 100", "Pupils can halve shapes"],
+      }),
+    );
+
+    expect(part).toContain("- Pupils can count to 100");
+    expect(part).toContain("- Pupils can halve shapes");
+    expect(part).toContain("PRIOR KNOWLEDGE TO ASSESS");
+  });
+
+  it("falls back to prerequisite guidance when prior knowledge is missing", () => {
+    const part = priorKnowledgeTargetPromptPart(makeCtx({}));
+
+    expect(part).toContain("No prior knowledge statements exist yet");
+    expect(part).toContain("do not test the lesson's own content");
+  });
+
+  it("falls back to prerequisite guidance when prior knowledge is empty", () => {
+    const part = priorKnowledgeTargetPromptPart(
+      makeCtx({ priorKnowledge: [] }),
+    );
+
+    expect(part).toContain("No prior knowledge statements exist yet");
+  });
+
+  it("tells the model never to test what the lesson will teach", () => {
+    const part = priorKnowledgeTargetPromptPart(
+      makeCtx({ priorKnowledge: ["Pupils can count to 100"] }),
+    );
+
+    expect(part).toMatch(/never test or hint at what this lesson itself/i);
+  });
+});

--- a/packages/aila/src/lib/agentic-system/agents/sharedPromptParts/priorKnowledgeTarget.part.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sharedPromptParts/priorKnowledgeTarget.part.ts
@@ -1,0 +1,24 @@
+import type { AilaExecutionContext } from "../../types";
+
+export function priorKnowledgeTargetPromptPart(
+  ctx: AilaExecutionContext,
+): string {
+  const priorKnowledge = ctx.currentTurn.document.priorKnowledge ?? [];
+
+  const statements =
+    priorKnowledge.length > 0
+      ? `The statements below are the lesson's stated prior knowledge and are the primary source for questions:
+
+${priorKnowledge.map((statement) => `- ${statement}`).join("\n")}`
+      : "No prior knowledge statements exist yet. Base questions strictly on prerequisite knowledge for this lesson's title and key stage; do not test the lesson's own content.";
+
+  return `## PRIOR KNOWLEDGE TO ASSESS
+
+The starter quiz assesses ONLY knowledge pupils should already have BEFORE this lesson begins.
+
+${statements}
+
+Rules:
+- Base questions on the statements above; topic-appropriate prerequisite knowledge for this key stage may supplement them.
+- Never test or hint at what this lesson itself will teach. Lesson context is for difficulty calibration only, never a source of questions.`;
+}

--- a/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
@@ -366,13 +366,16 @@ const SCORERS: Scorer[] = [
   },
   {
     id: "starter-quiz-grounding",
-    description: "Starter quiz questions vs prior knowledge (grounding review)",
+    description:
+      "Starter quiz vs prior knowledge (evidence for manual review; pass = prior knowledge present)",
     fn: ({ finalDocument }) => {
       const quiz = finalDocument.starterQuiz;
       if (!quiz) {
         return { heuristic: "skip", evidence: "No starter quiz present" };
       }
       const priorKnowledge = finalDocument.priorKnowledge ?? [];
+      const questions = quiz.questions ?? [];
+      const keyLearningPoints = finalDocument.keyLearningPoints ?? [];
       const lines: string[] = [];
       lines.push("Prior knowledge (questions should assess this):");
       lines.push(
@@ -381,12 +384,16 @@ const SCORERS: Scorer[] = [
           : ["  (none)"]),
       );
       lines.push("Starter quiz questions:");
-      for (const [qi, q] of (quiz.questions ?? []).entries()) {
-        lines.push(`  Q${qi + 1}: ${q.question}`);
-      }
+      lines.push(
+        ...(questions.length > 0
+          ? questions.map((q, qi) => `  Q${qi + 1}: ${q.question}`)
+          : ["  (none)"]),
+      );
       lines.push("Upcoming content (should NOT be tested):");
       lines.push(
-        ...(finalDocument.keyLearningPoints ?? []).map((klp) => `  - ${klp}`),
+        ...(keyLearningPoints.length > 0
+          ? keyLearningPoints.map((klp) => `  - ${klp}`)
+          : ["  (none)"]),
       );
       return {
         heuristic: priorKnowledge.length === 0 ? "flag" : "pass",

--- a/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
@@ -364,6 +364,36 @@ const SCORERS: Scorer[] = [
       };
     },
   },
+  {
+    id: "starter-quiz-grounding",
+    description: "Starter quiz questions vs prior knowledge (grounding review)",
+    fn: ({ finalDocument }) => {
+      const quiz = finalDocument.starterQuiz;
+      if (!quiz) {
+        return { heuristic: "skip", evidence: "No starter quiz present" };
+      }
+      const priorKnowledge = finalDocument.priorKnowledge ?? [];
+      const lines: string[] = [];
+      lines.push("Prior knowledge (questions should assess this):");
+      lines.push(
+        ...(priorKnowledge.length > 0
+          ? priorKnowledge.map((statement) => `  - ${statement}`)
+          : ["  (none)"]),
+      );
+      lines.push("Starter quiz questions:");
+      for (const [qi, q] of (quiz.questions ?? []).entries()) {
+        lines.push(`  Q${qi + 1}: ${q.question}`);
+      }
+      lines.push("Upcoming content (should NOT be tested):");
+      lines.push(
+        ...(finalDocument.keyLearningPoints ?? []).map((klp) => `  - ${klp}`),
+      );
+      return {
+        heuristic: priorKnowledge.length === 0 ? "flag" : "pass",
+        evidence: lines.join("\n"),
+      };
+    },
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
-codeHash: 3d0b0345ad18db9c639ebd016fb2a4bb32e1d819b4d1b2d9b4c7456cab24943e
-generated: 2026-07-02T16:15:25.302Z
+codeHash: 7ab2d096e61f1e30e36242f1d2ccaa4c1c948023ac2c4bde3f0aadf462c2812a
+generated: 2026-07-09T11:26:53.147Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -22,6 +22,8 @@ summary:
     americanisms-meanings:
       flag: 3
     quiz-question-count:
+      pass: 3
+    starter-quiz-grounding:
       pass: 3
     americanisms_corrector:
       corrections_attempted: 1
@@ -53,6 +55,8 @@ summary:
     americanisms-meanings:
       flag: 3
     quiz-question-count:
+      pass: 3
+    starter-quiz-grounding:
       pass: 3
     americanisms_corrector:
       corrections_attempted: 0

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
 codeHash: 48bd234fc51e430abe54da7255e3ea4bc32eaac5decd1f032e493cf0751e1853
-generated: 2026-07-13T18:20:45.450Z
+generated: 2026-07-14T08:40:50.040Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -26,13 +26,12 @@ summary:
     starter-quiz-grounding:
       pass: 3
     americanisms_corrector:
-      corrections_attempted: 1
-      corrections_not_needed: 32
+      corrections_attempted: 0
+      corrections_not_needed: 33
       corrections_failed: 0
-      correction_rate: 3.0%
+      correction_rate: 0.0%
       correction_failure_rate: 0.0%
-      corrections_by_section:
-        cycle3: 1
+      corrections_by_section: {}
   no-rag-lesson:
     generation-complete:
       pass: 3
@@ -59,9 +58,10 @@ summary:
     starter-quiz-grounding:
       pass: 3
     americanisms_corrector:
-      corrections_attempted: 0
-      corrections_not_needed: 33
+      corrections_attempted: 1
+      corrections_not_needed: 32
       corrections_failed: 0
-      correction_rate: 0.0%
+      correction_rate: 3.0%
       correction_failure_rate: 0.0%
-      corrections_by_section: {}
+      corrections_by_section:
+        exitQuiz: 1

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
-codeHash: 48bd234fc51e430abe54da7255e3ea4bc32eaac5decd1f032e493cf0751e1853
-generated: 2026-07-14T08:40:50.040Z
+codeHash: c79239c9993aa670f8663f6e5f371807010a8e94d2f349793dc8594edc960103
+generated: 2026-07-14T15:46:44.801Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -64,4 +64,4 @@ summary:
       correction_rate: 3.0%
       correction_failure_rate: 0.0%
       corrections_by_section:
-        exitQuiz: 1
+        cycle3: 1

--- a/packages/aila/src/lib/agentic-system/types.ts
+++ b/packages/aila/src/lib/agentic-system/types.ts
@@ -115,6 +115,8 @@ export type SectionPromptAgentProps<ResponseType> = {
   extraInputFromCtx?: (
     ctx: AilaExecutionContext,
   ) => { role: "user" | "developer"; content: string }[];
+  /** Narrows the CURRENT DOCUMENT the agent sees; defaults to the full document. */
+  documentForPrompt?: (document: PartialLessonPlan) => object;
   defaultVoice?: VoiceId;
   voices?: VoiceId[];
 };

--- a/packages/aila/src/lib/agentic-system/types.ts
+++ b/packages/aila/src/lib/agentic-system/types.ts
@@ -116,7 +116,7 @@ export type SectionPromptAgentProps<ResponseType> = {
     ctx: AilaExecutionContext,
   ) => { role: "user" | "developer"; content: string }[];
   /** Narrows the CURRENT DOCUMENT the agent sees; defaults to the full document. */
-  documentForPrompt?: (document: PartialLessonPlan) => object;
+  documentForPrompt?: (document: PartialLessonPlan) => PartialLessonPlan;
   defaultVoice?: VoiceId;
   voices?: VoiceId[];
 };


### PR DESCRIPTION
## Description

The starter quiz sometimes tested content the lesson is about to teach, not knowledge pupils already have. This was because the agent was handed the whole lesson plan, so it drew questions from upcoming material like key learning points and cycles, despite being told to assess prior knowledge only. This narrows its view to the lesson framing plus `priorKnowledge`, adds a dedicated `PRIOR KNOWLEDGE TO ASSESS` prompt section, and tightens the instructions. 

A new `starter-quiz-grounding` scorer shows prior knowledge against the generated questions in the report. Changes are scoped to the starter quiz agent so the exit quiz and every other agent are unchanged.

## Issue(s)

Fixes [AI-2331](https://app.notion.com/p/oaknationalacademy/Grounding-starter-quizzes-in-prior-knowledge-39826cc4e1b18021bfe5fb183ab0e566?source=copy_link)

## How to test

1. Go to <!-- vercel-preview -->https://oak-ai-lesson-assistant-website-gg4qeemar.vercel.thenational.academy<!-- /vercel-preview -->
2. Create a lesson on any topic and let it generate fully
3. Open the starter quiz and compare its questions against the lesson's Prior knowledge section: every question should check prerequisite knowledge, not the lesson's own key learning points or cycle content
4. Ask Aila to "regenerate the starter quiz", then "add a question to the starter quiz", then "rewrite question 2”. Expect: the prior-knowledge grounding should hold in each mode.

## Screenshots

n/a (prompt and agent-wiring change; no UI change)

## Checklist

- [x] ~~Manually tested across browsers / devices~~ (no UI change)
- [ ] ~~Considered impact on accessibility~~ (no UI change)
- [ ] ~~Does this PR update a package with a breaking change~~
