### PR TITLE
build: release candidate

### DIFF
--- a/packages/aila/src/core/chat/AilaStreamHandler.test.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.test.ts
@@ -145,6 +145,47 @@ function createThreatDetector(
   };
 }
 
+function collectPlannerGeneration({
+  status,
+  response,
+}: {
+  status: "SUCCESS" | "FAILED";
+  response: unknown;
+}) {
+  mockedCreateOpenAIPlannerAgent.mockImplementationOnce(
+    (_openai, collectGeneration) => () => {
+      collectGeneration?.({
+        agentId: "planner",
+        promptTemplateId: "planner",
+        promptTemplate: "planner template body",
+        promptInputs: {
+          agentId: "planner",
+          promptTemplateId: "planner",
+          model: "gpt-test",
+        },
+        status,
+        llmTimeTaken: 100,
+        promptTokensUsed: 1,
+        completionTokensUsed: 2,
+        promptText: "test prompt",
+        response,
+      });
+      return Promise.resolve(
+        status === "SUCCESS"
+          ? {
+              error: null,
+              data: {
+                decision: "plan" as const,
+                parsedUserMessage: "test prompt",
+                plan: [],
+              },
+            }
+          : { error: { message: String(response) } },
+      );
+    },
+  );
+}
+
 function createMockChat({
   useAgenticAila,
   threatDetectors = [],
@@ -169,7 +210,14 @@ function createMockChat({
       options: {
         useAgenticAila,
       },
-      prisma: {},
+      prisma: {
+        prompt: {
+          findFirst: jest.fn().mockResolvedValue({ id: "prompt_planner" }),
+        },
+        generation: {
+          createMany: jest.fn().mockResolvedValue({ count: 0 }),
+        },
+      },
       tracing: {
         span: async (
           _step: string,
@@ -255,6 +303,119 @@ describe("AilaStreamHandler", () => {
     expect(chat.enqueue).not.toHaveBeenCalledWith({
       type: "comment",
       value: "CHAT_COMPLETE",
+    });
+  });
+
+  it("does not attach failed agentic generations to the user's message", async () => {
+    collectPlannerGeneration({
+      status: "FAILED",
+      response: "planner failed",
+    });
+    mockedAilaTurn.mockImplementationOnce(async ({ runtime }) => {
+      await runtime.plannerAgent({} as never);
+      return createAilaTurnOutcome("failed");
+    });
+
+    const chat = createMockChat({ useAgenticAila: true });
+    const handler = new AilaStreamHandler(chat as never);
+
+    await consumeStream(handler.startStreaming());
+
+    expect(chat.aila.prisma.generation.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          promptId: "prompt_planner",
+          promptInputs: expect.objectContaining({
+            agentId: "planner",
+          }),
+          status: "FAILED",
+          appSessionId: "chat_123",
+          messageId: undefined,
+        }),
+      ],
+    });
+  });
+
+  it("does not attach failed agentic follow-up generations to the previous assistant message", async () => {
+    collectPlannerGeneration({
+      status: "FAILED",
+      response: "planner failed",
+    });
+    mockedAilaTurn.mockImplementationOnce(async ({ runtime }) => {
+      await runtime.plannerAgent({} as never);
+      return createAilaTurnOutcome("failed");
+    });
+
+    const chat = createMockChat({ useAgenticAila: true });
+    chat.messages.push({
+      id: "assistant_previous",
+      role: "assistant",
+      content: "Previous assistant response",
+    });
+    chat.messages.push({
+      id: "user_follow_up",
+      role: "user",
+      content: "Please change question 2",
+    });
+    const handler = new AilaStreamHandler(chat as never);
+
+    await consumeStream(handler.startStreaming());
+
+    expect(chat.aila.prisma.generation.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          status: "FAILED",
+          appSessionId: "chat_123",
+          messageId: undefined,
+        }),
+      ],
+    });
+  });
+
+  it("attaches successful agentic generations to the assistant message from the current turn", async () => {
+    collectPlannerGeneration({
+      status: "SUCCESS",
+      response: { value: {} },
+    });
+    mockedAilaTurn.mockImplementationOnce(async ({ runtime }) => {
+      await runtime.plannerAgent({} as never);
+      return createAilaTurnOutcome("success");
+    });
+
+    const chat = createMockChat({ useAgenticAila: true });
+    chat.messages.push({
+      id: "assistant_previous",
+      role: "assistant",
+      content: "Previous assistant response",
+    });
+    chat.messages.push({
+      id: "user_follow_up",
+      role: "user",
+      content: "Please change question 2",
+    });
+    chat.complete = jest.fn().mockImplementation(async () => {
+      chat.messages.push({
+        id: "assistant_current",
+        role: "assistant",
+        content: "Current assistant response",
+      });
+      await chat.enqueue({
+        type: "comment",
+        value: "CHAT_COMPLETE",
+      });
+    });
+    const handler = new AilaStreamHandler(chat as never);
+
+    await consumeStream(handler.startStreaming());
+
+    expect(chat.aila.prisma.generation.createMany).toHaveBeenCalledWith({
+      data: [
+        expect.objectContaining({
+          status: "SUCCESS",
+          appSessionId: "chat_123",
+          messageId: "assistant_current",
+        }),
+      ],
     });
   });
 

--- a/packages/aila/src/core/chat/AilaStreamHandler.ts
+++ b/packages/aila/src/core/chat/AilaStreamHandler.ts
@@ -8,7 +8,13 @@ import type { getRagLessonPlansByIds } from "@oakai/rag";
 
 import type { ReadableStreamDefaultController } from "stream/web";
 
+import { getLastAssistantMessage } from "../../helpers/chat/getLastAssistantMessage";
+import { resolveAgenticPromptIds } from "../../lib/agentic-system/agents/agenticPromptRegistry";
 import { createOpenAIBritishEnglishCorrectorAgent } from "../../lib/agentic-system/agents/britishEnglishCorrectorAgent";
+import type {
+  GenerationCollector,
+  PendingGeneration,
+} from "../../lib/agentic-system/agents/executeGenericPromptAgent";
 import { createOpenAIMessageToUserAgent } from "../../lib/agentic-system/agents/messageToUserAgent";
 import { createOpenAIPlannerAgent } from "../../lib/agentic-system/agents/plannerAgent";
 import { createSectionAgentRegistry } from "../../lib/agentic-system/agents/sectionAgents/sectionAgentRegistry";
@@ -27,6 +33,7 @@ import { AilaChatError } from "../AilaError";
 import { ReportStorage, createQuizTracker } from "../quiz/reporting";
 import type { AilaChat } from "./AilaChat";
 import type { PatchEnqueuer } from "./PatchEnqueuer";
+import { buildAgenticGenerationRows } from "./agenticGenerationPersistence";
 import type { Message } from "./types";
 
 const log = aiLogger("aila:stream");
@@ -62,6 +69,7 @@ export class AilaStreamHandler {
   private _controller?: ReadableStreamDefaultController;
   private readonly _patchEnqueuer: PatchEnqueuer;
   private _streamReader?: ReadableStreamDefaultReader<string>;
+  private _pendingGenerations: PendingGeneration[] = [];
 
   constructor(chat: AilaChat) {
     this._chat = chat;
@@ -106,6 +114,10 @@ export class AilaStreamHandler {
         m.role !== "data",
     );
   }
+
+  private collectPendingGenerationData = (generation: PendingGeneration) => {
+    this._pendingGenerations.push(generation);
+  };
 
   private async checkForThreats(): Promise<ThreatCheckOutcome> {
     const messagesToCheck = this.threatDetectionMessages();
@@ -193,9 +205,20 @@ export class AilaStreamHandler {
           status,
           chatId: this._chat.id,
         });
+        let currentTurnMessageId: string | undefined;
         if (outcome.status === "success") {
+          const previousAssistantMessageId = getLastAssistantMessage(
+            this._chat.messages,
+          )?.id;
           await this.completeChat();
+          const nextAssistantMessageId = getLastAssistantMessage(
+            this._chat.messages,
+          )?.id;
+          if (nextAssistantMessageId !== previousAssistantMessageId) {
+            currentTurnMessageId = nextAssistantMessageId;
+          }
         }
+        await this.persistPendingGenerations(currentTurnMessageId);
       } finally {
         this.closeController();
         log.info("Stream closed", this._chat.iteration, this._chat.id);
@@ -299,6 +322,10 @@ export class AilaStreamHandler {
       },
     });
 
+    // Capture generations for persistence, except in fixture mode
+    let collectGeneration: GenerationCollector | undefined =
+      this.collectPendingGenerationData;
+
     const { agenticFixture } = this._chat.aila.options;
     if (agenticFixture) {
       log.info(
@@ -307,6 +334,7 @@ export class AilaStreamHandler {
         agenticFixture.fixtureName,
       );
       openai = wrapOpenAIWithFixture(openai, agenticFixture);
+      collectGeneration = undefined;
     } else {
       log.info("No agenticFixture config — using real OpenAI client");
     }
@@ -344,14 +372,20 @@ export class AilaStreamHandler {
         config: {
           mathsQuizEnabled: this._chat.aila.options.useMathsQuizRag ?? false,
         },
-        plannerAgent: createOpenAIPlannerAgent(openai),
+        plannerAgent: createOpenAIPlannerAgent(openai, collectGeneration),
         sectionAgents: createSectionAgentRegistry({
           openai,
+          collectGeneration,
           customAgentHandlers: this.createMathsQuizAgentHandlers(),
         }),
-        messageToUserAgent: createOpenAIMessageToUserAgent(openai),
-        britishEnglishCorrectorAgent:
-          createOpenAIBritishEnglishCorrectorAgent(openai),
+        messageToUserAgent: createOpenAIMessageToUserAgent(
+          openai,
+          collectGeneration,
+        ),
+        britishEnglishCorrectorAgent: createOpenAIBritishEnglishCorrectorAgent(
+          openai,
+          collectGeneration,
+        ),
         fetchRelevantLessons: async ({ title, subject, keyStage }) => {
           const {
             getRelevantLessonPlans,
@@ -421,6 +455,41 @@ export class AilaStreamHandler {
       type: "error",
       value: "Something went wrong. Please try sending your message again.",
     });
+  }
+
+  private async persistPendingGenerations(messageId?: string) {
+    if (this._pendingGenerations.length === 0) {
+      return;
+    }
+
+    const userId = this._chat.userId;
+    if (!userId) {
+      log.info("No userId found for chat. Not persisting generations.");
+      return;
+    }
+
+    try {
+      const promptIdsByPromptTemplateId = await resolveAgenticPromptIds({
+        prisma: this._chat.aila.prisma,
+        templates: this._pendingGenerations.map((generation) => ({
+          promptTemplateId: generation.promptTemplateId,
+          promptTemplate: generation.promptTemplate,
+        })),
+      });
+      const data = buildAgenticGenerationRows({
+        pendingGenerations: this._pendingGenerations,
+        promptIdsByPromptTemplateId,
+        userId,
+        appSessionId: this._chat.id,
+        messageId,
+      });
+
+      await this._chat.aila.prisma.generation.createMany({ data });
+      log.info("Persisted %d agentic generation(s)", data.length);
+    } catch (e) {
+      log.error("Error persisting generation data", e);
+      this._chat.aila.errorReporter?.reportError(e);
+    }
   }
 
   private createMathsQuizAgentHandlers(): {

--- a/packages/aila/src/core/chat/agenticGenerationPersistence.test.ts
+++ b/packages/aila/src/core/chat/agenticGenerationPersistence.test.ts
@@ -1,0 +1,108 @@
+import { Prisma } from "@oakai/db/prisma/client";
+
+import type { PendingGeneration } from "../../lib/agentic-system/agents/executeGenericPromptAgent";
+import { buildAgenticGenerationRows } from "./agenticGenerationPersistence";
+
+const completedAt = new Date("2026-01-02T03:04:05.000Z");
+
+const promptIdsByPromptTemplateId = { planner: "prompt_planner" };
+
+function pendingGeneration(
+  overrides: Partial<PendingGeneration> = {},
+): PendingGeneration {
+  return {
+    agentId: "planner",
+    promptTemplateId: "planner",
+    promptTemplate: "planner template body",
+    promptInputs: {
+      agentId: "planner",
+      promptTemplateId: "planner",
+      model: "gpt-test",
+    },
+    status: "SUCCESS",
+    llmTimeTaken: 123,
+    promptTokensUsed: 10,
+    completionTokensUsed: 20,
+    response: { value: { title: "A lesson" } },
+    promptText: "system prompt\nuser prompt",
+    ...overrides,
+  };
+}
+
+describe("buildAgenticGenerationRows", () => {
+  it("maps pending generation telemetry to generation create rows", () => {
+    const rows = buildAgenticGenerationRows({
+      pendingGenerations: [pendingGeneration()],
+      promptIdsByPromptTemplateId,
+      userId: "user_123",
+      appSessionId: "chat_123",
+      messageId: "assistant_123",
+      completedAt,
+    });
+
+    expect(rows).toEqual([
+      {
+        promptId: "prompt_planner",
+        promptInputs: {
+          agentId: "planner",
+          promptTemplateId: "planner",
+          model: "gpt-test",
+        },
+        status: "SUCCESS",
+        llmTimeTaken: 123,
+        promptTokensUsed: 10,
+        completionTokensUsed: 20,
+        promptText: "system prompt\nuser prompt",
+        response: { value: { title: "A lesson" } },
+        userId: "user_123",
+        appId: "lesson-planner",
+        completedAt,
+        appSessionId: "chat_123",
+        messageId: "assistant_123",
+      },
+    ]);
+  });
+
+  it("maps top-level null to the JSON null sentinel", () => {
+    const [row] = buildAgenticGenerationRows({
+      pendingGenerations: [pendingGeneration({ response: null })],
+      promptIdsByPromptTemplateId,
+      userId: "user_123",
+      appSessionId: "chat_123",
+      completedAt,
+    });
+
+    expect(row?.response).toBe(Prisma.JsonNull);
+  });
+
+  it("preserves nested nulls in the response", () => {
+    const [row] = buildAgenticGenerationRows({
+      pendingGenerations: [
+        pendingGeneration({ response: { value: { title: null } } }),
+      ],
+      promptIdsByPromptTemplateId,
+      userId: "user_123",
+      appSessionId: "chat_123",
+      completedAt,
+    });
+
+    expect(row?.response).toEqual({ value: { title: null } });
+  });
+
+  it("throws when an agent has no resolved prompt id", () => {
+    expect(() =>
+      buildAgenticGenerationRows({
+        pendingGenerations: [
+          pendingGeneration({
+            agentId: "cycle--default",
+            promptTemplateId: "cycle--default",
+          }),
+        ],
+        promptIdsByPromptTemplateId,
+        userId: "user_123",
+        appSessionId: "chat_123",
+        completedAt,
+      }),
+    ).toThrow("Cannot persist agentic generation for cycle--default");
+  });
+});

--- a/packages/aila/src/core/chat/agenticGenerationPersistence.ts
+++ b/packages/aila/src/core/chat/agenticGenerationPersistence.ts
@@ -1,0 +1,58 @@
+import { Prisma } from "@oakai/db/prisma/client";
+
+import type { PendingGeneration } from "../../lib/agentic-system/agents/executeGenericPromptAgent";
+
+type BuildAgenticGenerationRowsArgs = {
+  pendingGenerations: PendingGeneration[];
+  promptIdsByPromptTemplateId: Record<string, string>;
+  userId: string;
+  appSessionId: string;
+  messageId?: string;
+  completedAt?: Date;
+};
+
+/**
+ * Prisma rejects a bare `null`/`undefined` at the top
+ * level of a Json column, so map that to the JSON null sentinel.
+ */
+function toJsonInput(
+  value: unknown,
+): Prisma.InputJsonValue | typeof Prisma.JsonNull {
+  return value == null ? Prisma.JsonNull : (value as Prisma.InputJsonValue);
+}
+
+export function buildAgenticGenerationRows({
+  pendingGenerations,
+  promptIdsByPromptTemplateId,
+  userId,
+  appSessionId,
+  messageId,
+  completedAt = new Date(),
+}: BuildAgenticGenerationRowsArgs): Prisma.GenerationCreateManyInput[] {
+  return pendingGenerations.map((generation) => {
+    const promptId = promptIdsByPromptTemplateId[generation.promptTemplateId];
+    if (!promptId) {
+      throw new Error(
+        `Cannot persist agentic generation for ${generation.agentId}: missing prompt id for ${generation.promptTemplateId}`,
+      );
+    }
+
+    return {
+      promptId,
+      status: generation.status,
+      llmTimeTaken: generation.llmTimeTaken,
+      promptTokensUsed: generation.promptTokensUsed,
+      completionTokensUsed: generation.completionTokensUsed,
+      promptText: generation.promptText,
+      promptInputs: generation.promptInputs
+        ? toJsonInput(generation.promptInputs)
+        : undefined,
+      response: toJsonInput(generation.response),
+      userId,
+      appId: "lesson-planner",
+      completedAt,
+      appSessionId,
+      messageId,
+    };
+  });
+}

--- a/packages/aila/src/lib/agentic-system/agents/__snapshots__/sectionToGenericPromptAgent.test.ts.snap
+++ b/packages/aila/src/lib/agentic-system/agents/__snapshots__/sectionToGenericPromptAgent.test.ts.snap
@@ -1,5 +1,97 @@
 // Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
+exports[`sectionToGenericPromptAgent input message generation should filter the current document with documentForPrompt 1`] = `
+[
+  {
+    "content": "# Identity
+
+You are a content generator within Aila, an AI-powered lesson planning assistant for UK teachers.
+Your output is section content only — it will be inserted directly into the lesson plan document.
+Do not address the user, ask questions, or produce conversational responses. A separate agent handles communication with the user.
+
+You will be given a specific task and the current state of the lesson plan. You may also receive section-specific instructions extracted from the user's message by the planner agent — follow these when provided.
+
+## Markdown
+Do not use markdown formatting unless specified for a specific section.
+
+## Language — British English (mandatory)
+Write **British English** throughout the lesson plan: spelling, vocabulary, and phrasing. This is mandatory because our audience is UK teachers and pupils. The only exception is if the user has explicitly set a different primary language for the lesson.
+
+### Spelling rules — apply these consistently
+- **Verbs ending in -ise/-yse, not -ize/-yze.** Always write *recognise*, *emphasise*, *utilise*, *organise*, *analyse*, *summarise*, *categorise*, *prioritise*. Never *recognize*, *emphasize*, *utilize*, *organize*, *analyze*. This applies to all tenses: *recognised*, *emphasising*, *utilised*.
+- **-our, not -or:** colour, behaviour, favour, neighbour, honour, labour.
+- **-re, not -er:** centre, metre, theatre, fibre, litre.
+- **Double the final L before suffixes** on verbs ending in a single vowel + L: *labelled*, *labelling* (not labeled/labeling); *travelled*, *travelling* (not traveled/traveling); *modelled*, *modelling*; *cancelled*, *cancelling*; *fuelled*, *fuelling*.
+- **Other common forms:** maths (not math), grey (not gray), aluminium (not aluminum), programme (TV/curriculum) vs program (software), practise (verb) / practice (noun), licence (noun) / license (verb).
+
+### Vocabulary rules — UK terms only
+- **rubber** (not eraser), **pavement** (not sidewalk), **lift** (not elevator), **rubbish** (not trash), **biscuit** (not cookie), **trousers** (not pants), **holiday** (not vacation).
+- **autumn** (not fall — except when meaning "to drop"), **at the weekend** (not "on the weekend"), **full stop** (not period), **have** / **have got** (not "have gotten").
+- **Year 7–13** (not "7th grade"), **secondary school** / **sixth form** (not high school), **pupil** (not student where context fits a school lesson).
+
+### Self-check before emitting content
+Before returning your section, scan your output for these specific patterns and correct them:
+1. Any word ending in **-ize**, **-izes**, **-ized**, **-izing**, **-yze**, **-yzes** → change to the **-ise** / **-yse** form.
+2. Any of: eraser, sidewalk, elevator, trash, cookie, vacation, "have gotten", "on the weekend", "period" (when used as punctuation), "math" → replace with the UK term above.
+3. Any **-or** ending in a noun where the **-our** form exists (colour, behaviour, favour, etc.).
+4. Any **-eled** / **-eling** / **-eler** / **-ueled** / **-ueling** / **-odeled** / **-anceled** ending → double the L (*labelled*, *travelling*, *modeller*, *fuelling*, *cancelled*).
+
+Do not mix British and American forms. If unsure, prefer the British form.
+",
+    "role": "developer",
+  },
+  {
+    "content": "## Voice Definitions
+
+The following voice definitions are available for this task:
+
+### AILA_TO_TEACHER
+Speaker: Aila
+Audience: User
+Supportive expert, guiding and coaching the teacher to create a high-quality lesson. Always be polite; you can ask the teacher to clarify if needed.",
+    "role": "developer",
+  },
+  {
+    "content": "## Voice guidance
+
+Unless otherwise specified, use AILA_TO_TEACHER.",
+    "role": "developer",
+  },
+  {
+    "content": "Generate key learning points for a science lesson about photosynthesis.",
+    "role": "developer",
+  },
+  {
+    "content": "CURRENT DOCUMENT
+
+This is the document in its current state.
+
+{
+  "title": "Introduction to Photosynthesis",
+  "keyStage": "ks3"
+}",
+    "role": "developer",
+  },
+  {
+    "content": "MESSAGE HISTORY
+
+These are the previous messages in the current conversation with the user.
+
+- user: Can you help me create a lesson about photosynthesis for Year 7 students?
+- assistant: I'd be happy to help you create a lesson about photosynthesis for Year 7 students.",
+    "role": "developer",
+  },
+  {
+    "content": "USER's MESSAGE
+
+This is the most recent message from the user that we've been attempting to process.
+
+Please make sure to include the key learning points about chlorophyll and glucose production.",
+    "role": "user",
+  },
+]
+`;
+
 exports[`sectionToGenericPromptAgent input message generation should generate consistent input messages with minimal props 1`] = `
 [
   {

--- a/packages/aila/src/lib/agentic-system/agents/agenticPromptRegistry.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/agenticPromptRegistry.test.ts
@@ -1,0 +1,185 @@
+import type { PrismaClientWithAccelerate } from "@oakai/db/client";
+
+import {
+  type AgenticPromptTemplate,
+  __clearAgenticPromptIdCache,
+  resolveAgenticPromptIds,
+} from "./agenticPromptRegistry";
+
+function createMockPrisma(promptId: string) {
+  const findFirst = jest.fn().mockResolvedValue({ id: promptId });
+  const findFirstOrThrow = jest
+    .fn()
+    .mockResolvedValue({ id: "lesson-planner" });
+  const upsert = jest.fn().mockResolvedValue({ id: promptId });
+  const updateMany = jest.fn().mockResolvedValue({ count: 0 });
+  const prisma = {
+    prompt: { findFirst, upsert, updateMany },
+    app: { findFirstOrThrow },
+    $queryRaw: jest.fn().mockResolvedValue([{ max_version: 0 }]),
+  } as unknown as PrismaClientWithAccelerate;
+  return { prisma, findFirst, findFirstOrThrow, upsert, updateMany };
+}
+
+function tpl(promptTemplateId: string): AgenticPromptTemplate {
+  return { promptTemplateId, promptTemplate: `body for ${promptTemplateId}` };
+}
+
+function tplWithBody(
+  promptTemplateId: string,
+  promptTemplate: string,
+): AgenticPromptTemplate {
+  return { promptTemplateId, promptTemplate };
+}
+
+describe("resolveAgenticPromptIds", () => {
+  beforeEach(() => {
+    __clearAgenticPromptIdCache();
+  });
+
+  it("resolves each template to its prompt id", async () => {
+    const { prisma } = createMockPrisma("prompt_x");
+
+    const result = await resolveAgenticPromptIds({
+      prisma,
+      templates: [tpl("planner"), tpl("cycle--default")],
+    });
+
+    expect(result).toEqual({
+      planner: "prompt_x",
+      "cycle--default": "prompt_x",
+    });
+  });
+
+  it("deduplicates repeated template ids within a single call", async () => {
+    const { prisma, findFirst } = createMockPrisma("prompt_x");
+
+    await resolveAgenticPromptIds({
+      prisma,
+      templates: [tpl("planner"), tpl("planner"), tpl("planner")],
+    });
+
+    expect(findFirst).toHaveBeenCalledTimes(1);
+  });
+
+  it("caches resolution across calls so the db is hit once per template", async () => {
+    const { prisma, findFirst } = createMockPrisma("prompt_x");
+
+    await resolveAgenticPromptIds({ prisma, templates: [tpl("planner")] });
+    await resolveAgenticPromptIds({ prisma, templates: [tpl("planner")] });
+
+    expect(findFirst).toHaveBeenCalledTimes(1);
+  });
+
+  it("does not reuse the cached prompt id when the same template id has a new body", async () => {
+    const { prisma, findFirst } = createMockPrisma("prompt_x");
+
+    await resolveAgenticPromptIds({
+      prisma,
+      templates: [tplWithBody("planner", "body v1")],
+    });
+    await resolveAgenticPromptIds({
+      prisma,
+      templates: [tplWithBody("planner", "body v2")],
+    });
+
+    expect(findFirst).toHaveBeenCalledTimes(2);
+  });
+
+  it("rejects conflicting bodies for the same template id in one resolution", async () => {
+    const { prisma, findFirst } = createMockPrisma("prompt_x");
+
+    await expect(
+      resolveAgenticPromptIds({
+        prisma,
+        templates: [
+          tplWithBody("planner", "body v1"),
+          tplWithBody("planner", "body v2"),
+        ],
+      }),
+    ).rejects.toThrow("Conflicting agentic prompt templates for planner");
+    expect(findFirst).not.toHaveBeenCalled();
+  });
+
+  it("does not cache failures", async () => {
+    const findFirst = jest
+      .fn()
+      .mockRejectedValueOnce(new Error("db down"))
+      .mockResolvedValueOnce({ id: "prompt_recovered" });
+    const prisma = {
+      prompt: { findFirst },
+    } as unknown as PrismaClientWithAccelerate;
+
+    await expect(
+      resolveAgenticPromptIds({ prisma, templates: [tpl("planner")] }),
+    ).rejects.toThrow("db down");
+
+    const result = await resolveAgenticPromptIds({
+      prisma,
+      templates: [tpl("planner")],
+    });
+
+    expect(result).toEqual({ planner: "prompt_recovered" });
+    expect(findFirst).toHaveBeenCalledTimes(2);
+  });
+
+  it("creates a prompt row from the captured body when none is current", async () => {
+    const { prisma, findFirst, findFirstOrThrow, upsert, updateMany } =
+      createMockPrisma("prompt_created");
+    findFirst.mockResolvedValueOnce(null);
+
+    const result = await resolveAgenticPromptIds({
+      prisma,
+      templates: [tpl("planner")],
+    });
+
+    expect(result).toEqual({ planner: "prompt_created" });
+    expect(findFirstOrThrow).toHaveBeenCalledWith({
+      where: { slug: "lesson-planner" },
+    });
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          appId: "lesson-planner",
+          slug: "agentic-planner",
+          template: "body for planner",
+          current: true,
+        }),
+        update: expect.objectContaining({
+          current: true,
+        }),
+      }),
+    );
+    expect(updateMany).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: expect.objectContaining({
+          slug: { equals: "agentic-planner" },
+          variant: { equals: "main" },
+        }),
+      }),
+    );
+  });
+
+  it("creates distinct prompt rows for compound (mode + key stage) variants", async () => {
+    const { prisma, findFirst, upsert } = createMockPrisma("prompt_created");
+    findFirst.mockResolvedValueOnce(null);
+
+    const result = await resolveAgenticPromptIds({
+      prisma,
+      templates: [tpl("starterQuiz--default:addOne:ks3")],
+    });
+
+    expect(result).toEqual({
+      "starterQuiz--default:addOne:ks3": "prompt_created",
+    });
+    expect(upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        create: expect.objectContaining({
+          name: "Agentic Aila: starterQuiz--default:addOne:ks3",
+          // cspell:ignore starterquiz addone
+          slug: "agentic-starterquiz-default-addone-ks3",
+        }),
+      }),
+    );
+  });
+});

--- a/packages/aila/src/lib/agentic-system/agents/agenticPromptRegistry.ts
+++ b/packages/aila/src/lib/agentic-system/agents/agenticPromptRegistry.ts
@@ -1,0 +1,121 @@
+import {
+  PromptVariants,
+  promptHash,
+} from "@oakai/core/src/models/promptVariants";
+import type { OakPromptDefinition } from "@oakai/core/src/prompts/types";
+import type { PrismaClientWithAccelerate } from "@oakai/db/client";
+
+import { z } from "zod";
+
+const VARIANT_SLUG = "main";
+
+/** A prompt template to resolve to a persisted `prompts.id`. */
+export type AgenticPromptTemplate = {
+  promptTemplateId: string;
+  /** The version-stable static prompt body captured at execution time. */
+  promptTemplate: string;
+};
+
+function promptTemplateIdToPromptSlug(promptTemplateId: string): string {
+  return `agentic-${promptTemplateId.replace(/[^a-zA-Z0-9]+/g, "-").toLowerCase()}`;
+}
+
+function createAgenticPromptDefinition({
+  promptTemplateId,
+  promptTemplate,
+}: AgenticPromptTemplate): OakPromptDefinition {
+  return {
+    appId: "lesson-planner",
+    name: `Agentic Aila: ${promptTemplateId}`,
+    slug: promptTemplateIdToPromptSlug(promptTemplateId),
+    variants: [
+      {
+        slug: VARIANT_SLUG,
+        parts: {
+          body: promptTemplate,
+          context: "",
+          output: "",
+          task: "",
+        },
+      },
+    ],
+    inputSchema: z.object({}),
+    outputSchema: z.object({}),
+  };
+}
+
+// Memoised per template body (keyed by its hash) so unchanged templates resolve
+// once per process, not every turn. Failures aren't cached, so they retry.
+const promptIdCache = new Map<string, Promise<string>>();
+
+async function resolveSinglePromptId(
+  prisma: PrismaClientWithAccelerate,
+  template: AgenticPromptTemplate,
+): Promise<string> {
+  const prompts = new PromptVariants(
+    prisma,
+    createAgenticPromptDefinition(template),
+    VARIANT_SLUG,
+  );
+  // Version only changes when the prompt body changes, not on every deploy.
+  const prompt = await prompts.setCurrent(VARIANT_SLUG, true, {
+    stableAcrossDeploys: true,
+  });
+  if (!prompt?.id) {
+    throw new Error(
+      `Failed to resolve agentic prompt id for ${template.promptTemplateId}`,
+    );
+  }
+  return prompt.id;
+}
+
+export async function resolveAgenticPromptIds({
+  prisma,
+  templates,
+}: {
+  prisma: PrismaClientWithAccelerate;
+  templates: AgenticPromptTemplate[];
+}): Promise<Record<string, string>> {
+  const uniqueTemplates = new Map<string, AgenticPromptTemplate>();
+  for (const template of templates) {
+    const existing = uniqueTemplates.get(template.promptTemplateId);
+    if (!existing) {
+      uniqueTemplates.set(template.promptTemplateId, template);
+      continue;
+    }
+
+    if (existing.promptTemplate !== template.promptTemplate) {
+      throw new Error(
+        `Conflicting agentic prompt templates for ${template.promptTemplateId}`,
+      );
+    }
+  }
+
+  const entries = await Promise.all(
+    [...uniqueTemplates.values()].map(async (template) => {
+      const { promptTemplateId } = template;
+      const cacheKey = promptHash({
+        slug: promptTemplateId,
+        variant: VARIANT_SLUG,
+        template: template.promptTemplate,
+        stableAcrossDeploys: true,
+      });
+      let idPromise = promptIdCache.get(cacheKey);
+      if (!idPromise) {
+        idPromise = resolveSinglePromptId(prisma, template).catch((error) => {
+          promptIdCache.delete(cacheKey);
+          throw error;
+        });
+        promptIdCache.set(cacheKey, idPromise);
+      }
+      return [promptTemplateId, await idPromise] as const;
+    }),
+  );
+
+  return Object.fromEntries(entries);
+}
+
+/** Test-only: clears the per-process prompt id memo. */
+export function __clearAgenticPromptIdCache(): void {
+  promptIdCache.clear();
+}

--- a/packages/aila/src/lib/agentic-system/agents/britishEnglishCorrectorAgent/createBritishEnglishCorrectorAgent.ts
+++ b/packages/aila/src/lib/agentic-system/agents/britishEnglishCorrectorAgent/createBritishEnglishCorrectorAgent.ts
@@ -47,7 +47,12 @@ export function createBritishEnglishCorrectorAgent({
   responseSchema,
 }: BritishEnglishCorrectorAgentProps): GenericPromptAgent<unknown> {
   return {
+    // The per-section id feeds the prompt cache key; versioning uses a stable
+    // promptTemplateId since the template is identical across sections.
     id: `british-english-corrector--${sectionKey}`,
+    promptTemplateId: "britishEnglishCorrector",
+    promptTemplate: britishEnglishCorrectorAgentInstructions,
+    promptInputs: { sectionKey },
     responseSchema,
     input: [
       {

--- a/packages/aila/src/lib/agentic-system/agents/britishEnglishCorrectorAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/britishEnglishCorrectorAgent/index.ts
@@ -1,7 +1,10 @@
 import type OpenAI from "openai";
 
 import type { AgentResult } from "../../types";
-import { executeGenericPromptAgent } from "../executeGenericPromptAgent";
+import {
+  type GenerationCollector,
+  executeGenericPromptAgent,
+} from "../executeGenericPromptAgent";
 import {
   type BritishEnglishCorrectorAgentProps,
   createBritishEnglishCorrectorAgent,
@@ -10,9 +13,10 @@ import {
 export type { BritishEnglishCorrectorAgentProps } from "./createBritishEnglishCorrectorAgent";
 
 export const createOpenAIBritishEnglishCorrectorAgent =
-  (openai: OpenAI) =>
+  (openai: OpenAI, collectGeneration?: GenerationCollector) =>
   (props: BritishEnglishCorrectorAgentProps): Promise<AgentResult<unknown>> =>
     executeGenericPromptAgent({
       agent: createBritishEnglishCorrectorAgent(props),
       openai,
+      collectGeneration,
     });

--- a/packages/aila/src/lib/agentic-system/agents/executeGenericPromptAgent.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/executeGenericPromptAgent.test.ts
@@ -1,0 +1,165 @@
+import type OpenAI from "openai";
+import { z } from "zod";
+
+import type { GenericPromptAgent } from "../schema";
+import {
+  type PendingGeneration,
+  executeGenericPromptAgent,
+} from "./executeGenericPromptAgent";
+
+function createFakeOpenAI(parse: jest.Mock): OpenAI {
+  return { responses: { parse } } as unknown as OpenAI;
+}
+
+const agent: GenericPromptAgent<{ title: string }> = {
+  id: "cycle--default",
+  promptTemplateId: "cycle--default:ks3",
+  promptTemplate: "static template body",
+  promptInputs: { keyStage: "KS3" },
+  responseSchema: z.object({ title: z.string() }),
+  input: [
+    { role: "developer", content: "system prompt" },
+    { role: "user", content: "make a lesson" },
+  ],
+  modelParams: { model: "gpt-x" },
+};
+
+const successResult = {
+  output: [],
+  output_parsed: { value: { title: "A lesson" } },
+  usage: { input_tokens: 5, output_tokens: 7 },
+};
+
+describe("executeGenericPromptAgent", () => {
+  it("returns the parsed value on success", async () => {
+    const parse = jest.fn().mockResolvedValue(successResult);
+
+    const result = await executeGenericPromptAgent({
+      agent,
+      openai: createFakeOpenAI(parse),
+    });
+
+    expect(result).toEqual({ error: null, data: { title: "A lesson" } });
+  });
+
+  it("captures a SUCCESS generation with the agent's persistence metadata", async () => {
+    const collected: PendingGeneration[] = [];
+    const parse = jest.fn().mockResolvedValue(successResult);
+
+    await executeGenericPromptAgent({
+      agent,
+      openai: createFakeOpenAI(parse),
+      collectGeneration: (g) => collected.push(g),
+    });
+
+    expect(collected).toHaveLength(1);
+    expect(collected[0]).toMatchObject({
+      agentId: "cycle--default",
+      promptTemplateId: "cycle--default:ks3",
+      promptTemplate: "static template body",
+      promptInputs: {
+        keyStage: "KS3",
+        agentId: "cycle--default",
+        promptTemplateId: "cycle--default:ks3",
+        model: "gpt-x",
+      },
+      status: "SUCCESS",
+      promptTokensUsed: 5,
+      completionTokensUsed: 7,
+      // Developer + user messages joined, not the raw response envelope.
+      promptText: "system prompt\nmake a lesson",
+      response: { value: { title: "A lesson" } },
+    });
+  });
+
+  it("defaults promptTemplateId to the agent id when not set", async () => {
+    const collected: PendingGeneration[] = [];
+    const parse = jest.fn().mockResolvedValue(successResult);
+
+    await executeGenericPromptAgent({
+      agent: { ...agent, promptTemplateId: undefined },
+      openai: createFakeOpenAI(parse),
+      collectGeneration: (g) => collected.push(g),
+    });
+
+    expect(collected[0]?.promptTemplateId).toBe("cycle--default");
+  });
+
+  it("does not require a collector", async () => {
+    const parse = jest.fn().mockResolvedValue(successResult);
+
+    await expect(
+      executeGenericPromptAgent({ agent, openai: createFakeOpenAI(parse) }),
+    ).resolves.toMatchObject({ error: null });
+  });
+
+  it("captures a FAILED generation and returns an error when the call throws", async () => {
+    const collected: PendingGeneration[] = [];
+    const parse = jest.fn().mockRejectedValue(new Error("boom"));
+
+    const result = await executeGenericPromptAgent({
+      agent,
+      openai: createFakeOpenAI(parse),
+      collectGeneration: (g) => collected.push(g),
+    });
+
+    expect(result).toEqual({ error: { message: "boom" } });
+    expect(collected).toHaveLength(1);
+    expect(collected[0]).toMatchObject({
+      agentId: "cycle--default",
+      status: "FAILED",
+      promptTokensUsed: 0,
+      completionTokensUsed: 0,
+      response: "boom",
+    });
+  });
+
+  it("captures a FAILED generation when the model refuses", async () => {
+    const collected: PendingGeneration[] = [];
+    const parse = jest.fn().mockResolvedValue({
+      output: [
+        {
+          type: "message",
+          content: [{ type: "refusal", refusal: "I can't help with that." }],
+        },
+      ],
+      output_parsed: null,
+      usage: { input_tokens: 3, output_tokens: 4 },
+    });
+
+    const result = await executeGenericPromptAgent({
+      agent,
+      openai: createFakeOpenAI(parse),
+      collectGeneration: (g) => collected.push(g),
+    });
+
+    expect(result).toEqual({ error: { message: "I can't help with that." } });
+    expect(collected[0]).toMatchObject({
+      status: "FAILED",
+      promptTokensUsed: 3,
+      completionTokensUsed: 4,
+    });
+  });
+
+  it("captures a FAILED generation when parsed output is unusable", async () => {
+    const collected: PendingGeneration[] = [];
+    const parse = jest.fn().mockResolvedValue({
+      output: [{ type: "message", content: [] }],
+      output_parsed: null,
+      usage: { input_tokens: 8, output_tokens: 9 },
+    });
+
+    const result = await executeGenericPromptAgent({
+      agent,
+      openai: createFakeOpenAI(parse),
+      collectGeneration: (g) => collected.push(g),
+    });
+
+    expect(result.error?.message).toContain("An unknown error occurred");
+    expect(collected[0]).toMatchObject({
+      status: "FAILED",
+      promptTokensUsed: 8,
+      completionTokensUsed: 9,
+    });
+  });
+});

--- a/packages/aila/src/lib/agentic-system/agents/executeGenericPromptAgent.ts
+++ b/packages/aila/src/lib/agentic-system/agents/executeGenericPromptAgent.ts
@@ -9,18 +9,71 @@ import type { AgentResult } from "../types";
 
 const log = aiLogger("aila:agents:prompts");
 
+/**
+ * Telemetry for a single agent LLM call, captured at the point of execution so
+ * it can later be persisted as a `Generation` row.
+ */
+export type PendingGeneration = {
+  agentId: string;
+  promptTemplateId: string;
+  /** The version-stable static prompt body this call used. */
+  promptTemplate: string;
+  promptInputs?: Record<string, unknown>;
+  status: "SUCCESS" | "FAILED";
+  llmTimeTaken: number;
+  promptTokensUsed: number;
+  completionTokensUsed: number;
+  response: unknown; // originates from JSON, only narrowed to a JSON value at the persistence boundary
+  promptText: string;
+};
+
+export type GenerationCollector = (generation: PendingGeneration) => void;
+
+function inputToText(input: GenericPromptAgent<unknown>["input"]): string {
+  return input.map((item) => item.content).join("\n");
+}
+
 export async function executeGenericPromptAgent<ResponseType>({
   agent,
   openai,
+  collectGeneration,
 }: {
   agent: GenericPromptAgent<ResponseType>;
   openai: OpenAI;
+  collectGeneration?: GenerationCollector;
 }): Promise<AgentResult<ResponseType>> {
   const schemaWrapped = z.object({
     value: agent.responseSchema,
   });
   const responseFormat = zodTextFormat(schemaWrapped, `agent_response_schema`);
   const model = agent.modelParams.model;
+  const promptText = inputToText(agent.input);
+  const promptTemplateId = agent.promptTemplateId ?? agent.id;
+  const startTime = Date.now();
+
+  const collect = (
+    status: PendingGeneration["status"],
+    response: unknown,
+    tokenUsage?: { inputTokens?: number; outputTokens?: number },
+  ) => {
+    collectGeneration?.({
+      agentId: agent.id,
+      promptTemplateId,
+      promptTemplate: agent.promptTemplate ?? "",
+      promptInputs: {
+        ...agent.promptInputs,
+        agentId: agent.id,
+        promptTemplateId,
+        model,
+      },
+      status,
+      llmTimeTaken: Date.now() - startTime,
+      promptTokensUsed: tokenUsage?.inputTokens ?? 0,
+      completionTokensUsed: tokenUsage?.outputTokens ?? 0,
+      response,
+      promptText,
+    });
+  };
 
   let result;
   try {
@@ -38,26 +91,36 @@ export async function executeGenericPromptAgent<ResponseType>({
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     log.error(`OpenAI Responses API error [${agent.id}]: ${message}`);
+    collect("FAILED", message);
     return { error: { message } };
   }
 
   logPromptCacheUsage({ agent, model, usage: result.usage });
 
-  if (
+  const tokenUsage = {
+    inputTokens: result.usage?.input_tokens ?? 0,
+    outputTokens: result.usage?.output_tokens ?? 0,
+  };
+
+  const refusal =
     result.output[0]?.type === "message" &&
     result.output[0]?.content[0]?.type === "refusal"
-  ) {
-    return { error: { message: result.output[0]?.content[0]?.refusal } };
-  }
+      ? result.output[0].content[0].refusal
+      : undefined;
 
-  if (!result.output_parsed || result.output_parsed.value === undefined) {
+  // A refusal or missing/undefined parsed value both mean the agent produced no
+  // usable result: record one FAILED generation and surface the reason.
+  if (refusal !== undefined || result.output_parsed?.value === undefined) {
+    collect("FAILED", result.output_parsed ?? result.output, tokenUsage);
     return {
       error: {
-        message: "An unknown error occurred\n\n" + JSON.stringify(result),
+        message:
+          refusal ?? "An unknown error occurred\n\n" + JSON.stringify(result),
       },
     };
   }
 
+  collect("SUCCESS", result.output_parsed, tokenUsage);
   return { error: null, data: result.output_parsed.value };
 }
 
@@ -82,7 +145,7 @@ function logPromptCacheUsage<ResponseType>({
   usage: OpenAI.Responses.ResponseUsage | null | undefined;
 }) {
   const inputTokens = usage?.input_tokens ?? 0;
-  const cachedInputTokens = usage?.input_tokens_details.cached_tokens ?? 0;
+  const cachedInputTokens = usage?.input_tokens_details?.cached_tokens ?? 0;
   const cacheHitRate =
     inputTokens > 0 ? Number((cachedInputTokens / inputTokens).toFixed(4)) : 0;
 

--- a/packages/aila/src/lib/agentic-system/agents/messageToUserAgent/createMessageToUserAgent.ts
+++ b/packages/aila/src/lib/agentic-system/agents/messageToUserAgent/createMessageToUserAgent.ts
@@ -33,22 +33,22 @@ export function createMessageToUserAgent({
   relevantLessons,
   relevantLessonsFetched,
 }: MessageToUserAgentProps): GenericPromptAgent<MessageToUserAgentOutput> {
+  // Static prefix shared between the runtime prompt and the persisted template.
+  const staticParts = [
+    { role: "developer" as const, content: messageToUserAgentInstructions },
+    {
+      role: "developer" as const,
+      content: getVoiceDefinitions(["AILA_TO_TEACHER"]),
+    },
+    { role: "developer" as const, content: getVoicePrompt("AILA_TO_TEACHER") },
+  ];
+
   return {
     id: "message-to-user",
+    promptTemplate: staticParts.map((part) => part.content).join("\n\n"),
     responseSchema: messageToUserAgentSchema,
     input: [
-      {
-        role: "developer" as const,
-        content: messageToUserAgentInstructions,
-      },
-      {
-        role: "developer" as const,
-        content: getVoiceDefinitions(["AILA_TO_TEACHER"]),
-      },
-      {
-        role: "developer" as const,
-        content: getVoicePrompt("AILA_TO_TEACHER"),
-      },
+      ...staticParts,
       errors.length > 0 && {
         role: "developer" as const,
         content: errorsPromptPart(errors),

--- a/packages/aila/src/lib/agentic-system/agents/messageToUserAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/messageToUserAgent/index.ts
@@ -1,12 +1,17 @@
 import type OpenAI from "openai";
 
 import type { MessageToUserAgentProps } from "../../types";
-import { executeGenericPromptAgent } from "../executeGenericPromptAgent";
+import {
+  type GenerationCollector,
+  executeGenericPromptAgent,
+} from "../executeGenericPromptAgent";
 import { createMessageToUserAgent } from "./createMessageToUserAgent";
 
 export const createOpenAIMessageToUserAgent =
-  (openai: OpenAI) => (props: MessageToUserAgentProps) =>
+  (openai: OpenAI, collectGeneration?: GenerationCollector) =>
+  (props: MessageToUserAgentProps) =>
     executeGenericPromptAgent({
       agent: createMessageToUserAgent(props),
       openai,
+      collectGeneration,
     });

--- a/packages/aila/src/lib/agentic-system/agents/plannerAgent/createPlannerAgent.ts
+++ b/packages/aila/src/lib/agentic-system/agents/plannerAgent/createPlannerAgent.ts
@@ -21,22 +21,22 @@ export const createPlannerAgent = ({
 }: PlannerAgentProps): GenericPromptAgent<
   z.infer<typeof plannerOutputSchema>
 > => {
+  // Static prefix shared between the runtime prompt and the persisted template.
+  const staticParts = [
+    { role: "developer" as const, content: plannerInstructions },
+    {
+      role: "developer" as const,
+      content: getVoiceDefinitions(["AGENT_TO_AGENT"]),
+    },
+    { role: "developer" as const, content: getVoicePrompt("AGENT_TO_AGENT") },
+  ];
+
   return {
     id: "planner",
+    promptTemplate: staticParts.map((part) => part.content).join("\n\n"),
     responseSchema: plannerOutputSchema,
     input: [
-      {
-        role: "developer",
-        content: plannerInstructions,
-      },
-      {
-        role: "developer" as const,
-        content: getVoiceDefinitions(["AGENT_TO_AGENT"]),
-      },
-      {
-        role: "developer" as const,
-        content: getVoicePrompt("AGENT_TO_AGENT"),
-      },
+      ...staticParts,
       {
         role: "developer" as const,
         content: relevantLessonsPromptPart(

--- a/packages/aila/src/lib/agentic-system/agents/plannerAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/plannerAgent/index.ts
@@ -1,12 +1,17 @@
 import type OpenAI from "openai";
 
 import type { PlannerAgentProps } from "../../types";
-import { executeGenericPromptAgent } from "../executeGenericPromptAgent";
+import {
+  type GenerationCollector,
+  executeGenericPromptAgent,
+} from "../executeGenericPromptAgent";
 import { createPlannerAgent } from "./createPlannerAgent";
 
 export const createOpenAIPlannerAgent =
-  (openai: OpenAI) => (props: PlannerAgentProps) =>
+  (openai: OpenAI, collectGeneration?: GenerationCollector) =>
+  (props: PlannerAgentProps) =>
     executeGenericPromptAgent({
       agent: createPlannerAgent(props),
       openai,
+      collectGeneration,
     });

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/createSectionAgent.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/createSectionAgent.test.ts
@@ -2,8 +2,12 @@ import type OpenAI from "openai";
 import { z } from "zod";
 
 import type { AilaExecutionContext } from "../../types";
+import { executeGenericPromptAgent } from "../executeGenericPromptAgent";
 import * as sectionModule from "../sectionToGenericPromptAgent";
-import { createSectionAgent } from "./createSectionAgent";
+import {
+  createSectionAgent,
+  keyStageBuildModeInstructions,
+} from "./createSectionAgent";
 
 jest.mock("../executeGenericPromptAgent", () => ({
   executeGenericPromptAgent: jest.fn().mockResolvedValue({ data: {} }),
@@ -44,6 +48,10 @@ const buildCtx = (overrides: { mathsQuizEnabled: boolean }) =>
   }) as unknown as AilaExecutionContext;
 
 describe("createSectionAgent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
   it("passes a static instructions string straight through", async () => {
     const spy = jest.spyOn(sectionModule, "sectionToGenericPromptAgent");
     const factory = createSectionAgent({
@@ -97,5 +105,81 @@ describe("createSectionAgent", () => {
     );
 
     spy.mockRestore();
+  });
+
+  it("composes the promptTemplateId from the id and variant and carries it on the agent", async () => {
+    const spy = jest.spyOn(sectionModule, "sectionToGenericPromptAgent");
+    const factory = createSectionAgent({
+      responseSchema: z.object({ value: z.string() }),
+      instructions: () => ({
+        text: "runtime prompt",
+        variant: "addOne",
+        promptInputs: { buildMode: "addOne" },
+      }),
+      modelParams: { model: "gpt-4o-mini" },
+    });
+    const agent = factory({
+      id: "starterQuiz--default",
+      description: "",
+      openai: {} as OpenAI,
+      contentFromDocument: () => undefined,
+    });
+
+    await agent.handler(buildCtx({ mathsQuizEnabled: false }));
+
+    // The section builder receives the composed id + telemetry...
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        instructions: "runtime prompt",
+        promptTemplateId: "starterQuiz--default:addOne",
+        promptInputs: expect.objectContaining({ buildMode: "addOne" }),
+      }),
+      expect.anything(),
+    );
+    // ...and the built agent carries it through to execution.
+    expect(executeGenericPromptAgent).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: expect.objectContaining({
+          id: "starterQuiz--default",
+          promptTemplateId: "starterQuiz--default:addOne",
+        }),
+      }),
+    );
+    spy.mockRestore();
+  });
+});
+
+describe("keyStageBuildModeInstructions", () => {
+  const resolver = keyStageBuildModeInstructions({
+    fullRegen: (keyStage) => `full ${keyStage}`,
+    addOne: (keyStage) => `add ${keyStage}`,
+    rewriteOne: (position, keyStage) => `rewrite ${position} for ${keyStage}`,
+  });
+
+  const ctxForRewrite = (position: number) =>
+    ({
+      currentTurn: {
+        document: { keyStage: "key-stage-3" },
+        currentStep: { itemIntent: { action: "CHANGE_ITEM", position } },
+      },
+    }) as unknown as AilaExecutionContext;
+
+  it("versions rewriteOne once per key stage, treating the position as telemetry only", () => {
+    const q3 = resolver(ctxForRewrite(3));
+    const q5 = resolver(ctxForRewrite(5));
+
+    // Same version regardless of position...
+    expect(q3.variant).toBe("rewriteOne:ks3");
+    expect(q5.variant).toBe("rewriteOne:ks3");
+    expect(q3.templateText).toBe("rewrite {position} for key-stage-3");
+    expect(q5.templateText).toBe(q3.templateText);
+
+    // ...but the runtime prompt and telemetry carry the real position.
+    expect(q3.text).toBe("rewrite 3 for key-stage-3");
+    expect(q5.text).toBe("rewrite 5 for key-stage-3");
+    expect(q3.promptInputs).toMatchObject({
+      buildMode: "rewriteOne",
+      position: 3,
+    });
   });
 });

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/createSectionAgent.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/createSectionAgent.ts
@@ -111,6 +111,7 @@ export function createSectionAgent<ResponseType>({
   instructions,
   contentToString = defaultContentToString,
   extraInputFromCtx,
+  documentForPrompt,
   defaultVoice,
   voices,
   modelParams,
@@ -121,6 +122,7 @@ export function createSectionAgent<ResponseType>({
   extraInputFromCtx?: (
     state: AilaExecutionContext,
   ) => { role: "user" | "developer"; content: string }[];
+  documentForPrompt?: (document: PartialLessonPlan) => PartialLessonPlan;
   defaultVoice?: VoiceId;
   voices?: VoiceId[];
   modelParams: Omit<
@@ -177,6 +179,7 @@ export function createSectionAgent<ResponseType>({
           currentValue,
           ctx,
           extraInputFromCtx,
+          documentForPrompt,
           defaultVoice,
           voices,
         },

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/createSectionAgent.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/createSectionAgent.ts
@@ -4,13 +4,103 @@ import type { ResponseCreateParamsNonStreaming } from "openai/resources/response
 import type { z } from "zod";
 
 import type { PartialLessonPlan } from "../../../../protocol/schema";
+import { deriveSectionBuildMode } from "../../quizOperations/deriveSectionBuildMode";
 import type { AilaExecutionContext } from "../../types";
-import { executeGenericPromptAgent } from "../executeGenericPromptAgent";
+import {
+  type GenerationCollector,
+  executeGenericPromptAgent,
+} from "../executeGenericPromptAgent";
 import { sectionToGenericPromptAgent } from "../sectionToGenericPromptAgent";
 import { getRelevantRAGValues } from "./getRevelantRAGValues";
+import { normaliseKeyStageForPrompt } from "./shared/keyStageLanguageGuidance";
+import {
+  POSITION_PLACEHOLDER,
+  type PositionPlaceholder,
+} from "./shared/positionPlaceholder";
 import type { VoiceId } from "./shared/voices";
 
-type InstructionsValue = string | ((ctx: AilaExecutionContext) => string);
+export type ResolvedInstructions = {
+  /** Instructions used in the runtime prompt. */
+  text: string;
+  /** Version-stable form stored as the template (defaults to `text`). */
+  templateText?: string;
+  /** Appended to the agent id to version distinct prompt bodies separately. */
+  variant?: string;
+  promptInputs?: Record<string, unknown>;
+};
+
+type InstructionsValue =
+  | string
+  | ((ctx: AilaExecutionContext) => string | ResolvedInstructions);
+
+function resolveInstructions(
+  instructions: InstructionsValue,
+  ctx: AilaExecutionContext,
+): ResolvedInstructions {
+  const resolved =
+    typeof instructions === "function" ? instructions(ctx) : instructions;
+  return typeof resolved === "string" ? { text: resolved } : resolved;
+}
+
+/** Versions key-stage-parameterised instructions per key stage. */
+export function keyStageInstructions(
+  instructionsForKeyStage: (keyStage: string) => string,
+): (ctx: AilaExecutionContext) => ResolvedInstructions {
+  return (ctx) => {
+    const keyStage = ctx.currentTurn.document.keyStage ?? "";
+    return {
+      text: instructionsForKeyStage(keyStage),
+      variant: normaliseKeyStageForPrompt(keyStage),
+      promptInputs: { keyStage },
+    };
+  };
+}
+
+/** Versions instructions that vary by both key stage and build mode. */
+export function keyStageBuildModeInstructions(instructionsByMode: {
+  fullRegen: (keyStage: string) => string;
+  addOne: (keyStage: string) => string;
+  rewriteOne: (
+    position: number | PositionPlaceholder,
+    keyStage: string,
+  ) => string;
+}): (ctx: AilaExecutionContext) => ResolvedInstructions {
+  return (ctx) => {
+    const keyStage = ctx.currentTurn.document.keyStage ?? "";
+    const normalisedKeyStage = normaliseKeyStageForPrompt(keyStage);
+    const mode = deriveSectionBuildMode(ctx.currentTurn.currentStep);
+    switch (mode.kind) {
+      case "fullRegen":
+        return {
+          text: instructionsByMode.fullRegen(keyStage),
+          variant: `fullRegen:${normalisedKeyStage}`,
+          promptInputs: { keyStage, buildMode: "fullRegen" },
+        };
+      case "addOne":
+        return {
+          text: instructionsByMode.addOne(keyStage),
+          variant: `addOne:${normalisedKeyStage}`,
+          promptInputs: { keyStage, buildMode: "addOne" },
+        };
+      case "rewriteOne":
+        // Position is a runtime input, not a distinct prompt: version once per
+        // key stage (placeholder body), keep the real position as telemetry.
+        return {
+          text: instructionsByMode.rewriteOne(mode.position, keyStage),
+          templateText: instructionsByMode.rewriteOne(
+            POSITION_PLACEHOLDER,
+            keyStage,
+          ),
+          variant: `rewriteOne:${normalisedKeyStage}`,
+          promptInputs: {
+            keyStage,
+            buildMode: "rewriteOne",
+            position: mode.position,
+          },
+        };
+    }
+  };
+}
 
 /**
  * This is a factory function for section agents.
@@ -43,6 +133,7 @@ export function createSectionAgent<ResponseType>({
     description,
     openai,
     contentFromDocument,
+    collectGeneration,
   }: {
     id: string;
     description: string;
@@ -51,12 +142,15 @@ export function createSectionAgent<ResponseType>({
       document: PartialLessonPlan,
       ctx: AilaExecutionContext,
     ) => ResponseType | undefined;
+    collectGeneration?: GenerationCollector;
   }) => ({
     id,
     description,
     handler: (ctx: AilaExecutionContext) => {
-      const resolvedInstructions =
-        typeof instructions === "function" ? instructions(ctx) : instructions;
+      const resolved = resolveInstructions(instructions, ctx);
+      const promptTemplateId = resolved.variant
+        ? `${id}:${resolved.variant}`
+        : id;
 
       const { basedOnContent, exemplarContent, currentValue } =
         getRelevantRAGValues({
@@ -67,8 +161,15 @@ export function createSectionAgent<ResponseType>({
       const genericPromptAgent = sectionToGenericPromptAgent(
         {
           responseSchema,
-          instructions: resolvedInstructions,
           id,
+          instructions: resolved.text,
+          templateText: resolved.templateText,
+          promptTemplateId,
+          promptInputs: {
+            sectionKey: ctx.currentTurn.currentStep?.sectionKey,
+            action: ctx.currentTurn.currentStep?.action,
+            ...resolved.promptInputs,
+          },
           messages: ctx.persistedState.messages,
           contentToString,
           basedOnContent,
@@ -85,6 +186,7 @@ export function createSectionAgent<ResponseType>({
       return executeGenericPromptAgent({
         agent: genericPromptAgent,
         openai,
+        collectGeneration,
       });
     },
   });

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/cycleAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/cycleAgent/index.ts
@@ -1,13 +1,15 @@
 import { DEFAULT_AGENT_MODEL_PARAMS } from "../../../constants";
 import { cycleTargetPromptPart } from "../../sharedPromptParts/cycleTarget.part";
-import { createSectionAgent } from "../createSectionAgent";
+import {
+  createSectionAgent,
+  keyStageInstructions,
+} from "../createSectionAgent";
 import { cyclesInstructions } from "./cycle.instructions";
 import { CycleSchema } from "./cycle.schema";
 
 export const cycleAgent = createSectionAgent({
   responseSchema: CycleSchema,
-  instructions: (ctx) =>
-    cyclesInstructions(ctx.currentTurn.document.keyStage ?? ""),
+  instructions: keyStageInstructions(cyclesInstructions),
   extraInputFromCtx: (ctx) => {
     const promptPart = cycleTargetPromptPart(ctx);
     return promptPart ? [{ role: "developer", content: promptPart }] : [];

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/exitQuizAgent/exitQuiz.instructions.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/exitQuizAgent/exitQuiz.instructions.test.ts
@@ -1,0 +1,16 @@
+import { exitQuizInstructions } from "./exitQuiz.instructions";
+
+describe("exitQuiz instructions", () => {
+  describe("exitQuizInstructions", () => {
+    it("asks for exactly 6 questions", () => {
+      expect(exitQuizInstructions("ks2")).toMatch(/exactly 6 questions/i);
+    });
+
+    it("asks for exactly 1 correct answer and exactly 2 distractors", () => {
+      expect(exitQuizInstructions("ks2")).toMatch(/exactly 1 correct answer/i);
+      expect(exitQuizInstructions("ks2")).toMatch(
+        /exactly 2 high-quality distractors/i,
+      );
+    });
+  });
+});

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/exitQuizAgent/exitQuiz.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/exitQuizAgent/exitQuiz.instructions.ts
@@ -1,3 +1,4 @@
+import type { PositionPlaceholder } from "../shared/positionPlaceholder";
 import { quizQuestionDesignInstructions } from "../shared/quizQuestionDesign.instructions";
 
 export function exitQuizInstructions(keyStage: string): string {
@@ -34,7 +35,7 @@ ${quizQuestionDesignInstructions(keyStage)}`;
 }
 
 export const rewriteOneQuizInstructions = (
-  position: number,
+  position: number | PositionPlaceholder,
   keyStage: string,
 ): string =>
   `# Task

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/exitQuizAgent/exitQuiz.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/exitQuizAgent/exitQuiz.instructions.ts
@@ -3,7 +3,7 @@ import { quizQuestionDesignInstructions } from "../shared/quizQuestionDesign.ins
 export function exitQuizInstructions(keyStage: string): string {
   return `# Task
 
-Create a 6-question multiple-choice quiz to assess pupil understanding of the lesson content.
+Create a multiple-choice quiz with exactly 6 questions to assess pupil understanding of the lesson content.
 
 ## Content Scope
 

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/exitQuizAgent/exitQuiz.schema.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/exitQuizAgent/exitQuiz.schema.ts
@@ -1,1 +1,1 @@
-export { LatestQuizSchema as ExitQuizSchema } from "../../../../../protocol/schema";
+export { LatestQuizMultipleChoiceOnlyStrictMax6Schema as ExitQuizSchema } from "../../../../../protocol/schema";

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/exitQuizAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/exitQuizAgent/index.ts
@@ -1,6 +1,8 @@
 import { DEFAULT_AGENT_MODEL_PARAMS } from "../../../constants";
-import { deriveSectionBuildMode } from "../../../quizOperations/deriveSectionBuildMode";
-import { createSectionAgent } from "../createSectionAgent";
+import {
+  createSectionAgent,
+  keyStageBuildModeInstructions,
+} from "../createSectionAgent";
 import {
   addOneQuizInstructions,
   exitQuizInstructions,
@@ -10,18 +12,11 @@ import { ExitQuizSchema } from "./exitQuiz.schema";
 
 export const exitQuizAgent = createSectionAgent({
   responseSchema: ExitQuizSchema,
-  instructions: (ctx) => {
-    const keyStage = ctx.currentTurn.document.keyStage ?? "";
-    const mode = deriveSectionBuildMode(ctx.currentTurn.currentStep);
-    switch (mode.kind) {
-      case "fullRegen":
-        return exitQuizInstructions(keyStage);
-      case "addOne":
-        return addOneQuizInstructions(keyStage);
-      case "rewriteOne":
-        return rewriteOneQuizInstructions(mode.position, keyStage);
-    }
-  },
+  instructions: keyStageBuildModeInstructions({
+    fullRegen: exitQuizInstructions,
+    addOne: addOneQuizInstructions,
+    rewriteOne: rewriteOneQuizInstructions,
+  }),
   defaultVoice: "TEACHER_TO_PUPIL_WRITTEN",
   modelParams: DEFAULT_AGENT_MODEL_PARAMS,
 });

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/keyLearningPointsAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/keyLearningPointsAgent/index.ts
@@ -1,13 +1,15 @@
 import { DEFAULT_AGENT_MODEL_PARAMS } from "../../../constants";
 import { stringListToText } from "../../../utils/stringListToText";
-import { createSectionAgent } from "../createSectionAgent";
+import {
+  createSectionAgent,
+  keyStageInstructions,
+} from "../createSectionAgent";
 import { keyLearningPointsInstructions } from "./keyLearningPoints.instructions";
 import { KeyLearningPointsSchema } from "./keyLearningPoints.schema";
 
 export const keyLearningPointsAgent = createSectionAgent({
   responseSchema: KeyLearningPointsSchema,
-  instructions: (ctx) =>
-    keyLearningPointsInstructions(ctx.currentTurn.document.keyStage ?? ""),
+  instructions: keyStageInstructions(keyLearningPointsInstructions),
   contentToString: stringListToText(),
   defaultVoice: "EXPERT_TEACHER",
   modelParams: DEFAULT_AGENT_MODEL_PARAMS,

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/keywordsAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/keywordsAgent/index.ts
@@ -1,7 +1,9 @@
 import { DEFAULT_AGENT_MODEL_PARAMS } from "../../../constants";
-import { deriveSectionBuildMode } from "../../../quizOperations/deriveSectionBuildMode";
 import { stringListToText } from "../../../utils/stringListToText";
-import { createSectionAgent } from "../createSectionAgent";
+import {
+  createSectionAgent,
+  keyStageBuildModeInstructions,
+} from "../createSectionAgent";
 import {
   addOneKeywordInstructions,
   changeOneKeywordInstructions,
@@ -11,18 +13,11 @@ import { KeywordsSchema } from "./keywords.schema";
 
 export const keywordsAgent = createSectionAgent({
   responseSchema: KeywordsSchema,
-  instructions: (ctx) => {
-    const keyStage = ctx.currentTurn.document.keyStage ?? "";
-    const mode = deriveSectionBuildMode(ctx.currentTurn.currentStep);
-    switch (mode.kind) {
-      case "fullRegen":
-        return keywordsInstructions(keyStage);
-      case "addOne":
-        return addOneKeywordInstructions(keyStage);
-      case "rewriteOne":
-        return changeOneKeywordInstructions(mode.position, keyStage);
-    }
-  },
+  instructions: keyStageBuildModeInstructions({
+    fullRegen: keywordsInstructions,
+    addOne: addOneKeywordInstructions,
+    rewriteOne: changeOneKeywordInstructions,
+  }),
   contentToString: stringListToText((k) => `${k.keyword}: ${k.definition}`),
   defaultVoice: "TEACHER_TO_PUPIL_WRITTEN",
   modelParams: DEFAULT_AGENT_MODEL_PARAMS,

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/keywordsAgent/keywords.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/keywordsAgent/keywords.instructions.ts
@@ -4,6 +4,7 @@ import {
   getKeyStageLanguageGuidance,
   normaliseKeyStageForPrompt,
 } from "../shared/keyStageLanguageGuidance";
+import type { PositionPlaceholder } from "../shared/positionPlaceholder";
 import { tier2And3VocabularyDefinitions } from "../shared/tier2And3VocabularyDefinitions";
 
 export function keywordsInstructions(keyStage: string): string {
@@ -52,7 +53,7 @@ ${getKeyStageLanguageGuidance(normalisedKeyStage)}`;
 }
 
 export function changeOneKeywordInstructions(
-  position: number,
+  position: number | PositionPlaceholder,
   keyStage: string,
 ): string {
   const normalisedKeyStage = normaliseKeyStageForPrompt(keyStage);

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/learningCycleOutcomesAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/learningCycleOutcomesAgent/index.ts
@@ -1,12 +1,14 @@
 import { DEFAULT_AGENT_MODEL_PARAMS } from "../../../constants";
-import { createSectionAgent } from "../createSectionAgent";
+import {
+  createSectionAgent,
+  keyStageInstructions,
+} from "../createSectionAgent";
 import { learningCycleTitlesInstructions } from "./learningCycleOutcomes.instructions";
 import { LearningCyclesSchema } from "./learningCycleOutcomes.schema";
 
 export const learningCycleOutcomesAgent = createSectionAgent({
   responseSchema: LearningCyclesSchema,
-  instructions: (ctx) =>
-    learningCycleTitlesInstructions(ctx.currentTurn.document.keyStage ?? ""),
+  instructions: keyStageInstructions(learningCycleTitlesInstructions),
   defaultVoice: "EXPERT_TEACHER",
   modelParams: DEFAULT_AGENT_MODEL_PARAMS,
 });

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/learningOutcomeAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/learningOutcomeAgent/index.ts
@@ -1,12 +1,14 @@
 import { DEFAULT_AGENT_MODEL_PARAMS } from "../../../constants";
-import { createSectionAgent } from "../createSectionAgent";
+import {
+  createSectionAgent,
+  keyStageInstructions,
+} from "../createSectionAgent";
 import { learningOutcomeInstructions } from "./learningOutcome.instructions";
 import { LearningOutcomeSchema } from "./learningOutcome.schema";
 
 export const learningOutcomeAgent = createSectionAgent({
   responseSchema: LearningOutcomeSchema,
-  instructions: (ctx) =>
-    learningOutcomeInstructions(ctx.currentTurn.document.keyStage ?? ""),
+  instructions: keyStageInstructions(learningOutcomeInstructions),
   defaultVoice: "PUPIL",
   modelParams: DEFAULT_AGENT_MODEL_PARAMS,
 });

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/misconceptionsAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/misconceptionsAgent/index.ts
@@ -1,7 +1,9 @@
 import { DEFAULT_AGENT_MODEL_PARAMS } from "../../../constants";
-import { deriveSectionBuildMode } from "../../../quizOperations/deriveSectionBuildMode";
 import { stringListToText } from "../../../utils/stringListToText";
-import { createSectionAgent } from "../createSectionAgent";
+import {
+  createSectionAgent,
+  keyStageBuildModeInstructions,
+} from "../createSectionAgent";
 import {
   addOneMisconceptionInstructions,
   changeOneMisconceptionInstructions,
@@ -11,18 +13,11 @@ import { MisconceptionsSchema } from "./misconceptions.schema";
 
 export const misconceptionsAgent = createSectionAgent({
   responseSchema: MisconceptionsSchema,
-  instructions: (ctx) => {
-    const keyStage = ctx.currentTurn.document.keyStage ?? "";
-    const mode = deriveSectionBuildMode(ctx.currentTurn.currentStep);
-    switch (mode.kind) {
-      case "fullRegen":
-        return misconceptionsInstructions(keyStage);
-      case "addOne":
-        return addOneMisconceptionInstructions(keyStage);
-      case "rewriteOne":
-        return changeOneMisconceptionInstructions(mode.position, keyStage);
-    }
-  },
+  instructions: keyStageBuildModeInstructions({
+    fullRegen: misconceptionsInstructions,
+    addOne: addOneMisconceptionInstructions,
+    rewriteOne: changeOneMisconceptionInstructions,
+  }),
   contentToString: stringListToText(
     (m) => `${m.misconception}: ${m.description}`,
   ),

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/misconceptionsAgent/misconceptions.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/misconceptionsAgent/misconceptions.instructions.ts
@@ -2,6 +2,7 @@ import {
   getKeyStageLanguageGuidance,
   normaliseKeyStageForPrompt,
 } from "../shared/keyStageLanguageGuidance";
+import type { PositionPlaceholder } from "../shared/positionPlaceholder";
 
 export function misconceptionsInstructions(keyStage: string): string {
   const normalisedKeyStage = normaliseKeyStageForPrompt(keyStage);
@@ -35,7 +36,7 @@ ${getKeyStageLanguageGuidance(normalisedKeyStage)}`;
 }
 
 export function changeOneMisconceptionInstructions(
-  position: number,
+  position: number | PositionPlaceholder,
   keyStage: string,
 ): string {
   const normalisedKeyStage = normaliseKeyStageForPrompt(keyStage);

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/priorKnowledgeAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/priorKnowledgeAgent/index.ts
@@ -1,13 +1,15 @@
 import { DEFAULT_AGENT_MODEL_PARAMS } from "../../../constants";
 import { stringListToText } from "../../../utils/stringListToText";
-import { createSectionAgent } from "../createSectionAgent";
+import {
+  createSectionAgent,
+  keyStageInstructions,
+} from "../createSectionAgent";
 import { priorKnowledgeInstructions } from "./priorKnowledge.instructions";
 import { PriorKnowledgeSchema } from "./priorKnowledge.schema";
 
 export const priorKnowledgeAgent = createSectionAgent({
   responseSchema: PriorKnowledgeSchema,
-  instructions: (ctx) =>
-    priorKnowledgeInstructions(ctx.currentTurn.document.keyStage ?? ""),
+  instructions: keyStageInstructions(priorKnowledgeInstructions),
   contentToString: stringListToText(),
   defaultVoice: "EXPERT_TEACHER",
   modelParams: DEFAULT_AGENT_MODEL_PARAMS,

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/sectionAgentRegistry.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/sectionAgentRegistry.ts
@@ -11,6 +11,7 @@ import type {
   SectionAgent,
   SectionAgentRegistry,
 } from "../../types";
+import type { GenerationCollector } from "../executeGenericPromptAgent";
 import { isCycleSectionKey } from "../sharedPromptParts/cycleTarget.part";
 import { additionalMaterialsAgent } from "./additionalMaterialsAgent";
 import { basedOnAgent } from "./basedOnAgent";
@@ -29,9 +30,11 @@ import { titleAgent } from "./titleAgent";
 
 export const createSectionAgentRegistry = ({
   openai,
+  collectGeneration,
   customAgentHandlers,
 }: {
   openai: OpenAI;
+  collectGeneration?: GenerationCollector;
   customAgentHandlers: {
     "starterQuiz--maths": SectionAgent<LatestQuiz>["handler"];
     "exitQuiz--maths": SectionAgent<LatestQuiz>["handler"];
@@ -41,66 +44,77 @@ export const createSectionAgentRegistry = ({
     id: "keyStage--default",
     description: "",
     openai,
+    collectGeneration,
     contentFromDocument: (document) => document.keyStage,
   }),
   "subject--default": subjectAgent({
     id: "subject--default",
     description: "Generates the subject for the lesson",
     openai,
+    collectGeneration,
     contentFromDocument: (document) => document.subject,
   }),
   "title--default": titleAgent({
     id: "title--default",
     description: "Generates the title for the lesson",
     openai,
+    collectGeneration,
     contentFromDocument: (document) => document.title,
   }),
   "basedOn--default": basedOnAgent({
     id: "basedOn--default",
     description: "Generates what the lesson is based on",
     openai,
+    collectGeneration,
     contentFromDocument: (document) => document.basedOn ?? undefined,
   }),
   "learningOutcome--default": learningOutcomeAgent({
     id: "learningOutcome--default",
     description: "Generates the learning outcome for the lesson",
     openai,
+    collectGeneration,
     contentFromDocument: (document) => document.learningOutcome,
   }),
   "learningCycleOutcomes--default": learningCycleOutcomesAgent({
     id: "learningCycleOutcomes--default",
     description: "Generates learning cycle outcomes",
     openai,
+    collectGeneration,
     contentFromDocument: (document) => document.learningCycles,
   }),
   "priorKnowledge--default": priorKnowledgeAgent({
     id: "priorKnowledge--default",
     description: "Generates prior knowledge requirements",
     openai,
+    collectGeneration,
     contentFromDocument: (document) => document.priorKnowledge,
   }),
   "keyLearningPoints--default": keyLearningPointsAgent({
     id: "keyLearningPoints--default",
     description: "Generates key learning points",
     openai,
+    collectGeneration,
     contentFromDocument: (document) => document.keyLearningPoints,
   }),
   "misconceptions--default": misconceptionsAgent({
     id: "misconceptions--default",
     description: "Generates common misconceptions",
     openai,
+    collectGeneration,
     contentFromDocument: (document) => document.misconceptions,
   }),
   "keywords--default": keywordsAgent({
     id: "keywords--default",
     description: "Generates keywords for the lesson",
     openai,
+    collectGeneration,
     contentFromDocument: (document) => document.keywords,
   }),
   "starterQuiz--default": starterQuizAgent({
     id: "starterQuiz--default",
     description: "Generates starter quiz questions",
     openai,
+    collectGeneration,
     contentFromDocument: (document) =>
       toMultipleChoiceOnlyQuiz(
         "starterQuiz" in document ? document.starterQuiz : undefined,
@@ -115,12 +129,14 @@ export const createSectionAgentRegistry = ({
     id: "cycle--default",
     description: "Generates learning cycle content",
     openai,
+    collectGeneration,
     contentFromDocument: getCycleContentFromDocument,
   }),
   "exitQuiz--default": exitQuizAgent({
     id: "exitQuiz--default",
     description: "Generates exit quiz questions",
     openai,
+    collectGeneration,
     contentFromDocument: (document) =>
       toMultipleChoiceOnlyQuiz(
         "exitQuiz" in document ? document.exitQuiz : undefined,
@@ -135,6 +151,7 @@ export const createSectionAgentRegistry = ({
     id: "additionalMaterials--default",
     description: "Provides additional materials for the lesson",
     openai,
+    collectGeneration,
     contentFromDocument: (document) =>
       document.additionalMaterials ?? undefined,
   }),

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/sectionAgentRegistry.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/sectionAgentRegistry.ts
@@ -5,6 +5,7 @@ import type {
   LatestQuiz,
   PartialLessonPlan,
 } from "../../../../protocol/schema";
+import { toMultipleChoiceOnlyQuiz } from "../../quizOperations/toMultipleChoiceOnlyQuiz";
 import type {
   AilaExecutionContext,
   SectionAgent,
@@ -101,7 +102,9 @@ export const createSectionAgentRegistry = ({
     description: "Generates starter quiz questions",
     openai,
     contentFromDocument: (document) =>
-      "starterQuiz" in document ? document.starterQuiz : undefined,
+      toMultipleChoiceOnlyQuiz(
+        "starterQuiz" in document ? document.starterQuiz : undefined,
+      ),
   }),
   "starterQuiz--maths": {
     id: "starterQuiz--maths",
@@ -119,7 +122,9 @@ export const createSectionAgentRegistry = ({
     description: "Generates exit quiz questions",
     openai,
     contentFromDocument: (document) =>
-      "exitQuiz" in document ? document.exitQuiz : undefined,
+      toMultipleChoiceOnlyQuiz(
+        "exitQuiz" in document ? document.exitQuiz : undefined,
+      ),
   }),
   "exitQuiz--maths": {
     id: "exitQuiz--maths",

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/shared/positionPlaceholder.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/shared/positionPlaceholder.ts
@@ -1,0 +1,8 @@
+/**
+ * Stands in for the rewrite position in a version-stable stored prompt template,
+ * so rewriting different positions doesn't create a new prompt version. Rewrite
+ * instructions accept `number | PositionPlaceholder` for the position.
+ */
+export const POSITION_PLACEHOLDER = "{position}";
+
+export type PositionPlaceholder = typeof POSITION_PLACEHOLDER;

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/shared/quizQuestionDesign.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/shared/quizQuestionDesign.instructions.ts
@@ -16,7 +16,7 @@ export function quizQuestionDesignInstructions(keyStage: string): string {
 ${getKeyStageLanguageGuidance(keyStage)}
 
 ## Answers
-- Include 1 correct answer + 2 high-quality distractors.
+- Every question must have exactly 3 answer options: exactly 1 correct answer + exactly 2 high-quality distractors. Never include more.
 - Mutually exclusive (i.e. only one answer is correct)
 - Do not include 'all/none of the above' as an answer option.
 - Not include words from the question in the answers which may give away the correct answer.

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/index.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/index.test.ts
@@ -1,0 +1,129 @@
+import type OpenAI from "openai";
+
+import { starterQuizAgent } from ".";
+import type { PartialLessonPlan } from "../../../../../protocol/schema";
+import { toMultipleChoiceOnlyQuiz } from "../../../quizOperations/toMultipleChoiceOnlyQuiz";
+import type {
+  AilaExecutionContext,
+  SectionAgentRegistry,
+} from "../../../types";
+import { executeGenericPromptAgent } from "../../executeGenericPromptAgent";
+
+jest.mock("../../executeGenericPromptAgent", () => ({
+  executeGenericPromptAgent: jest.fn().mockResolvedValue({ data: {} }),
+}));
+
+const document: PartialLessonPlan = {
+  title: "Comparing fractions",
+  keyStage: "ks2",
+  priorKnowledge: ["Pupils can halve shapes"],
+  keyLearningPoints: ["A fraction shows parts of a whole"],
+  cycle1: {
+    title: "Compare unit fractions",
+    durationInMinutes: 10,
+    explanation: {
+      spokenExplanation: "Explain comparing unit fractions.",
+      accompanyingSlideDetails: "Two fraction bars",
+      imagePrompt: "fraction bars",
+      slideText: "Compare unit fractions",
+    },
+    checkForUnderstanding: [
+      {
+        question: "Which is larger, 1/2 or 1/4?",
+        answers: ["1/2"],
+        distractors: ["1/4", "They are equal"],
+      },
+      {
+        question: "Which is smaller, 1/3 or 1/5?",
+        answers: ["1/5"],
+        distractors: ["1/3", "They are equal"],
+      },
+    ],
+    practice: "Sort fractions by size.",
+    feedback: "1/2 is the largest unit fraction.",
+  },
+};
+
+const buildCtx = (): AilaExecutionContext => ({
+  persistedState: {
+    messages: [],
+    initialDocument: {},
+    relevantLessons: [],
+    ragFetched: { status: "not_fetched", searchIdentity: null },
+  },
+  runtime: {
+    plannerAgent: jest.fn(),
+    // empty stub; the prompt-building path never reads the registry
+    sectionAgents: {} as SectionAgentRegistry,
+    messageToUserAgent: jest.fn(),
+    britishEnglishCorrectorAgent: jest.fn(),
+    fetchRelevantLessons: jest.fn(),
+    config: { mathsQuizEnabled: false },
+  },
+  currentTurn: {
+    document,
+    plannerOutput: null,
+    errors: [],
+    notes: [],
+    stepsExecuted: [],
+    relevantLessonsFetched: false,
+    relevantLessons: [],
+    currentStep: null,
+    correctorStats: { attempted: [], notNeeded: [], failed: [] },
+  },
+  callbacks: {
+    onPlannerComplete: jest.fn(),
+    onSectionComplete: jest.fn(),
+    onRagFetchedChange: jest.fn(),
+    onTurnComplete: jest.fn(),
+    onTurnFailed: jest.fn(),
+  },
+});
+
+const runAgentAndGetPromptContents = async (): Promise<string[]> => {
+  const agent = starterQuizAgent({
+    id: "starterQuiz--default",
+    description: "Generates starter quiz questions",
+    openai: {} as OpenAI,
+    contentFromDocument: (doc) =>
+      toMultipleChoiceOnlyQuiz(
+        "starterQuiz" in doc ? doc.starterQuiz : undefined,
+      ),
+  });
+
+  await agent.handler(buildCtx());
+
+  const { calls } = jest.mocked(executeGenericPromptAgent).mock;
+  const lastCall = calls[calls.length - 1];
+  if (!lastCall) throw new Error("executeGenericPromptAgent was not called");
+  return lastCall[0].agent.input.map((message) => message.content);
+};
+
+describe("starterQuizAgent", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("adds the prior knowledge to assess section to the prompt", async () => {
+    const contents = await runAgentAndGetPromptContents();
+
+    const part = contents.find((content) =>
+      content.startsWith("## PRIOR KNOWLEDGE TO ASSESS"),
+    );
+    expect(part).toBeDefined();
+    expect(part).toContain("- Pupils can halve shapes");
+  });
+
+  it("hides the lesson's teaching content from the current document", async () => {
+    const contents = await runAgentAndGetPromptContents();
+
+    const currentDocument = contents.find((content) =>
+      content.startsWith("CURRENT DOCUMENT"),
+    );
+    expect(currentDocument).toBeDefined();
+    expect(currentDocument).toContain("Comparing fractions");
+    expect(currentDocument).toContain("Pupils can halve shapes");
+    expect(currentDocument).not.toContain("A fraction shows parts of a whole");
+    expect(currentDocument).not.toContain("Compare unit fractions");
+  });
+});

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/index.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_AGENT_MODEL_PARAMS } from "../../../constants";
+import { priorKnowledgeTargetPromptPart } from "../../sharedPromptParts/priorKnowledgeTarget.part";
 import {
   createSectionAgent,
   keyStageBuildModeInstructions,
@@ -9,6 +10,7 @@ import {
   starterQuizInstructions,
 } from "./starterQuiz.instructions";
 import { StarterQuizSchema } from "./starterQuiz.schema";
+import { starterQuizDocumentForPrompt } from "./starterQuizDocumentView";
 
 export const starterQuizAgent = createSectionAgent({
   responseSchema: StarterQuizSchema,
@@ -17,6 +19,10 @@ export const starterQuizAgent = createSectionAgent({
     addOne: addOneQuizInstructions,
     rewriteOne: rewriteOneQuizInstructions,
   }),
+  extraInputFromCtx: (ctx) => [
+    { role: "developer", content: priorKnowledgeTargetPromptPart(ctx) },
+  ],
+  documentForPrompt: starterQuizDocumentForPrompt,
   defaultVoice: "TEACHER_TO_PUPIL_WRITTEN",
   modelParams: DEFAULT_AGENT_MODEL_PARAMS,
 });

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/index.ts
@@ -1,6 +1,8 @@
 import { DEFAULT_AGENT_MODEL_PARAMS } from "../../../constants";
-import { deriveSectionBuildMode } from "../../../quizOperations/deriveSectionBuildMode";
-import { createSectionAgent } from "../createSectionAgent";
+import {
+  createSectionAgent,
+  keyStageBuildModeInstructions,
+} from "../createSectionAgent";
 import {
   addOneQuizInstructions,
   rewriteOneQuizInstructions,
@@ -10,18 +12,11 @@ import { StarterQuizSchema } from "./starterQuiz.schema";
 
 export const starterQuizAgent = createSectionAgent({
   responseSchema: StarterQuizSchema,
-  instructions: (ctx) => {
-    const keyStage = ctx.currentTurn.document.keyStage ?? "";
-    const mode = deriveSectionBuildMode(ctx.currentTurn.currentStep);
-    switch (mode.kind) {
-      case "fullRegen":
-        return starterQuizInstructions(keyStage);
-      case "addOne":
-        return addOneQuizInstructions(keyStage);
-      case "rewriteOne":
-        return rewriteOneQuizInstructions(mode.position, keyStage);
-    }
-  },
+  instructions: keyStageBuildModeInstructions({
+    fullRegen: starterQuizInstructions,
+    addOne: addOneQuizInstructions,
+    rewriteOne: rewriteOneQuizInstructions,
+  }),
   defaultVoice: "TEACHER_TO_PUPIL_WRITTEN",
   modelParams: DEFAULT_AGENT_MODEL_PARAMS,
 });

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.test.ts
@@ -5,7 +5,31 @@ import {
 } from "./starterQuiz.instructions";
 
 describe("starterQuiz instructions", () => {
+  describe("starterQuizInstructions", () => {
+    it("asks for exactly 6 questions", () => {
+      expect(starterQuizInstructions("ks2")).toMatch(/exactly 6 questions/i);
+    });
+
+    it("asks for exactly 1 correct answer and exactly 2 distractors", () => {
+      expect(starterQuizInstructions("ks2")).toMatch(
+        /exactly 1 correct answer/i,
+      );
+      expect(starterQuizInstructions("ks2")).toMatch(
+        /exactly 2 high-quality distractors/i,
+      );
+    });
+  });
+
   describe("addOneQuizInstructions", () => {
+    it("asks for exactly 1 correct answer and exactly 2 distractors", () => {
+      expect(addOneQuizInstructions("ks2")).toMatch(
+        /exactly 1 correct answer/i,
+      );
+      expect(addOneQuizInstructions("ks2")).toMatch(
+        /exactly 2 high-quality distractors/i,
+      );
+    });
+
     it("directs the LLM to generate exactly one question", () => {
       expect(addOneQuizInstructions("ks2")).toMatch(/exactly one/i);
     });

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.test.ts
@@ -6,6 +6,12 @@ import {
 
 describe("starterQuiz instructions", () => {
   describe("starterQuizInstructions", () => {
+    it("binds questions to the prior knowledge to assess section", () => {
+      expect(starterQuizInstructions("ks2")).toMatch(
+        /PRIOR KNOWLEDGE TO ASSESS/,
+      );
+    });
+
     it("asks for exactly 6 questions", () => {
       expect(starterQuizInstructions("ks2")).toMatch(/exactly 6 questions/i);
     });
@@ -21,6 +27,12 @@ describe("starterQuiz instructions", () => {
   });
 
   describe("addOneQuizInstructions", () => {
+    it("binds the new question to the prior knowledge to assess section", () => {
+      expect(addOneQuizInstructions("ks2")).toMatch(
+        /PRIOR KNOWLEDGE TO ASSESS/,
+      );
+    });
+
     it("asks for exactly 1 correct answer and exactly 2 distractors", () => {
       expect(addOneQuizInstructions("ks2")).toMatch(
         /exactly 1 correct answer/i,
@@ -52,6 +64,12 @@ describe("starterQuiz instructions", () => {
   });
 
   describe("rewriteOneQuizInstructions", () => {
+    it("binds the replacement question to the prior knowledge to assess section", () => {
+      expect(rewriteOneQuizInstructions(2, "ks2")).toMatch(
+        /PRIOR KNOWLEDGE TO ASSESS/,
+      );
+    });
+
     it("is a function that accepts a 1-indexed position", () => {
       expect(typeof rewriteOneQuizInstructions).toBe("function");
     });

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.ts
@@ -8,8 +8,8 @@ Create a multiple-choice quiz with exactly 6 questions to assess PRIOR KNOWLEDGE
 
 ## Content Scope:
 
-- Use only content from the PRIOR KNOWLEDGE section
-- Do not test or mention any of this lessons key learning points
+- Base questions on the PRIOR KNOWLEDGE TO ASSESS section provided below
+- Do not test or mention any of this lesson's key learning points
 - Content should be age-appropriate
 - Questions should increase in difficulty
 - Designed so the average pupil scores 5 out of 6.
@@ -25,6 +25,11 @@ export function addOneQuizInstructions(keyStage: string): string {
 
 Generate exactly ONE new multiple-choice question to ADD to the existing quiz. Do not output, modify, or restate the existing questions — they will be preserved by the system.
 
+## Content Scope
+
+- The new question must assess prior knowledge from the PRIOR KNOWLEDGE TO ASSESS section provided below.
+- It must not overlap with the existing questions or test new lesson content.
+
 ## Question Design
 
 ${quizQuestionDesignInstructions(keyStage)}`;
@@ -37,6 +42,11 @@ export const rewriteOneQuizInstructions = (
   `# Task
 
 Rewrite question ${position} of the existing quiz. Return only the replacement question. Do not modify or output any of the other questions — they will be preserved by the system.
+
+## Content Scope
+
+- The replacement question must assess prior knowledge from the PRIOR KNOWLEDGE TO ASSESS section provided below.
+- It must not overlap with the other questions or test new lesson content.
 
 ## Question Design
 

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.ts
@@ -1,3 +1,4 @@
+import type { PositionPlaceholder } from "../shared/positionPlaceholder";
 import { quizQuestionDesignInstructions } from "../shared/quizQuestionDesign.instructions";
 
 export function starterQuizInstructions(keyStage: string): string {
@@ -30,7 +31,7 @@ ${quizQuestionDesignInstructions(keyStage)}`;
 }
 
 export const rewriteOneQuizInstructions = (
-  position: number,
+  position: number | PositionPlaceholder,
   keyStage: string,
 ): string =>
   `# Task

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.instructions.ts
@@ -3,7 +3,7 @@ import { quizQuestionDesignInstructions } from "../shared/quizQuestionDesign.ins
 export function starterQuizInstructions(keyStage: string): string {
   return `# Task
 
-Create a 6-question multiple-choice quiz to assess PRIOR KNOWLEDGE ONLY — do not include or hint at new lesson content.
+Create a multiple-choice quiz with exactly 6 questions to assess PRIOR KNOWLEDGE ONLY — do not include or hint at new lesson content.
 
 ## Content Scope:
 

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.schema.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuiz.schema.ts
@@ -1,1 +1,1 @@
-export { LatestQuizSchema as StarterQuizSchema } from "../../../../../protocol/schema";
+export { LatestQuizMultipleChoiceOnlyStrictMax6Schema as StarterQuizSchema } from "../../../../../protocol/schema";

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuizDocumentView.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuizDocumentView.test.ts
@@ -1,0 +1,65 @@
+import type { PartialLessonPlan } from "../../../../../protocol/schema";
+import { starterQuizDocumentForPrompt } from "./starterQuizDocumentView";
+
+describe("starterQuizDocumentForPrompt", () => {
+  it("keeps lesson context fields and prior knowledge only", () => {
+    const document: PartialLessonPlan = {
+      title: "Comparing fractions",
+      subject: "maths",
+      keyStage: "ks2",
+      topic: "Fractions",
+      learningOutcome: "I can compare fractions with the same denominator",
+      priorKnowledge: ["Pupils can halve shapes"],
+      basedOn: { id: "lesson-1", title: "Fractions of shapes" },
+      keyLearningPoints: ["A fraction shows parts of a whole"],
+      keywords: [{ keyword: "denominator", definition: "The bottom number" }],
+      learningCycles: ["Compare unit fractions"],
+      misconceptions: [
+        {
+          misconception: "Bigger denominators mean bigger fractions",
+          description: "Show that 1/8 is smaller than 1/4 using fraction bars.",
+        },
+      ],
+      cycle1: {
+        title: "Compare unit fractions",
+        durationInMinutes: 10,
+        explanation: {
+          spokenExplanation: "Explain comparing unit fractions.",
+          accompanyingSlideDetails: "Two fraction bars",
+          imagePrompt: "fraction bars",
+          slideText: "Compare unit fractions",
+        },
+        checkForUnderstanding: [
+          {
+            question: "Which is larger, 1/2 or 1/4?",
+            answers: ["1/2"],
+            distractors: ["1/4", "They are equal"],
+          },
+          {
+            question: "Which is smaller, 1/3 or 1/5?",
+            answers: ["1/5"],
+            distractors: ["1/3", "They are equal"],
+          },
+        ],
+        practice: "Sort fractions by size.",
+        feedback: "1/2 is the largest unit fraction.",
+      },
+      exitQuiz: { version: "v3", questions: [], imageMetadata: [] },
+    };
+
+    expect(starterQuizDocumentForPrompt(document)).toEqual({
+      title: "Comparing fractions",
+      subject: "maths",
+      keyStage: "ks2",
+      topic: "Fractions",
+      learningOutcome: "I can compare fractions with the same denominator",
+      priorKnowledge: ["Pupils can halve shapes"],
+    });
+  });
+
+  it("handles a sparse document", () => {
+    expect(starterQuizDocumentForPrompt({ title: "New lesson" })).toEqual({
+      title: "New lesson",
+    });
+  });
+});

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuizDocumentView.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/starterQuizAgent/starterQuizDocumentView.ts
@@ -1,0 +1,22 @@
+import { pick } from "remeda";
+
+import type { PartialLessonPlan } from "../../../../../protocol/schema";
+
+/**
+ * The starter quiz assesses prior knowledge only, so the agent must not see
+ * the lesson's own teaching content (key learning points, cycles, keywords,
+ * exit quiz); with it in view the model tends to test upcoming material.
+ * The learning outcome stays for topic anchoring and difficulty calibration.
+ */
+export function starterQuizDocumentForPrompt(
+  document: PartialLessonPlan,
+): PartialLessonPlan {
+  return pick(document, [
+    "title",
+    "subject",
+    "keyStage",
+    "topic",
+    "learningOutcome",
+    "priorKnowledge",
+  ]);
+}

--- a/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.test.ts
@@ -199,6 +199,20 @@ describe("sectionToGenericPromptAgent", () => {
       expect(agent.input).toMatchSnapshot();
     });
 
+    it("should filter the current document with documentForPrompt", () => {
+      const propsWithDocumentView: SectionPromptAgentProps<MockSchemaType> = {
+        ...baseProps,
+        documentForPrompt: (document) => ({
+          title: document.title,
+          keyStage: document.keyStage,
+        }),
+      };
+
+      const agent = createAgent(propsWithDocumentView);
+
+      expect(agent.input).toMatchSnapshot();
+    });
+
     it("should handle extra input from context", () => {
       const extraInputFromCtx = (_ctx: AilaExecutionContext) => [
         {

--- a/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.ts
@@ -21,6 +21,9 @@ export function sectionToGenericPromptAgent<SectionValueType>(
     responseSchema,
     id,
     instructions,
+    templateText,
+    promptTemplateId,
+    promptInputs,
     messages,
     exemplarContent,
     basedOnContent,
@@ -36,28 +39,44 @@ export function sectionToGenericPromptAgent<SectionValueType>(
     "input" | "text" | "stream"
   >,
 ): GenericPromptAgent<SectionValueType> {
-  voices = voices.includes(defaultVoice) ? voices : [defaultVoice, ...voices];
+  const resolvedVoices = voices.includes(defaultVoice)
+    ? voices
+    : [defaultVoice, ...voices];
+
+  // Identity and voice first (most stable → best prompt-cache prefix), then
+  // instructions; shared between the runtime prompt and the stored template.
+  const voicePrefix = [
+    { role: "developer" as const, content: identityAndVoice },
+    resolvedVoices.length > 0 && {
+      role: "developer" as const,
+      content: getVoiceDefinitions(resolvedVoices),
+    },
+    defaultVoice && {
+      role: "developer" as const,
+      content: getVoicePrompt(defaultVoice),
+    },
+  ].filter(isTruthy);
+
+  const staticParts = [
+    ...voicePrefix,
+    { role: "developer" as const, content: instructions },
+  ];
+
+  // Stored template prefers `templateText` (version-stable) over the runtime
+  // instructions.
+  const promptTemplate = [
+    ...voicePrefix.map((part) => part.content),
+    templateText ?? instructions,
+  ].join("\n\n");
 
   return {
     id,
+    promptTemplateId,
+    promptTemplate,
+    promptInputs,
     responseSchema: responseSchema,
     input: [
-      {
-        role: "developer" as const,
-        content: identityAndVoice,
-      },
-      voices.length > 0 && {
-        role: "developer" as const,
-        content: getVoiceDefinitions(voices),
-      },
-      defaultVoice && {
-        role: "developer" as const,
-        content: getVoicePrompt(defaultVoice),
-      },
-      {
-        role: "developer" as const,
-        content: instructions,
-      },
+      ...staticParts,
       {
         role: "developer" as const,
         content: currentDocumentPromptPart(ctx.currentTurn.document),

--- a/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.ts
@@ -31,6 +31,7 @@ export function sectionToGenericPromptAgent<SectionValueType>(
     contentToString,
     ctx,
     extraInputFromCtx,
+    documentForPrompt,
     defaultVoice = "AILA_TO_TEACHER",
     voices = [],
   }: SectionPromptAgentProps<SectionValueType>,
@@ -79,7 +80,10 @@ export function sectionToGenericPromptAgent<SectionValueType>(
       ...staticParts,
       {
         role: "developer" as const,
-        content: currentDocumentPromptPart(ctx.currentTurn.document),
+        content: currentDocumentPromptPart(
+          documentForPrompt?.(ctx.currentTurn.document) ??
+            ctx.currentTurn.document,
+        ),
       },
       currentValue && {
         role: "developer" as const,

--- a/packages/aila/src/lib/agentic-system/agents/sharedPromptParts/priorKnowledgeTarget.part.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sharedPromptParts/priorKnowledgeTarget.part.test.ts
@@ -1,0 +1,43 @@
+import type { PartialLessonPlan } from "../../../../protocol/schema";
+import type { AilaExecutionContext } from "../../types";
+import { priorKnowledgeTargetPromptPart } from "./priorKnowledgeTarget.part";
+
+const makeCtx = (document: PartialLessonPlan): AilaExecutionContext =>
+  ({ currentTurn: { document } }) as AilaExecutionContext;
+
+describe("priorKnowledgeTargetPromptPart", () => {
+  it("lists each prior knowledge statement as a bullet", () => {
+    const part = priorKnowledgeTargetPromptPart(
+      makeCtx({
+        priorKnowledge: ["Pupils can count to 100", "Pupils can halve shapes"],
+      }),
+    );
+
+    expect(part).toContain("- Pupils can count to 100");
+    expect(part).toContain("- Pupils can halve shapes");
+    expect(part).toContain("PRIOR KNOWLEDGE TO ASSESS");
+  });
+
+  it("falls back to prerequisite guidance when prior knowledge is missing", () => {
+    const part = priorKnowledgeTargetPromptPart(makeCtx({}));
+
+    expect(part).toContain("No prior knowledge statements exist yet");
+    expect(part).toContain("do not test the lesson's own content");
+  });
+
+  it("falls back to prerequisite guidance when prior knowledge is empty", () => {
+    const part = priorKnowledgeTargetPromptPart(
+      makeCtx({ priorKnowledge: [] }),
+    );
+
+    expect(part).toContain("No prior knowledge statements exist yet");
+  });
+
+  it("tells the model never to test what the lesson will teach", () => {
+    const part = priorKnowledgeTargetPromptPart(
+      makeCtx({ priorKnowledge: ["Pupils can count to 100"] }),
+    );
+
+    expect(part).toMatch(/never test or hint at what this lesson itself/i);
+  });
+});

--- a/packages/aila/src/lib/agentic-system/agents/sharedPromptParts/priorKnowledgeTarget.part.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sharedPromptParts/priorKnowledgeTarget.part.ts
@@ -1,0 +1,24 @@
+import type { AilaExecutionContext } from "../../types";
+
+export function priorKnowledgeTargetPromptPart(
+  ctx: AilaExecutionContext,
+): string {
+  const priorKnowledge = ctx.currentTurn.document.priorKnowledge ?? [];
+
+  const statements =
+    priorKnowledge.length > 0
+      ? `The statements below are the lesson's stated prior knowledge and are the primary source for questions:
+
+${priorKnowledge.map((statement) => `- ${statement}`).join("\n")}`
+      : "No prior knowledge statements exist yet. Base questions strictly on prerequisite knowledge for this lesson's title and key stage; do not test the lesson's own content.";
+
+  return `## PRIOR KNOWLEDGE TO ASSESS
+
+The starter quiz assesses ONLY knowledge pupils should already have BEFORE this lesson begins.
+
+${statements}
+
+Rules:
+- Base questions on the statements above; topic-appropriate prerequisite knowledge for this key stage may supplement them.
+- Never test or hint at what this lesson itself will teach. Lesson context is for difficulty calibration only, never a source of questions.`;
+}

--- a/packages/aila/src/lib/agentic-system/execution/executePlanSteps.quiz.test.ts
+++ b/packages/aila/src/lib/agentic-system/execution/executePlanSteps.quiz.test.ts
@@ -487,6 +487,152 @@ describe("executePlanSteps — quiz dispatch intercept", () => {
         britishQuestion,
       ]);
     });
+
+    it("falls back to the uncorrected question when the corrector adds extra options", async () => {
+      const americanQuestion = makeQuestion("What color is a healthy leaf?");
+      const overOptioned = {
+        ...americanQuestion,
+        question: "What colour is a healthy leaf?",
+        distractors: ["Wrong A", "Wrong B", "Wrong C"],
+      };
+      const sectionAgent = jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          version: "v3",
+          questions: [americanQuestion],
+          imageMetadata: [],
+        },
+      });
+      const corrector = jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          version: "v3",
+          questions: [overOptioned],
+          imageMetadata: [],
+        },
+      });
+      const callbacks = makeCallbacks();
+
+      const runtime = makeRuntime({
+        plannerAgent: jest.fn().mockResolvedValue({
+          error: null,
+          data: {
+            decision: "plan",
+            parsedUserMessage: "Add a question about colour",
+            plan: [
+              {
+                type: "section",
+                sectionKey: "starterQuiz",
+                action: "generate",
+                sectionInstructions: null,
+                itemIntent: {
+                  action: "ADD_ITEM",
+                  position: null,
+                },
+              },
+            ],
+          },
+        }),
+        sectionAgents: {
+          "starterQuiz--default": {
+            id: "starterQuiz--default",
+            description: "starter quiz",
+            handler: sectionAgent,
+          },
+        } as unknown as SectionAgentRegistry,
+        britishEnglishCorrectorAgent: corrector,
+      });
+
+      await ailaTurn({
+        persistedState: makePersistedState(),
+        runtime,
+        callbacks,
+      });
+
+      expect(corrector).toHaveBeenCalledTimes(1);
+      expect(getUpdatedStarterQuiz(callbacks)?.questions).toEqual([
+        q1,
+        q2,
+        q3,
+        americanQuestion,
+      ]);
+    });
+
+    it("keeps the permissive schema for maths quiz corrections", async () => {
+      const americanQuestion: LatestQuizQuestion = {
+        questionType: "short-answer",
+        question: "What color is a healthy leaf?",
+        hint: null,
+        answers: ["green"],
+      };
+      const britishQuestion = {
+        ...americanQuestion,
+        question: "What colour is a healthy leaf?",
+      };
+      const mathsAgent = jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          version: "v3",
+          questions: [americanQuestion],
+          imageMetadata: [],
+        },
+      });
+      const corrector = jest.fn().mockResolvedValue({
+        error: null,
+        data: {
+          version: "v3",
+          questions: [britishQuestion],
+          imageMetadata: [],
+        },
+      });
+      const callbacks = makeCallbacks();
+
+      const mathsState: AilaPersistedState = {
+        ...makePersistedState(),
+        initialDocument: { subject: "maths", starterQuiz },
+      };
+
+      const runtime = makeRuntime({
+        config: { mathsQuizEnabled: true },
+        plannerAgent: jest.fn().mockResolvedValue({
+          error: null,
+          data: {
+            decision: "plan",
+            parsedUserMessage: "Add a question about colour",
+            plan: [
+              {
+                type: "section",
+                sectionKey: "starterQuiz",
+                action: "generate",
+                sectionInstructions: null,
+                itemIntent: {
+                  action: "ADD_ITEM",
+                  position: null,
+                },
+              },
+            ],
+          },
+        }),
+        sectionAgents: {
+          "starterQuiz--maths": {
+            id: "starterQuiz--maths",
+            description: "maths starter quiz",
+            handler: mathsAgent,
+          },
+        } as unknown as SectionAgentRegistry,
+        britishEnglishCorrectorAgent: corrector,
+      });
+
+      await ailaTurn({ persistedState: mathsState, runtime, callbacks });
+
+      expect(corrector).toHaveBeenCalledTimes(1);
+      expect(getUpdatedStarterQuiz(callbacks)?.questions).toEqual([
+        q1,
+        q2,
+        q3,
+        britishQuestion,
+      ]);
+    });
   });
 
   describe("REMOVE_ITEM", () => {

--- a/packages/aila/src/lib/agentic-system/execution/executePlanSteps.ts
+++ b/packages/aila/src/lib/agentic-system/execution/executePlanSteps.ts
@@ -12,6 +12,7 @@ import type {
 import {
   CompletedLessonPlanSchema,
   KeywordsSchema,
+  LatestQuizMultipleChoiceOnlyStrictMax6Schema,
   LatestQuizSchema,
   MisconceptionsSchema,
 } from "../../../protocol/schema";
@@ -198,7 +199,7 @@ async function executeGenerateStep(
     context,
     sectionKey: step.sectionKey,
     content: result.data,
-    responseSchema: sectionSchema,
+    responseSchema: correctorResponseSchema(context, step),
   });
 
   const validated = corrected ?? sectionSchema.parse(result.data);
@@ -214,6 +215,28 @@ async function executeGenerateStep(
   });
 
   return { status: "continue" };
+}
+
+/**
+ * The corrector validates its output against this schema. Strict for
+ * default-agent quizzes so it cannot re-introduce extra options or questions;
+ * permissive for maths-bank quizzes and every other section.
+ */
+function correctorResponseSchema(
+  context: AilaExecutionContext,
+  step: PlanStep,
+) {
+  const { sectionKey } = step;
+  if (sectionKey === "starterQuiz" || sectionKey === "exitQuiz") {
+    const agentId = sectionStepToAgentId(step, {
+      config: context.runtime.config,
+      document: context.currentTurn.document,
+    });
+    if (agentId === `${sectionKey}--default`) {
+      return LatestQuizMultipleChoiceOnlyStrictMax6Schema;
+    }
+  }
+  return CompletedLessonPlanSchema.shape[sectionKey];
 }
 
 function getMissingCycleOutcomeMessage(
@@ -265,11 +288,15 @@ async function executeQuizDispatchStep(
       if (!validateSingleQuestion(question)) return null;
       // Correct only this new question, wrapped as a single-question quiz, so
       // existing questions are never sent to the corrector and stay untouched.
+      // Strict schema for default agents, as in correctorResponseSchema.
       const correctedQuiz = await applyBritishEnglishCorrection({
         context,
         sectionKey,
         content: { ...currentQuiz, questions: [question] },
-        responseSchema: CompletedLessonPlanSchema.shape[sectionKey],
+        responseSchema:
+          agentId === `${sectionKey}--default`
+            ? LatestQuizMultipleChoiceOnlyStrictMax6Schema
+            : CompletedLessonPlanSchema.shape[sectionKey],
       });
       return correctedQuiz?.questions[0] ?? question ?? null;
     },

--- a/packages/aila/src/lib/agentic-system/quizOperations/quizOperationDispatcher.test.ts
+++ b/packages/aila/src/lib/agentic-system/quizOperations/quizOperationDispatcher.test.ts
@@ -1,4 +1,5 @@
 import type { LatestQuiz, LatestQuizQuestion } from "../../../protocol/schema";
+import { QUIZ_MAX_QUESTIONS } from "../../../protocol/schemas/quiz/quizV3";
 import type { StructuralItemIntent } from "../schema";
 import { quizOperationDispatcher } from "./quizOperationDispatcher";
 import type { RunSingleQuestionFn } from "./quizOperationDispatcher";
@@ -119,7 +120,9 @@ describe("quizOperationDispatcher", () => {
     });
     it("returns the quiz unchanged with a note when the quiz is already at the maximum size", async () => {
       const quiz = makeQuiz(
-        Array.from({ length: 50 }, (_, i) => makeQuestion(`Question ${i + 1}`)),
+        Array.from({ length: QUIZ_MAX_QUESTIONS }, (_, i) =>
+          makeQuestion(`Question ${i + 1}`),
+        ),
       );
       const agent = jest.fn() as jest.MockedFunction<RunSingleQuestionFn>;
 

--- a/packages/aila/src/lib/agentic-system/quizOperations/quizOperationDispatcher.ts
+++ b/packages/aila/src/lib/agentic-system/quizOperations/quizOperationDispatcher.ts
@@ -1,4 +1,5 @@
 import type { LatestQuiz, LatestQuizQuestion } from "../../../protocol/schema";
+import { QUIZ_MAX_QUESTIONS } from "../../../protocol/schemas/quiz/quizV3";
 import type { StructuralItemIntent } from "../schema";
 import {
   type RunSingleItemFn,
@@ -6,9 +7,6 @@ import {
 } from "./sectionListOperationDispatcher";
 
 export type RunSingleQuestionFn = RunSingleItemFn<LatestQuizQuestion>;
-
-// Sanity cap, not a pedagogical limit; far above any practical quiz size.
-const MAX_QUIZ_QUESTIONS = 50;
 
 export type QuizDispatchResult = {
   data: LatestQuiz;
@@ -31,7 +29,7 @@ export async function quizOperationDispatcher(
     {
       itemNoun: "question",
       min: 0,
-      max: MAX_QUIZ_QUESTIONS,
+      max: QUIZ_MAX_QUESTIONS,
       regenerateSuggestion: "Generate a new quiz",
     },
   );

--- a/packages/aila/src/lib/agentic-system/quizOperations/toMultipleChoiceOnlyQuiz.test.ts
+++ b/packages/aila/src/lib/agentic-system/quizOperations/toMultipleChoiceOnlyQuiz.test.ts
@@ -1,0 +1,98 @@
+import type { LatestQuiz, LatestQuizQuestion } from "../../../protocol/schema";
+import { toMultipleChoiceOnlyQuiz } from "./toMultipleChoiceOnlyQuiz";
+
+const mcQuestion = (
+  overrides: Partial<
+    Extract<LatestQuizQuestion, { questionType: "multiple-choice" }>
+  > = {},
+): LatestQuizQuestion => ({
+  questionType: "multiple-choice",
+  question: "What is 1+1?",
+  hint: null,
+  answers: ["2"],
+  distractors: ["1", "3"],
+  ...overrides,
+});
+
+const makeQuiz = (questions: LatestQuizQuestion[]): LatestQuiz => ({
+  version: "v3",
+  questions,
+  imageMetadata: [],
+});
+
+describe("toMultipleChoiceOnlyQuiz", () => {
+  // A quiz may be missing because the lesson hasn't reached that section yet,
+  // or an exemplar lesson lacks it. Missing quizzes should be undefined and
+  // not become an empty quiz that would be shown to the LLM as a real example.
+  it("returns undefined when there is no quiz", () => {
+    expect(toMultipleChoiceOnlyQuiz(undefined)).toBeUndefined();
+  });
+
+  it("keeps a conforming quiz's questions unchanged", () => {
+    const quiz = makeQuiz([mcQuestion()]);
+
+    expect(toMultipleChoiceOnlyQuiz(quiz)?.questions).toEqual(quiz.questions);
+  });
+
+  it("filters out non-multiple-choice questions", () => {
+    const quiz = makeQuiz([
+      mcQuestion(),
+      {
+        questionType: "short-answer",
+        question: "Name a prime number.",
+        hint: null,
+        answers: ["2", "3"],
+      },
+      {
+        questionType: "order",
+        question: "Order these numbers.",
+        hint: null,
+        items: ["1", "2", "3"],
+      },
+    ]);
+
+    expect(toMultipleChoiceOnlyQuiz(quiz)?.questions).toEqual([mcQuestion()]);
+  });
+
+  it("keeps only the first correct answer when there are several", () => {
+    const quiz = makeQuiz([mcQuestion({ answers: ["2", "two"] })]);
+
+    expect(toMultipleChoiceOnlyQuiz(quiz)?.questions[0]?.answers).toEqual([
+      "2",
+    ]);
+  });
+
+  it("trims distractors to two when there are more", () => {
+    const quiz = makeQuiz([mcQuestion({ distractors: ["1", "3", "4", "5"] })]);
+
+    expect(toMultipleChoiceOnlyQuiz(quiz)?.questions[0]?.distractors).toEqual([
+      "1",
+      "3",
+    ]);
+  });
+
+  it("preserves imageMetadata", () => {
+    const imageMetadata = [
+      {
+        imageUrl: "https://example.com/image.png",
+        attribution: "Example",
+        width: 100,
+        height: 100,
+        aiDescription: "An example image",
+      },
+    ];
+    const quiz: LatestQuiz = { ...makeQuiz([mcQuestion()]), imageMetadata };
+
+    expect(toMultipleChoiceOnlyQuiz(quiz)?.imageMetadata).toEqual(
+      imageMetadata,
+    );
+  });
+
+  // reportId points at a maths pipeline generation report. It should be
+  // dropped because the LLM shouldn't see it.
+  it("drops reportId", () => {
+    const quiz: LatestQuiz = { ...makeQuiz([mcQuestion()]), reportId: "abc" };
+
+    expect(toMultipleChoiceOnlyQuiz(quiz)).not.toHaveProperty("reportId");
+  });
+});

--- a/packages/aila/src/lib/agentic-system/quizOperations/toMultipleChoiceOnlyQuiz.ts
+++ b/packages/aila/src/lib/agentic-system/quizOperations/toMultipleChoiceOnlyQuiz.ts
@@ -1,0 +1,32 @@
+import type { LatestQuiz } from "../../../protocol/schema";
+import {
+  QUIZ_MC_ANSWER_COUNT,
+  QUIZ_MC_DISTRACTOR_COUNT,
+  type QuizV3MultipleChoiceOnly,
+  type QuizV3QuestionMultipleChoice,
+} from "../../../protocol/schemas/quiz/quizV3";
+
+/**
+ * Best-effort shaping of a persisted quiz towards the multiple-choice-only
+ * LLM schema: drops other question types and trims extra answer options.
+ * Prompt context only; never validated against the strict schema.
+ */
+export function toMultipleChoiceOnlyQuiz(
+  quiz: LatestQuiz | undefined,
+): QuizV3MultipleChoiceOnly | undefined {
+  if (!quiz) return undefined;
+  return {
+    version: "v3",
+    questions: quiz.questions
+      .filter(
+        (q): q is QuizV3QuestionMultipleChoice =>
+          q.questionType === "multiple-choice",
+      )
+      .map((q) => ({
+        ...q,
+        answers: q.answers.slice(0, QUIZ_MC_ANSWER_COUNT),
+        distractors: q.distractors.slice(0, QUIZ_MC_DISTRACTOR_COUNT),
+      })),
+    imageMetadata: quiz.imageMetadata,
+  };
+}

--- a/packages/aila/src/lib/agentic-system/schema.ts
+++ b/packages/aila/src/lib/agentic-system/schema.ts
@@ -142,6 +142,11 @@ export type GenericPromptAgent<ResponseType> = {
     ResponseCreateParamsNonStreaming,
     "input" | "text" | "stream"
   >;
+  // Optional persistence metadata: which prompt template this call used
+  // (promptTemplateId, defaults to id), its version-stable body, and telemetry.
+  promptTemplateId?: string;
+  promptTemplate?: string;
+  promptInputs?: Record<string, unknown>;
 };
 
 /**

--- a/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
@@ -364,6 +364,43 @@ const SCORERS: Scorer[] = [
       };
     },
   },
+  {
+    id: "starter-quiz-grounding",
+    description:
+      "Starter quiz vs prior knowledge (evidence for manual review; pass = prior knowledge present)",
+    fn: ({ finalDocument }) => {
+      const quiz = finalDocument.starterQuiz;
+      if (!quiz) {
+        return { heuristic: "skip", evidence: "No starter quiz present" };
+      }
+      const priorKnowledge = finalDocument.priorKnowledge ?? [];
+      const questions = quiz.questions ?? [];
+      const keyLearningPoints = finalDocument.keyLearningPoints ?? [];
+      const lines: string[] = [];
+      lines.push("Prior knowledge (questions should assess this):");
+      lines.push(
+        ...(priorKnowledge.length > 0
+          ? priorKnowledge.map((statement) => `  - ${statement}`)
+          : ["  (none)"]),
+      );
+      lines.push("Starter quiz questions:");
+      lines.push(
+        ...(questions.length > 0
+          ? questions.map((q, qi) => `  Q${qi + 1}: ${q.question}`)
+          : ["  (none)"]),
+      );
+      lines.push("Upcoming content (should NOT be tested):");
+      lines.push(
+        ...(keyLearningPoints.length > 0
+          ? keyLearningPoints.map((klp) => `  - ${klp}`)
+          : ["  (none)"]),
+      );
+      return {
+        heuristic: priorKnowledge.length === 0 ? "flag" : "pass",
+        evidence: lines.join("\n"),
+      };
+    },
+  },
 ];
 
 // ---------------------------------------------------------------------------

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
-codeHash: 3d0b0345ad18db9c639ebd016fb2a4bb32e1d819b4d1b2d9b4c7456cab24943e
-generated: 2026-07-02T16:15:25.302Z
+codeHash: 78da7dd00cfc96d2614c475ca91c6824e9fdb6c1d7ab4b683f297828e3ac43f3
+generated: 2026-07-07T13:42:59.252Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -24,13 +24,12 @@ summary:
     quiz-question-count:
       pass: 3
     americanisms_corrector:
-      corrections_attempted: 1
-      corrections_not_needed: 32
+      corrections_attempted: 0
+      corrections_not_needed: 33
       corrections_failed: 0
-      correction_rate: 3.0%
+      correction_rate: 0.0%
       correction_failure_rate: 0.0%
-      corrections_by_section:
-        starterQuiz: 1
+      corrections_by_section: {}
   no-rag-lesson:
     generation-complete:
       pass: 3
@@ -55,9 +54,11 @@ summary:
     quiz-question-count:
       pass: 3
     americanisms_corrector:
-      corrections_attempted: 0
-      corrections_not_needed: 33
+      corrections_attempted: 2
+      corrections_not_needed: 31
       corrections_failed: 0
-      correction_rate: 0.0%
+      correction_rate: 6.1%
       correction_failure_rate: 0.0%
-      corrections_by_section: {}
+      corrections_by_section:
+        exitQuiz: 1
+        cycle2: 1

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
-codeHash: 78da7dd00cfc96d2614c475ca91c6824e9fdb6c1d7ab4b683f297828e3ac43f3
-generated: 2026-07-07T13:42:59.252Z
+codeHash: a23fea47a932d0c47716adbc900dcafa09de7b2b88b8830675dcd208f396c6e5
+generated: 2026-07-14T10:41:44.917Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -24,12 +24,13 @@ summary:
     quiz-question-count:
       pass: 3
     americanisms_corrector:
-      corrections_attempted: 0
-      corrections_not_needed: 33
+      corrections_attempted: 1
+      corrections_not_needed: 32
       corrections_failed: 0
-      correction_rate: 0.0%
+      correction_rate: 3.0%
       correction_failure_rate: 0.0%
-      corrections_by_section: {}
+      corrections_by_section:
+        cycle1: 1
   no-rag-lesson:
     generation-complete:
       pass: 3
@@ -60,5 +61,5 @@ summary:
       correction_rate: 6.1%
       correction_failure_rate: 0.0%
       corrections_by_section:
-        exitQuiz: 1
-        cycle2: 1
+        keyLearningPoints: 1
+        starterQuiz: 1

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
-codeHash: a23fea47a932d0c47716adbc900dcafa09de7b2b88b8830675dcd208f396c6e5
-generated: 2026-07-14T10:41:44.917Z
+codeHash: df430cd3a8582ff31c0d1bcaca104ab7260004794bee698dd93675798bbdc7b7
+generated: 2026-07-14T15:55:45.711Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -23,14 +23,15 @@ summary:
       flag: 3
     quiz-question-count:
       pass: 3
+    starter-quiz-grounding:
+      pass: 3
     americanisms_corrector:
-      corrections_attempted: 1
-      corrections_not_needed: 32
+      corrections_attempted: 0
+      corrections_not_needed: 33
       corrections_failed: 0
-      correction_rate: 3.0%
+      correction_rate: 0.0%
       correction_failure_rate: 0.0%
-      corrections_by_section:
-        cycle1: 1
+      corrections_by_section: {}
   no-rag-lesson:
     generation-complete:
       pass: 3
@@ -49,17 +50,19 @@ summary:
     americanisms-spelling:
       pass: 3
     americanisms-phrasing:
-      pass: 3
+      pass: 2
+      flag: 1
     americanisms-meanings:
       flag: 3
     quiz-question-count:
       pass: 3
+    starter-quiz-grounding:
+      pass: 3
     americanisms_corrector:
-      corrections_attempted: 2
-      corrections_not_needed: 31
+      corrections_attempted: 1
+      corrections_not_needed: 32
       corrections_failed: 0
-      correction_rate: 6.1%
+      correction_rate: 3.0%
       correction_failure_rate: 0.0%
       corrections_by_section:
-        keyLearningPoints: 1
         starterQuiz: 1

--- a/packages/aila/src/lib/agentic-system/types.ts
+++ b/packages/aila/src/lib/agentic-system/types.ts
@@ -107,6 +107,11 @@ export type SectionPromptAgentProps<ResponseType> = {
   id: string;
   messages: ChatMessage[];
   instructions: string;
+  /** Version-stable form stored as the template (defaults to `instructions`). */
+  templateText?: string;
+  /** Identifies the prompt template for versioning (defaults to `id`). */
+  promptTemplateId?: string;
+  promptInputs?: Record<string, unknown>;
   currentValue: ResponseType | undefined;
   exemplarContent: ResponseType[] | undefined;
   basedOnContent: ResponseType | undefined;

--- a/packages/aila/src/lib/agentic-system/types.ts
+++ b/packages/aila/src/lib/agentic-system/types.ts
@@ -120,6 +120,8 @@ export type SectionPromptAgentProps<ResponseType> = {
   extraInputFromCtx?: (
     ctx: AilaExecutionContext,
   ) => { role: "user" | "developer"; content: string }[];
+  /** Narrows the CURRENT DOCUMENT the agent sees; defaults to the full document. */
+  documentForPrompt?: (document: PartialLessonPlan) => PartialLessonPlan;
   defaultVoice?: VoiceId;
   voices?: VoiceId[];
 };

--- a/packages/aila/src/protocol/schemas/quiz/quizV3.test.ts
+++ b/packages/aila/src/protocol/schemas/quiz/quizV3.test.ts
@@ -1,0 +1,112 @@
+import {
+  QUIZ_MAX_QUESTIONS,
+  QuizV3MultipleChoiceOnlyStrictMax6Schema,
+  QuizV3Schema,
+} from "./quizV3";
+
+const mcQuestion = (overrides: Record<string, unknown> = {}) => ({
+  questionType: "multiple-choice",
+  question: "What is 1+1?",
+  hint: null,
+  answers: ["2"],
+  distractors: ["1", "3"],
+  ...overrides,
+});
+
+const strictQuiz = (questions: unknown[]) => ({
+  version: "v3",
+  questions,
+  imageMetadata: [],
+});
+
+describe("QuizV3MultipleChoiceOnlyStrictMax6Schema", () => {
+  it("accepts a full quiz of questions with one answer and two distractors", () => {
+    const quiz = strictQuiz(
+      Array.from({ length: QUIZ_MAX_QUESTIONS }, () => mcQuestion()),
+    );
+
+    expect(
+      QuizV3MultipleChoiceOnlyStrictMax6Schema.safeParse(quiz).success,
+    ).toBe(true);
+  });
+
+  it("rejects a question with a third distractor", () => {
+    const quiz = strictQuiz([mcQuestion({ distractors: ["1", "3", "4"] })]);
+
+    expect(
+      QuizV3MultipleChoiceOnlyStrictMax6Schema.safeParse(quiz).success,
+    ).toBe(false);
+  });
+
+  it("rejects a question with two correct answers", () => {
+    const quiz = strictQuiz([mcQuestion({ answers: ["2", "two"] })]);
+
+    expect(
+      QuizV3MultipleChoiceOnlyStrictMax6Schema.safeParse(quiz).success,
+    ).toBe(false);
+  });
+
+  it("rejects a question with a single distractor", () => {
+    const quiz = strictQuiz([mcQuestion({ distractors: ["1"] })]);
+
+    expect(
+      QuizV3MultipleChoiceOnlyStrictMax6Schema.safeParse(quiz).success,
+    ).toBe(false);
+  });
+
+  it("rejects a quiz with more questions than the maximum", () => {
+    const quiz = strictQuiz(
+      Array.from({ length: QUIZ_MAX_QUESTIONS + 1 }, () => mcQuestion()),
+    );
+
+    expect(
+      QuizV3MultipleChoiceOnlyStrictMax6Schema.safeParse(quiz).success,
+    ).toBe(false);
+  });
+
+  it("rejects an empty quiz", () => {
+    expect(
+      QuizV3MultipleChoiceOnlyStrictMax6Schema.safeParse(strictQuiz([]))
+        .success,
+    ).toBe(false);
+  });
+
+  it("rejects non-multiple-choice question types", () => {
+    const quiz = strictQuiz([
+      {
+        questionType: "short-answer",
+        question: "Name a prime number.",
+        hint: null,
+        answers: ["2"],
+      },
+    ]);
+
+    expect(
+      QuizV3MultipleChoiceOnlyStrictMax6Schema.safeParse(quiz).success,
+    ).toBe(false);
+  });
+});
+
+// This tests the schema for persisted quizzes we already hold: lessons saved
+// in the database, basedOn/RAG quizzes and maths-bank questions. These can
+// have shapes the LLM is not allowed to produce, so it must keep accepting them.
+describe("QuizV3Schema (persisted)", () => {
+  it("still accepts questions with four answer options", () => {
+    const quiz = strictQuiz([mcQuestion({ distractors: ["1", "3", "4"] })]);
+
+    expect(QuizV3Schema.safeParse(quiz).success).toBe(true);
+  });
+
+  it("still accepts non-multiple-choice question types", () => {
+    const quiz = strictQuiz([
+      {
+        questionType: "match",
+        question: "Match the halves.",
+        hint: null,
+        pairs: [{ left: "1/2", right: "0.5" }],
+      },
+    ]);
+
+    expect(QuizV3Schema.safeParse(quiz).success).toBe(true);
+  });
+});

--- a/packages/aila/src/protocol/schemas/quiz/quizV3.ts
+++ b/packages/aila/src/protocol/schemas/quiz/quizV3.ts
@@ -107,9 +107,31 @@ export type QuizV3QuestionOrder = z.infer<typeof QuizV3QuestionOrderSchema>;
 
 // ********** LLM-SPECIFIC SCHEMAS (MULTIPLE CHOICE ONLY) **********
 
-// LLM can only generate multiple choice questions, so we create specific schemas for that
+// Export templates (Google Slides) have fixed placeholders per quiz: 6 questions,
+// each with 1 correct answer + 2 distractors. Adjust these if the templates change.
+export const QUIZ_MAX_QUESTIONS = 6;
+export const QUIZ_MC_ANSWER_COUNT = 1;
+export const QUIZ_MC_DISTRACTOR_COUNT = 2;
+
+// LLM can only generate multiple choice questions, so we create specific schemas for that.
+// Answer option counts are hard bounds so exports never receive extra options.
 export const QuizV3MultipleChoiceOnlyQuestionSchema =
-  QuizV3QuestionMultipleChoiceSchema;
+  QuizV3QuestionMultipleChoiceSchema.extend({
+    answers: z
+      .array(z.string())
+      .min(QUIZ_MC_ANSWER_COUNT)
+      .max(QUIZ_MC_ANSWER_COUNT)
+      .describe(
+        `Correct answers as markdown. ${minMaxText({ min: QUIZ_MC_ANSWER_COUNT, max: QUIZ_MC_ANSWER_COUNT })}`,
+      ),
+    distractors: z
+      .array(z.string())
+      .min(QUIZ_MC_DISTRACTOR_COUNT)
+      .max(QUIZ_MC_DISTRACTOR_COUNT)
+      .describe(
+        `Incorrect answer options as markdown. ${minMaxText({ min: QUIZ_MC_DISTRACTOR_COUNT, max: QUIZ_MC_DISTRACTOR_COUNT })}`,
+      ),
+  });
 
 export const QuizV3MultipleChoiceOnlySchema = z.object({
   version: z.literal("v3").describe("Schema version identifier"),
@@ -131,7 +153,13 @@ export const QuizV3MultipleChoiceOnlyOptionalSchema =
 
 export const QuizV3MultipleChoiceOnlyStrictMax6Schema =
   QuizV3MultipleChoiceOnlySchema.extend({
-    questions: z.array(QuizV3MultipleChoiceOnlyQuestionSchema).min(1).max(6),
+    questions: z
+      .array(QuizV3MultipleChoiceOnlyQuestionSchema)
+      .min(1)
+      .max(QUIZ_MAX_QUESTIONS)
+      .describe(
+        `Array of multiple choice quiz questions. ${minMaxText({ min: 1, max: QUIZ_MAX_QUESTIONS })}`,
+      ),
   });
 
 // Type exports for LLM-specific schemas

--- a/packages/core/src/models/promptVariants.test.ts
+++ b/packages/core/src/models/promptVariants.test.ts
@@ -1,0 +1,106 @@
+import { z } from "zod";
+
+import type { OakPromptDefinition } from "../prompts/types";
+import { PromptVariants, promptHash } from "./promptVariants";
+
+function promptDefinition(): OakPromptDefinition {
+  return {
+    appId: "lesson-planner",
+    name: "Test prompt",
+    slug: "test-prompt",
+    inputSchema: z.object({}),
+    outputSchema: z.object({}),
+    variants: [
+      {
+        slug: "main",
+        parts: {
+          body: "main body",
+          context: "",
+          output: "",
+          task: "",
+        },
+      },
+      {
+        slug: "target",
+        parts: {
+          body: "target body",
+          context: "",
+          output: "",
+          task: "",
+        },
+      },
+    ],
+  };
+}
+
+describe("PromptVariants", () => {
+  const originalCommitSha = process.env.VERCEL_GIT_COMMIT_SHA;
+
+  afterEach(() => {
+    process.env.VERCEL_GIT_COMMIT_SHA = originalCommitSha;
+  });
+
+  it("selects the requested variant without mutating variant slugs", () => {
+    const definition = promptDefinition();
+
+    const prompts = new PromptVariants({} as never, definition, "target");
+
+    expect(prompts.variant.parts.body).toBe("target body");
+    expect(definition.variants.map((variant) => variant.slug)).toEqual([
+      "main",
+      "target",
+    ]);
+  });
+
+  it("falls back to the main variant when the requested variant is absent", () => {
+    const prompts = new PromptVariants(
+      {} as never,
+      promptDefinition(),
+      "missing",
+    );
+
+    expect(prompts.variant.parts.body).toBe("main body");
+  });
+
+  it("includes the deploy sha in normal prompt hashes", () => {
+    process.env.VERCEL_GIT_COMMIT_SHA = "commit_a";
+    const hashA = promptHash({
+      slug: "test-prompt",
+      variant: "main",
+      template: "body",
+    });
+
+    process.env.VERCEL_GIT_COMMIT_SHA = "commit_b";
+    const hashB = promptHash({
+      slug: "test-prompt",
+      variant: "main",
+      template: "body",
+    });
+
+    expect(hashA).not.toBe(hashB);
+    expect(hashA).toContain("commit_a");
+    expect(hashB).toContain("commit_b");
+  });
+
+  it("can hash prompts independently of deploy sha", () => {
+    process.env.VERCEL_GIT_COMMIT_SHA = "commit_a";
+    const hashA = promptHash({
+      slug: "test-prompt",
+      variant: "main",
+      template: "body",
+      stableAcrossDeploys: true,
+    });
+
+    process.env.VERCEL_GIT_COMMIT_SHA = "commit_b";
+    const hashB = promptHash({
+      slug: "test-prompt",
+      variant: "main",
+      template: "body",
+      stableAcrossDeploys: true,
+    });
+
+    expect(hashA).toBe(hashB);
+    expect(hashA).not.toContain("commit_a");
+    expect(hashA).not.toContain("commit_b");
+  });
+});

--- a/packages/core/src/models/promptVariants.ts
+++ b/packages/core/src/models/promptVariants.ts
@@ -20,7 +20,7 @@ export class PromptVariants {
   ) {
     this.definition = promptDefinition;
     const foundVariant =
-      promptDefinition.variants.find((v) => (v.slug = variantSlug)) ??
+      promptDefinition.variants.find((v) => v.slug === variantSlug) ??
       promptDefinition.variants.find((v) => v.slug === "main");
     if (!foundVariant) {
       throw new Error("No variant found");
@@ -28,10 +28,14 @@ export class PromptVariants {
     this.variant = foundVariant;
   }
 
-  async setCurrent(variant: string, storeAsJson = false) {
+  async setCurrent(
+    variant: string,
+    storeAsJson = false,
+    { stableAcrossDeploys = false }: { stableAcrossDeploys?: boolean } = {},
+  ) {
     const template = this.format({ storeAsJson });
     const { slug } = this.definition;
-    const hash = promptHash({ slug, variant, template });
+    const hash = promptHash({ slug, variant, template, stableAcrossDeploys });
     const existing = await this.prisma.prompt.findFirst({
       where: {
         AND: [{ hash }, { slug }, { variant }, { current: true }],
@@ -55,8 +59,11 @@ export class PromptVariants {
     >`SELECT MAX(version) AS max_version FROM prompts WHERE slug = ${slug}`;
     const maxVersion = maxVersionRow[0]?.max_version ?? 0;
     const version = maxVersion + 1;
-    const created = await this.prisma.prompt.create({
-      data: {
+    const now = new Date().toISOString();
+    // Upsert on the unique hash
+    const created = await this.prisma.prompt.upsert({
+      where: { hash },
+      create: {
         hash,
         appId: app.id,
         name,
@@ -65,8 +72,8 @@ export class PromptVariants {
         inputSchema: JSON.stringify(inputSchema),
         outputSchema: JSON.stringify(outputSchema),
         current: true,
-        createdAt: new Date().toISOString(),
-        updatedAt: new Date().toISOString(),
+        createdAt: now,
+        updatedAt: now,
         variant,
         identifier: promptIdentifier({ slug, variant, version }),
         version,
@@ -75,13 +82,17 @@ export class PromptVariants {
           process.env.CACHED_COMMIT_REF ??
           null, // Vercel- and Netlify-specific environment variable for the latest git commit
       },
+      update: {
+        current: true,
+        updatedAt: now,
+      },
     });
 
     // Mark previous prompts as historic
     await this.prisma.prompt.updateMany({
       data: {
         current: false,
-        updatedAt: new Date().toISOString(),
+        updatedAt: now,
       },
       where: {
         slug: {
@@ -132,12 +143,17 @@ export function promptHash({
   slug,
   variant,
   template,
+  stableAcrossDeploys = false,
 }: {
   slug: string;
   variant: string;
   template: string;
+  stableAcrossDeploys?: boolean; // default false to preserve per-deploy versioning for non-agentic
 }) {
-  return `${slug}-${variant}-${Md5.hashStr(template)}-${process.env.VERCEL_GIT_COMMIT_SHA ?? "dev"}`;
+  const deploySuffix = stableAcrossDeploys
+    ? ""
+    : `-${process.env.VERCEL_GIT_COMMIT_SHA ?? "dev"}`;
+  return `${slug}-${variant}-${Md5.hashStr(template)}${deploySuffix}`;
 }
 
 export function promptIdentifier({


### PR DESCRIPTION
## Description

### Features
- **Enforce quiz structure in Aila**: Added schema validation to ensure quizzes contain the required number of questions and answer options. [#1102](https://github.com/oaknational/oak-ai-lesson-assistant/pull/1102)
- **Persist agentic generations from a single prompt source**: Added persistence for agentic generation outputs while consolidating prompt templates into a single source of truth. [#1103](https://github.com/oaknational/oak-ai-lesson-assistant/pull/1103)
- **Ground starter quizzes in prior knowledge**: Updated Aila to generate starter quizzes based on pupils’ existing knowledge. [#1105](https://github.com/oaknational/oak-ai-lesson-assistant/pull/1105)