### PR TITLE
fix(aila): cap key learning points and practice tasks to fit exports

### DIFF
--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/additionalMaterialsAgent/additionalMaterials.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/additionalMaterialsAgent/additionalMaterials.instructions.ts
@@ -13,6 +13,7 @@ This section could include:
 * suggestions for alternative equipment/case studies/examples.
 * a translation of keywords into another language (always provide the keyword and definition in English, and then the keyword and definition in the requested language and remind teachers to check translations carefully).
 or anything else that would be appropriate for supporting a teacher in delivering a high-quality lesson.
+If a learning cycle's practice task refers pupils to a worksheet or to the additional materials (e.g. "Complete the sentences on the worksheet."), include that stimulus material here in full.
 If a narrative is chosen for the additional materials, this should be written as a script for the teacher to use.
 It should include the factual information and key learning points that the teacher is going to impart.
 Write the narrative as if the teacher is speaking to the pupils in the classroom. 

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/cycleAgent/cycle.instructions.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/cycleAgent/cycle.instructions.test.ts
@@ -1,8 +1,8 @@
 import { cyclesInstructions } from "./cycle.instructions";
 
 describe("cycle instructions", () => {
-  it("caps the practice task at 50 words", () => {
-    expect(cyclesInstructions("ks3")).toMatch(/at most 50 words/i);
+  it("caps the practice task at 12 lines", () => {
+    expect(cyclesInstructions("ks3")).toMatch(/at most 12 lines/i);
   });
 
   it("explains that the slide text box is fixed size", () => {
@@ -11,5 +11,11 @@ describe("cycle instructions", () => {
 
   it("directs overlong stimulus to the additional materials", () => {
     expect(cyclesInstructions("ks3")).toMatch(/additional materials/i);
+  });
+
+  it("applies the same slide limit to feedback", () => {
+    expect(cyclesInstructions("ks3")).toMatch(
+      /same fixed-size box as the practice task/i,
+    );
   });
 });

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/cycleAgent/cycle.instructions.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/cycleAgent/cycle.instructions.test.ts
@@ -1,0 +1,15 @@
+import { cyclesInstructions } from "./cycle.instructions";
+
+describe("cycle instructions", () => {
+  it("caps the practice task at 50 words", () => {
+    expect(cyclesInstructions("ks3")).toMatch(/at most 50 words/i);
+  });
+
+  it("explains that the slide text box is fixed size", () => {
+    expect(cyclesInstructions("ks3")).toMatch(/fixed-size text box/i);
+  });
+
+  it("directs overlong stimulus to the additional materials", () => {
+    expect(cyclesInstructions("ks3")).toMatch(/additional materials/i);
+  });
+});

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/cycleAgent/cycle.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/cycleAgent/cycle.instructions.ts
@@ -165,7 +165,7 @@ Examples include:
 
 The practice task is displayed on one slide in a fixed-size text box. Text that does not fit is cut off; the slide cannot shrink or grow the text.
 
-- The whole practice task must be at most 50 words, counting every sub-task, sentence starter, data item and label. Aim for 25-40 words.
+- The whole practice task must fit in at most 12 lines (aim for about 10), counting every step and every blank separator line, as blank lines take up slide space too. Keep each line a single short instruction or sentence (about 12 words or fewer so it does not wrap). Use one short numbered or bulleted step per line.
 - Never place long stimulus material on the slide. If the task needs material that would take it over the limit (a text extract, a data set or results table, statements to sort or sequence, sentences to complete, an extended set of calculations), write only the short instruction on the slide and direct pupils to the accompanying materials, e.g. "Complete the sentences on the worksheet." or "Use the data table in the additional materials."
 - Refer to offloaded material generically ("the worksheet", "the additional materials"). Do not invent document names. The teacher can generate this material in the lesson's additional materials section.
 - Prefer practice tasks that are self-contained within the limit; only offload stimulus when the task genuinely requires it.
@@ -181,6 +181,7 @@ This section provides pupils with the chance to get feedback on their practice t
   - Worked Example (e.g. steps in a calculation)
   - Success Criteria (e.g. 3 key features of a good answer)
 - If you have included a keyword bank or sentence starters in the practice task, update the feedback section to include these.
+- Feedback is shown on one slide in the same fixed-size box as the practice task. It must fit in at most 12 lines (aim for about 10), counting every line and blank separator, with each line short enough not to wrap. If a full worked example will not fit, give the key steps or success criteria only.
 
 **Examples:**
 - Practice = completing calculations

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/cycleAgent/cycle.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/cycleAgent/cycle.instructions.ts
@@ -97,9 +97,9 @@ Voice: TEACHER_TO_PUPIL_WRITTEN
 
 Write the task as a set of instructions that pupils can follow.
 
-- The instructions should contain all information needed to complete the task e.g. "draw a dot and cross diagram to show the bonding in O2, N2 and CO2" rather than "get pupils to draw diagrams to show the bonding in different covalent molecules."
+- The instructions should contain all information needed to complete the task, within the slide length limit below, e.g. "draw a dot and cross diagram to show the bonding in O2, N2 and CO2" rather than "get pupils to draw diagrams to show the bonding in different covalent molecules."
 - Reflect the command word in the cycle outcome — keep the task at that level (if the outcome says "Describe", pupils should describe, not evaluate or judge significance)
-- Include all content needed e.g. if asking pupils to:
+- Include all content needed on the slide only when it fits within the slide length limit below; otherwise follow the stimulus rule in that section. E.g. if asking pupils to:
   - analyse a set of results, provide them with the results and a set of questions to support analysis.
   - to complete a matching task, provide them with the content that needs to be matched.
   - complete sentences, provide them with the sentences with the gaps marked within them.
@@ -160,6 +160,15 @@ Examples include:
 - Compare/contrast, extract conclusions, reflect on criteria
 - Apply skills or knowledge in context
   (See full list if needed for inspiration.)
+
+#### Slide length limit (hard requirement)
+
+The practice task is displayed on one slide in a fixed-size text box. Text that does not fit is cut off; the slide cannot shrink or grow the text.
+
+- The whole practice task must be at most 50 words, counting every sub-task, sentence starter, data item and label. Aim for 25-40 words.
+- Never place long stimulus material on the slide. If the task needs material that would take it over the limit (a text extract, a data set or results table, statements to sort or sequence, sentences to complete, an extended set of calculations), write only the short instruction on the slide and direct pupils to the accompanying materials, e.g. "Complete the sentences on the worksheet." or "Use the data table in the additional materials."
+- Refer to offloaded material generically ("the worksheet", "the additional materials"). Do not invent document names. The teacher can generate this material in the lesson's additional materials section.
+- Prefer practice tasks that are self-contained within the limit; only offload stimulus when the task genuinely requires it.
 
 ### 5. Feedback
 

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/keyLearningPointsAgent/keyLearningPoints.instructions.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/keyLearningPointsAgent/keyLearningPoints.instructions.test.ts
@@ -1,11 +1,13 @@
 import { keyLearningPointsInstructions } from "./keyLearningPoints.instructions";
 
 describe("keyLearningPoints instructions", () => {
-  it("asks for between 3 and 4 points", () => {
-    expect(keyLearningPointsInstructions("ks3")).toMatch(/between 3 and 4/i);
+  it("asks for 3 or 4 points", () => {
+    expect(keyLearningPointsInstructions("ks3")).toMatch(/3 or 4/i);
   });
 
   it("forbids more than 4 points", () => {
-    expect(keyLearningPointsInstructions("ks3")).toMatch(/never more than 4/i);
+    expect(keyLearningPointsInstructions("ks3")).toMatch(
+      /never write more than 4/i,
+    );
   });
 });

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/keyLearningPointsAgent/keyLearningPoints.instructions.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/keyLearningPointsAgent/keyLearningPoints.instructions.test.ts
@@ -1,0 +1,11 @@
+import { keyLearningPointsInstructions } from "./keyLearningPoints.instructions";
+
+describe("keyLearningPoints instructions", () => {
+  it("asks for between 3 and 4 points", () => {
+    expect(keyLearningPointsInstructions("ks3")).toMatch(/between 3 and 4/i);
+  });
+
+  it("forbids more than 4 points", () => {
+    expect(keyLearningPointsInstructions("ks3")).toMatch(/never more than 4/i);
+  });
+});

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/keyLearningPointsAgent/keyLearningPoints.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/keyLearningPointsAgent/keyLearningPoints.instructions.ts
@@ -10,6 +10,7 @@ export function keyLearningPointsInstructions(keyStage: string): string {
 
 List the most important factual things pupils should learn in the lesson.
 
+- Produce between 3 and 4 key learning points, never more than 4. The downloadable lesson plan document has space for exactly 4.
 - Use succinct, knowledge-rich statements
 - Focus on specific things that pupils will know or be able to do rather than the overall concepts or learning outcome.
 - Avoid vague or descriptive phrasing

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/keyLearningPointsAgent/keyLearningPoints.instructions.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/keyLearningPointsAgent/keyLearningPoints.instructions.ts
@@ -10,7 +10,7 @@ export function keyLearningPointsInstructions(keyStage: string): string {
 
 List the most important factual things pupils should learn in the lesson.
 
-- Produce between 3 and 4 key learning points, never more than 4. The downloadable lesson plan document has space for exactly 4.
+- Produce 3 or 4 key learning points. The downloadable lesson plan document has room for up to 4, so never write more than 4.
 - Use succinct, knowledge-rich statements
 - Focus on specific things that pupils will know or be able to do rather than the overall concepts or learning outcome.
 - Avoid vague or descriptive phrasing

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/keyLearningPointsAgent/keyLearningPoints.schema.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/keyLearningPointsAgent/keyLearningPoints.schema.ts
@@ -1,1 +1,1 @@
-export { KeyLearningPointsSchema } from "../../../../../protocol/schema";
+export { KeyLearningPointsStrictMax4Schema as KeyLearningPointsSchema } from "../../../../../protocol/schema";

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/sectionAgentRegistry.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/sectionAgentRegistry.ts
@@ -5,6 +5,7 @@ import type {
   LatestQuiz,
   PartialLessonPlan,
 } from "../../../../protocol/schema";
+import { KEY_LEARNING_POINTS_MAX } from "../../../../protocol/schema";
 import { toMultipleChoiceOnlyQuiz } from "../../quizOperations/toMultipleChoiceOnlyQuiz";
 import type {
   AilaExecutionContext,
@@ -94,7 +95,10 @@ export const createSectionAgentRegistry = ({
     description: "Generates key learning points",
     openai,
     collectGeneration,
-    contentFromDocument: (document) => document.keyLearningPoints,
+    // Prompt context only (basedOn/exemplar/current value): trim to the count
+    // the strict response schema allows, mirroring toMultipleChoiceOnlyQuiz.
+    contentFromDocument: (document) =>
+      document.keyLearningPoints?.slice(0, KEY_LEARNING_POINTS_MAX),
   }),
   "misconceptions--default": misconceptionsAgent({
     id: "misconceptions--default",

--- a/packages/aila/src/lib/agentic-system/execution/executePlanSteps.keyLearningPoints.test.ts
+++ b/packages/aila/src/lib/agentic-system/execution/executePlanSteps.keyLearningPoints.test.ts
@@ -1,0 +1,147 @@
+import { ailaTurn } from "../ailaTurn";
+import type {
+  AilaPersistedState,
+  AilaRuntimeContext,
+  AilaTurnCallbacks,
+  SectionAgentRegistry,
+} from "../types";
+
+const generatedPoints = [
+  "The color wheel shows primary and secondary colours.",
+  "Primary colours cannot be mixed from other colours.",
+  "Secondary colours are made by mixing two primary colours.",
+  "Complementary colours sit opposite each other on the wheel.",
+];
+
+const correctedPoints = generatedPoints.map((point) =>
+  point.replace("color", "colour"),
+);
+
+function makeCallbacks(): AilaTurnCallbacks {
+  return {
+    onPlannerComplete: jest.fn(),
+    onSectionComplete: jest.fn(),
+    onTurnComplete: jest.fn().mockResolvedValue(undefined),
+    onTurnFailed: jest.fn().mockResolvedValue(undefined),
+    onRagFetchedChange: jest.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makePersistedState(): AilaPersistedState {
+  return {
+    messages: [
+      {
+        id: "u1",
+        role: "user",
+        content: "Generate the key learning points",
+      },
+    ],
+    initialDocument: {},
+    relevantLessons: null,
+    ragFetched: { status: "not_fetched", searchIdentity: null },
+  };
+}
+
+function makeRuntime(
+  overrides: Partial<AilaRuntimeContext> = {},
+): AilaRuntimeContext {
+  return {
+    config: { mathsQuizEnabled: false },
+    plannerAgent: jest.fn().mockResolvedValue({
+      error: null,
+      data: {
+        decision: "plan",
+        parsedUserMessage: "Generate the key learning points",
+        plan: [
+          {
+            type: "section",
+            sectionKey: "keyLearningPoints",
+            action: "generate",
+            sectionInstructions: null,
+          },
+        ],
+      },
+    }),
+    sectionAgents: {} as unknown as SectionAgentRegistry,
+    messageToUserAgent: jest.fn().mockResolvedValue({
+      error: null,
+      data: { message: "Done" },
+    }),
+    britishEnglishCorrectorAgent: jest.fn(),
+    fetchRelevantLessons: jest.fn().mockResolvedValue([]),
+    ...overrides,
+  };
+}
+
+function getUpdatedKeyLearningPoints(
+  callbacks: AilaTurnCallbacks,
+): string[] | undefined {
+  const call = jest.mocked(callbacks.onTurnComplete).mock.calls[0]?.[0];
+  return call?.document?.keyLearningPoints;
+}
+
+describe("executePlanSteps key learning points correction", () => {
+  it("corrects points that contain an Americanism", async () => {
+    const sectionAgent = jest.fn().mockResolvedValue({
+      error: null,
+      data: generatedPoints,
+    });
+    const corrector = jest.fn().mockResolvedValue({
+      error: null,
+      data: correctedPoints,
+    });
+    const callbacks = makeCallbacks();
+
+    const runtime = makeRuntime({
+      sectionAgents: {
+        "keyLearningPoints--default": {
+          id: "keyLearningPoints--default",
+          description: "key learning points",
+          handler: sectionAgent,
+        },
+      } as unknown as SectionAgentRegistry,
+      britishEnglishCorrectorAgent: corrector,
+    });
+
+    await ailaTurn({
+      persistedState: makePersistedState(),
+      runtime,
+      callbacks,
+    });
+
+    expect(corrector).toHaveBeenCalledTimes(1);
+    expect(getUpdatedKeyLearningPoints(callbacks)).toEqual(correctedPoints);
+  });
+
+  it("falls back to the uncorrected points when the corrector adds a fifth point", async () => {
+    const sectionAgent = jest.fn().mockResolvedValue({
+      error: null,
+      data: generatedPoints,
+    });
+    const corrector = jest.fn().mockResolvedValue({
+      error: null,
+      data: [...correctedPoints, "An extra point the corrector invented."],
+    });
+    const callbacks = makeCallbacks();
+
+    const runtime = makeRuntime({
+      sectionAgents: {
+        "keyLearningPoints--default": {
+          id: "keyLearningPoints--default",
+          description: "key learning points",
+          handler: sectionAgent,
+        },
+      } as unknown as SectionAgentRegistry,
+      britishEnglishCorrectorAgent: corrector,
+    });
+
+    await ailaTurn({
+      persistedState: makePersistedState(),
+      runtime,
+      callbacks,
+    });
+
+    expect(corrector).toHaveBeenCalledTimes(1);
+    expect(getUpdatedKeyLearningPoints(callbacks)).toEqual(generatedPoints);
+  });
+});

--- a/packages/aila/src/lib/agentic-system/execution/executePlanSteps.ts
+++ b/packages/aila/src/lib/agentic-system/execution/executePlanSteps.ts
@@ -11,6 +11,7 @@ import type {
 } from "../../../protocol/schema";
 import {
   CompletedLessonPlanSchema,
+  KeyLearningPointsStrictMax4Schema,
   KeywordsSchema,
   LatestQuizMultipleChoiceOnlyStrictMax6Schema,
   LatestQuizSchema,
@@ -219,8 +220,9 @@ async function executeGenerateStep(
 
 /**
  * The corrector validates its output against this schema. Strict for
- * default-agent quizzes so it cannot re-introduce extra options or questions;
- * permissive for maths-bank quizzes and every other section.
+ * default-agent quizzes and key learning points so it cannot re-introduce
+ * extra options, questions or points; permissive for maths-bank quizzes and
+ * every other section.
  */
 function correctorResponseSchema(
   context: AilaExecutionContext,
@@ -235,6 +237,9 @@ function correctorResponseSchema(
     if (agentId === `${sectionKey}--default`) {
       return LatestQuizMultipleChoiceOnlyStrictMax6Schema;
     }
+  }
+  if (sectionKey === "keyLearningPoints") {
+    return KeyLearningPointsStrictMax4Schema;
   }
   return CompletedLessonPlanSchema.shape[sectionKey];
 }

--- a/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
@@ -211,28 +211,46 @@ const SCORERS: Scorer[] = [
     },
   },
   {
-    id: "practice-length",
-    description: "Cycle practice task fits the slide (max 50 words)",
+    id: "cycle-slide-lines",
+    description: "Practice and feedback fit the slide (max 12 lines)",
     fn: ({ finalDocument }) => {
-      const lines: string[] = [];
-      let anyLong = false;
+      // Keep 12 in sync with the line limit in cycle.instructions.ts. Estimate
+      // rendered lines: a long line wraps at ~10 words, a blank line counts as
+      // one, since both take up slide height.
+      const MAX_LINES = 12;
+      const WORDS_PER_LINE = 10;
+      const renderedLines = (text: string) =>
+        text
+          .split("\n")
+          .reduce(
+            (total, line) =>
+              total + Math.max(1, Math.ceil(wordCount(line) / WORDS_PER_LINE)),
+            0,
+          );
+      const evidence: string[] = [];
+      let anyOverflow = false;
+      const check = (label: string, text: string) => {
+        const rendered = renderedLines(text);
+        const overflow = rendered > MAX_LINES;
+        if (overflow) anyOverflow = true;
+        evidence.push(
+          `${label}: ~${rendered} rendered lines${overflow ? " [overflow]" : ""}`,
+        );
+        evidence.push(text);
+        evidence.push("");
+      };
       for (const key of ["cycle1", "cycle2", "cycle3"] as const) {
         const cycle = finalDocument[key];
         if (!cycle) {
-          lines.push(`${key}: not present`);
+          evidence.push(`${key}: not present`);
           continue;
         }
-        const practiceWords = wordCount(cycle.practice ?? "");
-        if (practiceWords > 50) anyLong = true;
-        lines.push(`${key} practice (${practiceWords} words):`);
-        lines.push(cycle.practice ?? "");
-        // Feedback shares the same box; recorded as evidence for a future cap.
-        lines.push(`${key} feedback: ${wordCount(cycle.feedback ?? "")} words`);
-        lines.push("");
+        check(`${key} practice`, cycle.practice ?? "");
+        check(`${key} feedback`, cycle.feedback ?? "");
       }
       return {
-        heuristic: anyLong ? "flag" : "pass",
-        evidence: lines.join("\n"),
+        heuristic: anyOverflow ? "flag" : "pass",
+        evidence: evidence.join("\n"),
       };
     },
   },

--- a/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
+++ b/packages/aila/src/lib/agentic-system/scoring/scoreAgenticIssues.ts
@@ -26,6 +26,8 @@ import {
 import { AilaAmericanisms } from "../../../features/americanisms/AilaAmericanisms";
 import {
   CompletedLessonPlanSchema,
+  KEY_LEARNING_POINTS_MAX,
+  KEY_LEARNING_POINTS_MIN,
   type PartialLessonPlan,
 } from "../../../protocol/schema";
 import { createOpenAIBritishEnglishCorrectorAgent } from "../agents/britishEnglishCorrectorAgent";
@@ -205,6 +207,48 @@ const SCORERS: Scorer[] = [
       return {
         heuristic: anyLong ? "flag" : "pass",
         evidence: lines.join("\n"),
+      };
+    },
+  },
+  {
+    id: "practice-length",
+    description: "Cycle practice task fits the slide (max 50 words)",
+    fn: ({ finalDocument }) => {
+      const lines: string[] = [];
+      let anyLong = false;
+      for (const key of ["cycle1", "cycle2", "cycle3"] as const) {
+        const cycle = finalDocument[key];
+        if (!cycle) {
+          lines.push(`${key}: not present`);
+          continue;
+        }
+        const practiceWords = wordCount(cycle.practice ?? "");
+        if (practiceWords > 50) anyLong = true;
+        lines.push(`${key} practice (${practiceWords} words):`);
+        lines.push(cycle.practice ?? "");
+        // Feedback shares the same box; recorded as evidence for a future cap.
+        lines.push(`${key} feedback: ${wordCount(cycle.feedback ?? "")} words`);
+        lines.push("");
+      }
+      return {
+        heuristic: anyLong ? "flag" : "pass",
+        evidence: lines.join("\n"),
+      };
+    },
+  },
+  {
+    id: "klp-count",
+    description: "Key learning point count matches the export template (3-4)",
+    fn: ({ finalDocument }) => {
+      const points = finalDocument.keyLearningPoints;
+      if (!points)
+        return { heuristic: "skip", evidence: "No keyLearningPoints field" };
+      const outOfRange =
+        points.length < KEY_LEARNING_POINTS_MIN ||
+        points.length > KEY_LEARNING_POINTS_MAX;
+      return {
+        heuristic: outOfRange ? "flag" : "pass",
+        evidence: [`${points.length} points`, ...points].join("\n"),
       };
     },
   },

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
-codeHash: df430cd3a8582ff31c0d1bcaca104ab7260004794bee698dd93675798bbdc7b7
-generated: 2026-07-14T15:55:45.711Z
+codeHash: 974f7e3ff1c0466971ebe323fe5d912aa937e1f897f5979c8a55b51285ebf4b0
+generated: 2026-07-18T23:15:07.781Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -10,6 +10,10 @@ summary:
     additional-materials-tone:
       skip: 3
     cycle-verbosity:
+      pass: 3
+    practice-length:
+      pass: 3
+    klp-count:
       pass: 3
     keyword-casing:
       pass: 3
@@ -41,6 +45,10 @@ summary:
       skip: 3
     cycle-verbosity:
       pass: 3
+    practice-length:
+      pass: 3
+    klp-count:
+      pass: 3
     keyword-casing:
       pass: 3
     title-no-gerund:
@@ -50,8 +58,7 @@ summary:
     americanisms-spelling:
       pass: 3
     americanisms-phrasing:
-      pass: 2
-      flag: 1
+      pass: 3
     americanisms-meanings:
       flag: 3
     quiz-question-count:
@@ -59,10 +66,11 @@ summary:
     starter-quiz-grounding:
       pass: 3
     americanisms_corrector:
-      corrections_attempted: 1
-      corrections_not_needed: 32
+      corrections_attempted: 3
+      corrections_not_needed: 30
       corrections_failed: 0
-      correction_rate: 3.0%
+      correction_rate: 9.1%
       correction_failure_rate: 0.0%
       corrections_by_section:
-        starterQuiz: 1
+        cycle3: 2
+        exitQuiz: 1

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
-codeHash: 974f7e3ff1c0466971ebe323fe5d912aa937e1f897f5979c8a55b51285ebf4b0
-generated: 2026-07-18T23:15:07.781Z
+codeHash: 4d591231e3e53eab736af806d6abea8313e9e1607a839c3896fa5772a31e8b73
+generated: 2026-07-20T12:56:34.404Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -11,7 +11,7 @@ summary:
       skip: 3
     cycle-verbosity:
       pass: 3
-    practice-length:
+    cycle-slide-lines:
       pass: 3
     klp-count:
       pass: 3
@@ -45,7 +45,7 @@ summary:
       skip: 3
     cycle-verbosity:
       pass: 3
-    practice-length:
+    cycle-slide-lines:
       pass: 3
     klp-count:
       pass: 3
@@ -66,11 +66,9 @@ summary:
     starter-quiz-grounding:
       pass: 3
     americanisms_corrector:
-      corrections_attempted: 3
-      corrections_not_needed: 30
+      corrections_attempted: 0
+      corrections_not_needed: 33
       corrections_failed: 0
-      correction_rate: 9.1%
+      correction_rate: 0.0%
       correction_failure_rate: 0.0%
-      corrections_by_section:
-        cycle3: 2
-        exitQuiz: 1
+      corrections_by_section: {}

--- a/packages/aila/src/lib/agentic-system/scoring/scores.yaml
+++ b/packages/aila/src/lib/agentic-system/scoring/scores.yaml
@@ -1,5 +1,5 @@
-codeHash: 4d591231e3e53eab736af806d6abea8313e9e1607a839c3896fa5772a31e8b73
-generated: 2026-07-20T12:56:34.404Z
+codeHash: 64e773bce801786f3084a51e22d5c6b4c1189a82111aa050f84dacfefe53770f
+generated: 2026-07-20T13:59:12.120Z
 runsPerScenario: 3
 summary:
   full-lesson:
@@ -66,9 +66,10 @@ summary:
     starter-quiz-grounding:
       pass: 3
     americanisms_corrector:
-      corrections_attempted: 0
-      corrections_not_needed: 33
+      corrections_attempted: 1
+      corrections_not_needed: 32
       corrections_failed: 0
-      correction_rate: 0.0%
+      correction_rate: 3.0%
       correction_failure_rate: 0.0%
-      corrections_by_section: {}
+      corrections_by_section:
+        exitQuiz: 1

--- a/packages/aila/src/protocol/schema.keyLearningPoints.test.ts
+++ b/packages/aila/src/protocol/schema.keyLearningPoints.test.ts
@@ -42,9 +42,8 @@ describe("KeyLearningPointsStrictMax4Schema", () => {
   });
 });
 
-// This tests the schema for persisted lesson plans we already hold: lessons
-// saved in the database and basedOn/RAG lessons routinely carry more key
-// learning points than the LLM is now allowed to produce.
+// Persisted and basedOn/RAG lessons can carry more points
+// than the LLM is now allowed to produce.
 describe("KeyLearningPointsSchema (persisted)", () => {
   it("still accepts ten points", () => {
     expect(KeyLearningPointsSchema.safeParse(points(10)).success).toBe(true);

--- a/packages/aila/src/protocol/schema.keyLearningPoints.test.ts
+++ b/packages/aila/src/protocol/schema.keyLearningPoints.test.ts
@@ -1,0 +1,52 @@
+import {
+  KEY_LEARNING_POINTS_MAX,
+  KEY_LEARNING_POINTS_MIN,
+  KeyLearningPointsSchema,
+  KeyLearningPointsStrictMax4Schema,
+} from "./schema";
+
+const points = (count: number) =>
+  Array.from({ length: count }, (_, i) => `Key learning point ${i + 1}`);
+
+describe("KeyLearningPointsStrictMax4Schema", () => {
+  it("accepts the minimum number of points", () => {
+    expect(
+      KeyLearningPointsStrictMax4Schema.safeParse(
+        points(KEY_LEARNING_POINTS_MIN),
+      ).success,
+    ).toBe(true);
+  });
+
+  it("accepts the maximum number of points", () => {
+    expect(
+      KeyLearningPointsStrictMax4Schema.safeParse(
+        points(KEY_LEARNING_POINTS_MAX),
+      ).success,
+    ).toBe(true);
+  });
+
+  it("rejects fewer points than the minimum", () => {
+    expect(
+      KeyLearningPointsStrictMax4Schema.safeParse(
+        points(KEY_LEARNING_POINTS_MIN - 1),
+      ).success,
+    ).toBe(false);
+  });
+
+  it("rejects more points than the maximum", () => {
+    expect(
+      KeyLearningPointsStrictMax4Schema.safeParse(
+        points(KEY_LEARNING_POINTS_MAX + 1),
+      ).success,
+    ).toBe(false);
+  });
+});
+
+// This tests the schema for persisted lesson plans we already hold: lessons
+// saved in the database and basedOn/RAG lessons routinely carry more key
+// learning points than the LLM is now allowed to produce.
+describe("KeyLearningPointsSchema (persisted)", () => {
+  it("still accepts ten points", () => {
+    expect(KeyLearningPointsSchema.safeParse(points(10)).success).toBe(true);
+  });
+});

--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -244,6 +244,14 @@ export type KeywordOptional = z.infer<typeof KeywordOptionalSchema>;
 export type Keyword = z.infer<typeof KeywordSchema>;
 
 // ********** LESSON PLAN **********
+
+// The exported lesson plan document has exactly 4 key learning point
+// placeholders (key_learning_point_1..4 in
+// packages/exports/src/schema/lessonPlanDocsTemplate.schema.ts). Adjust these
+// if the template changes.
+export const KEY_LEARNING_POINTS_MIN = 3;
+export const KEY_LEARNING_POINTS_MAX = 4;
+
 export const LESSON_PLAN_DESCRIPTIONS = {
   title: dedent`The title of the lesson. Lesson titles should be a unique and succinct statement, not a question.
     Can include special characters if appropriate but should not use & sign instead of 'and'.
@@ -284,8 +292,8 @@ export const LESSON_PLAN_DESCRIPTIONS = {
     })}`,
   keyLearningPoints: dedent`An array of learning points, each being a succinct sentence.
     ${minMaxText({
-      min: 3,
-      max: 5,
+      min: KEY_LEARNING_POINTS_MIN,
+      max: KEY_LEARNING_POINTS_MAX,
       entity: "elements",
     })}`,
   starterQuiz: dedent`The starter quiz for the lesson, which tests prior knowledge only, ignoring the content that is delivered in the lesson.
@@ -349,8 +357,9 @@ export const KeyLearningPointsSchema = z
   .array(z.string())
   .describe(LESSON_PLAN_DESCRIPTIONS.keyLearningPoints);
 
-export const KeyLearningPointsStrictMax5Schema =
-  KeyLearningPointsSchema.min(3).max(5);
+export const KeyLearningPointsStrictMax4Schema = KeyLearningPointsSchema.min(
+  KEY_LEARNING_POINTS_MIN,
+).max(KEY_LEARNING_POINTS_MAX);
 
 export const AdditionalMaterialsSchema = z
   .string()

--- a/packages/exports/src/dataHelpers/prepLessonPlanForDocs.test.ts
+++ b/packages/exports/src/dataHelpers/prepLessonPlanForDocs.test.ts
@@ -125,6 +125,26 @@ describe("prepLessonPlanForDocs", () => {
       expect(result.key_learning_point_3).toBe(" ");
       expect(result.key_learning_point_4).toBe(" ");
     });
+
+    it("should drop points beyond the four template placeholders (legacy plans)", async () => {
+      const result = await prepLessonPlanForDocs(
+        makeBaseLessonPlan({
+          keyLearningPoints: [
+            "KLP 1",
+            "KLP 2",
+            "KLP 3",
+            "KLP 4",
+            "KLP 5",
+            "KLP 6",
+          ],
+        }),
+      );
+
+      expect(result.key_learning_point_4).toBe("4.     KLP 4");
+      const values = Object.values(result).flat().join("\n");
+      expect(values).not.toContain("KLP 5");
+      expect(values).not.toContain("KLP 6");
+    });
   });
 
   describe("learningCycles", () => {


### PR DESCRIPTION
## Description

Two agentic Aila fixes:

1. Previously the key learning points agent could emit any number of points but the exported lesson plan document has only four slots, so extras were silently dropped
2. Practice tasks and cycle feedback had no length limit, so long ones overflowed the fixed-size slide text box and were cut off. This PR bounds the agent to 3-4 points (matching the template) and limits practice tasks and feedback by line count (at most 12 lines) so they fit the slide, offloading bulk stimulus to the worksheet or additional materials.

Export templates are untouched and the shared schema stays unbounded so existing lessons still parse.

## Issue(s)

Fixes #

## How to test

Go to <!-- vercel-preview -->https://oak-ai-lesson-assistant-website-rkmrwvp4r.vercel.thenational.academy<!-- /vercel-preview --> with the agentic flow enabled.

**Fix 1 - key learning points capped to the template's slots**

1. Generate a lesson with the agentic flow (e.g. "teach a lesson on truth tables for ks4 computer science").
2. Check the lesson plan shows between 3 and 4 key learning points, never more.
3. Download the lesson plan document and confirm every key learning point appears (none silently dropped).

**Fix 2 - practice tasks and feedback fit the slide**

1. Generate a lesson (e.g. the drum lesson from agentic testing: "KS4 Music, sequencing drum grooves in a DAW").
2. Check each learning cycle's practice task keeps its step-by-step structure while staying concise, and the feedback/model answer is concise.
3. Export the lesson slides and confirm both the practice task and its feedback fit without overflowing off the slide.

## Screenshots

N/A

## Checklist

- [x] Manually tested across browsers / devices (no app UI change; affects generated export content only)
- [ ] ~~Considered impact on accessibility~~ (no markup or rendering change)
- [ ] ~~Does this PR update a package with a breaking change~~ (no package API or version change)
