### PR TITLE
fix: exclude required actions with related slug

### DIFF
--- a/packages/api/src/router/owaLesson/schemas.ts
+++ b/packages/api/src/router/owaLesson/schemas.ts
@@ -64,6 +64,7 @@ export const lessonBrowseDataByKsSchema = syntheticUnitvariantLessonsSchema
     null_unitvariant_id: true,
     unit_data: true,
     programme_fields: true,
+    actions: true,
   })
   .extend({
     lesson_data: z.object({


### PR DESCRIPTION
## Description

- Excludes actions from schema, this contains related_subject_slugs which we are not using.

fixes this bug - https://oak-national-academy.sentry.io/issues/129771335/?environment=production&project=4507089597300816&query=is%3Aunresolved&referrer=issue-stream


## Issue(s)

Fixes #

## How to test

1. Go to <!-- vercel-preview -->{deployment_url}<!-- /vercel-preview -->

You should now be able to create a TM with this lesson.

aila/teaching-materials?lessonSlug=website-building-blocks&programmeSlug=computing-secondary-ks3&docType=additional-exit-quiz



## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
