### PR TITLE
chore: update to zod 4 use v3

### DIFF
--- a/apps/nextjs/package.json
+++ b/apps/nextjs/package.json
@@ -59,7 +59,7 @@
     "@oakai/teaching-materials": "*",
     "@oaknational/oak-components": "^2.36.0",
     "@oaknational/oak-consent-client": "^2.1.0",
-    "@oaknational/oak-curriculum-schema": "1.61.0",
+    "@oaknational/oak-curriculum-schema": "2.15.0",
     "@portabletext/react": "^3.1.0",
     "@prisma/client": "^6.3.1",
     "@prisma/extension-accelerate": "^1.2.1",
@@ -135,8 +135,8 @@
     "tsx": "^4.16.0",
     "untruncate-json": "^0.0.1",
     "usehooks-ts": "^2.9.1",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.23.0",
+    "zod": "^4.4.3",
+    "zod-to-json-schema": "^3.25.2",
     "zustand": "^5.0.3"
   },
   "devDependencies": {

--- a/apps/nextjs/src/ai-apps/common/parseLocalStorageData.ts
+++ b/apps/nextjs/src/ai-apps/common/parseLocalStorageData.ts
@@ -1,7 +1,7 @@
 import { aiLogger } from "@oakai/logger";
 
 import * as Sentry from "@sentry/nextjs";
-import type { z } from "zod";
+import type { z } from "zod/v3";
 
 const log = aiLogger("ui");
 

--- a/apps/nextjs/src/ai-apps/lesson-planner/state/types.ts
+++ b/apps/nextjs/src/ai-apps/lesson-planner/state/types.ts
@@ -4,7 +4,7 @@ import {
   generationPartSchema,
 } from "@oakai/core/src/types";
 
-import { z } from "zod";
+import { z } from "zod/v3";
 
 // Quiz question schemas for lesson planner quizzes
 const quizAppQuestionSchema = z.object({

--- a/apps/nextjs/src/app/api/chat/chatHandler.ts
+++ b/apps/nextjs/src/app/api/chat/chatHandler.ts
@@ -29,7 +29,7 @@ import { captureException } from "@sentry/nextjs";
 import * as Sentry from "@sentry/node";
 import type { NextRequest } from "next/server";
 import invariant from "tiny-invariant";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { Config } from "./configTypes";
 import { handleChatException } from "./errorHandling";

--- a/apps/nextjs/src/app/api/chat/fixtures/FixtureRecordLLMService.ts
+++ b/apps/nextjs/src/app/api/chat/fixtures/FixtureRecordLLMService.ts
@@ -4,7 +4,7 @@ import { OpenAIService } from "@oakai/aila/src/core/llm/OpenAIService";
 import { aiLogger } from "@oakai/logger";
 
 import fs from "fs/promises";
-import type { ZodSchema } from "zod";
+import type { ZodSchema } from "zod/v3";
 
 const log = aiLogger("fixtures");
 

--- a/apps/nextjs/src/components/AppComponents/Chat/Chat/hooks/useProgressForDownloads.ts
+++ b/apps/nextjs/src/components/AppComponents/Chat/Chat/hooks/useProgressForDownloads.ts
@@ -6,7 +6,7 @@ import type {
 } from "@oakai/aila/src/protocol/schema";
 import { lessonPlanSectionsSchema } from "@oakai/exports/src/schema/input.schema";
 
-import type { ZodIssue } from "zod";
+import type { ZodIssue } from "zod/v3";
 
 export type ProgressForDownloads = {
   sections: ProgressSection[];

--- a/apps/nextjs/src/components/AppComponents/download/DownloadAllButton.tsx
+++ b/apps/nextjs/src/components/AppComponents/download/DownloadAllButton.tsx
@@ -7,7 +7,7 @@ import { aiLogger } from "@oakai/logger";
 import { Box } from "@radix-ui/themes";
 import * as Sentry from "@sentry/nextjs";
 import Link from "next/link";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import useAnalytics from "@/lib/analytics/useAnalytics";
 import { trpc } from "@/utils/trpc";

--- a/apps/nextjs/src/components/ExportsDialogs/useExportAdditionalMaterials.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportAdditionalMaterials.ts
@@ -5,7 +5,7 @@ import type { LessonSlidesInputData } from "@oakai/exports/src/schema/input.sche
 
 import * as Sentry from "@sentry/nextjs";
 import { useDebounce } from "@uidotdev/usehooks";
-import type { ZodError } from "zod";
+import type { ZodError } from "zod/v3";
 
 import { trpc } from "@/utils/trpc";
 

--- a/apps/nextjs/src/components/ExportsDialogs/useExportAllLessonAssets.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportAllLessonAssets.ts
@@ -7,7 +7,7 @@ import { aiLogger } from "@oakai/logger";
 
 import * as Sentry from "@sentry/nextjs";
 import { useDebounce } from "@uidotdev/usehooks";
-import type { ZodError } from "zod";
+import type { ZodError } from "zod/v3";
 
 import { trpc } from "@/utils/trpc";
 

--- a/apps/nextjs/src/components/ExportsDialogs/useExportLessonPlanDoc.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportLessonPlanDoc.ts
@@ -5,7 +5,7 @@ import type { LessonPlanDocInputData } from "@oakai/exports/src/schema/input.sch
 
 import * as Sentry from "@sentry/nextjs";
 import { useDebounce } from "@uidotdev/usehooks";
-import type { ZodError } from "zod";
+import type { ZodError } from "zod/v3";
 
 import { trpc } from "@/utils/trpc";
 

--- a/apps/nextjs/src/components/ExportsDialogs/useExportLessonSlides.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportLessonSlides.ts
@@ -5,7 +5,7 @@ import type { LessonSlidesInputData } from "@oakai/exports/src/schema/input.sche
 
 import * as Sentry from "@sentry/nextjs";
 import { useDebounce } from "@uidotdev/usehooks";
-import type { ZodError } from "zod";
+import type { ZodError } from "zod/v3";
 
 import { trpc } from "@/utils/trpc";
 

--- a/apps/nextjs/src/components/ExportsDialogs/useExportQuizDoc.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportQuizDoc.ts
@@ -8,7 +8,7 @@ import type {
 
 import * as Sentry from "@sentry/nextjs";
 import { useDebounce } from "@uidotdev/usehooks";
-import type { ZodError } from "zod";
+import type { ZodError } from "zod/v3";
 
 import { trpc } from "@/utils/trpc";
 

--- a/apps/nextjs/src/components/ExportsDialogs/useExportWorksheetSlides.ts
+++ b/apps/nextjs/src/components/ExportsDialogs/useExportWorksheetSlides.ts
@@ -5,7 +5,7 @@ import type { WorksheetSlidesInputData } from "@oakai/exports/src/schema/input.s
 
 import * as Sentry from "@sentry/nextjs";
 import { useDebounce } from "@uidotdev/usehooks";
-import type { ZodError } from "zod";
+import type { ZodError } from "zod/v3";
 
 import { trpc } from "@/utils/trpc";
 

--- a/apps/nextjs/src/env/schema.mjs
+++ b/apps/nextjs/src/env/schema.mjs
@@ -1,5 +1,5 @@
 // @ts-check
-import { z } from "zod";
+import { z } from "zod/v3";
 
 /**
  * Specify your server-side environment variables schema here.

--- a/apps/nextjs/src/lib/types.ts
+++ b/apps/nextjs/src/lib/types.ts
@@ -1,4 +1,4 @@
-import { date, z } from "zod";
+import { date, z } from "zod/v3";
 
 export const sideBarChatItemSchema = z
   .object({

--- a/apps/nextjs/src/stores/teachingMaterialsStore/actionFunctions/handleCreateMaterialSession.ts
+++ b/apps/nextjs/src/stores/teachingMaterialsStore/actionFunctions/handleCreateMaterialSession.ts
@@ -1,7 +1,7 @@
 import { aiLogger } from "@oakai/logger";
 import { teachingMaterialTypeEnum } from "@oakai/teaching-materials/src/documents/teachingMaterials/configSchema";
 
-import z from "zod";
+import z from "zod/v3";
 
 import type { TrpcUtils } from "@/utils/trpc";
 

--- a/apps/nextjs/src/stores/teachingMaterialsStore/actionFunctions/handleFetchOwaLesson.ts
+++ b/apps/nextjs/src/stores/teachingMaterialsStore/actionFunctions/handleFetchOwaLesson.ts
@@ -2,7 +2,7 @@ import { aiLogger } from "@oakai/logger";
 import { teachingMaterialTypeEnum } from "@oakai/teaching-materials/src/documents/teachingMaterials/configSchema";
 
 import invariant from "tiny-invariant";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { TrpcUtils } from "@/utils/trpc";
 

--- a/apps/nextjs/src/stores/teachingMaterialsStore/types.ts
+++ b/apps/nextjs/src/stores/teachingMaterialsStore/types.ts
@@ -6,7 +6,7 @@ import type {
 import type { RefinementOption } from "@oakai/teaching-materials/src/documents/teachingMaterials/materialTypes";
 import type { LessonPlanSchemaTeachingMaterials } from "@oakai/teaching-materials/src/documents/teachingMaterials/sharedSchema";
 
-import { z } from "zod";
+import { z } from "zod/v3";
 import type { StoreApi } from "zustand";
 
 import type { TeachingMaterialsPageProps } from "@/app/aila/teaching-materials/teachingMaterialsView";

--- a/apps/nextjs/src/utils/constructOwaLessonUrl.ts
+++ b/apps/nextjs/src/utils/constructOwaLessonUrl.ts
@@ -3,7 +3,7 @@
  * NOTE: This constructs urls for the legacy content, once new content is introduced the syntheticProgrammeSlug will need to be updated. Tiers and exam boards will also need to be considered
  *
  */
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export function constructOwaLessonUrl(
   keyStageSlug: string,

--- a/apps/nextjs/src/utils/testHelpers/consumeStream.ts
+++ b/apps/nextjs/src/utils/testHelpers/consumeStream.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 const UnknownStreamMessageSchema = z
   .object({

--- a/packages/aila/package.json
+++ b/packages/aila/package.json
@@ -48,8 +48,8 @@
     "remeda": "^1.29.0",
     "superjson": "^1.9.1",
     "tiny-invariant": "^1.3.1",
-    "zod": "3.25.76",
-    "zod-to-json-schema": "^3.23.0"
+    "zod": "^4.4.3",
+    "zod-to-json-schema": "^3.25.2"
   },
   "devDependencies": {
     "@oakai/eslint-config": "*",

--- a/packages/aila/src/core/chat/types.ts
+++ b/packages/aila/src/core/chat/types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const MessageSchema = z.object({
   id: z.string(),

--- a/packages/aila/src/core/llm/LLMService.ts
+++ b/packages/aila/src/core/llm/LLMService.ts
@@ -1,4 +1,4 @@
-import type { ZodSchema } from "zod";
+import type { ZodSchema } from "zod/v3";
 
 import type { Message } from "../chat";
 

--- a/packages/aila/src/core/llm/OpenAIService.ts
+++ b/packages/aila/src/core/llm/OpenAIService.ts
@@ -3,8 +3,8 @@ import { createVercelOpenAIClient } from "@oakai/core/src/llm/openai";
 import { aiLogger } from "@oakai/logger";
 
 import type { OpenAIProvider } from "@ai-sdk/openai";
-import { streamObject, streamText } from "ai";
-import type { ZodSchema } from "zod";
+import { type Schema, streamObject, streamText } from "ai";
+import type { ZodSchema } from "zod/v3";
 
 import type { Message } from "../chat";
 import type { LLMService } from "./LLMService";
@@ -57,7 +57,9 @@ export class OpenAIService implements LLMService {
     const { textStream: stream } = streamObject({
       model: this._openAIProvider(model, { structuredOutputs: true }),
       output: "object",
-      schema,
+      // AI SDK's zod overload references z.ZodTypeDef (removed in Zod 4) so it
+      // no longer matches our Zod 3 schema; cast to the SDK's Schema<T> branch.
+      schema: schema as unknown as Schema<unknown>,
       schemaName,
       messages: messages.map((m) => ({
         role: m.role,

--- a/packages/aila/src/core/quiz/composers/LLMQuizComposerPrompts.ts
+++ b/packages/aila/src/core/quiz/composers/LLMQuizComposerPrompts.ts
@@ -1,5 +1,5 @@
 import dedent from "dedent";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { PartialLessonPlan, QuizPath } from "../../../protocol/schema";
 import type { ImageMetadata } from "../../../protocol/schemas/quiz";

--- a/packages/aila/src/core/quiz/reporting/schemas.ts
+++ b/packages/aila/src/core/quiz/reporting/schemas.ts
@@ -3,7 +3,7 @@
  * Each node type has a schema defining what data it should contain when complete.
  * These serve as documentation and contract enforcement.
  */
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { QuizQuestionPool } from "../interfaces";
 

--- a/packages/aila/src/core/quiz/schema.ts
+++ b/packages/aila/src/core/quiz/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 // Question Source Types
 export const QuestionSourceTypeSchema = z.enum([

--- a/packages/aila/src/core/quiz/services/CohereReranker.ts
+++ b/packages/aila/src/core/quiz/services/CohereReranker.ts
@@ -1,7 +1,7 @@
 import { aiLogger } from "@oakai/logger";
 
 import { CohereClient } from "cohere-ai";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { SimplifiedResult } from "../interfaces";
 import type { Task } from "../reporting";

--- a/packages/aila/src/core/quiz/services/SemanticQueryGenerator.ts
+++ b/packages/aila/src/core/quiz/services/SemanticQueryGenerator.ts
@@ -2,7 +2,7 @@ import { aiLogger } from "@oakai/logger";
 
 import OpenAI from "openai";
 import { zodResponseFormat } from "openai/helpers/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { PartialLessonPlan, QuizPath } from "../../../protocol/schema";
 import { unpackLessonPlanForPrompt } from "../unpackLessonPlan";

--- a/packages/aila/src/features/americanisms/index.ts
+++ b/packages/aila/src/features/americanisms/index.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { AilaDocumentContent } from "./AilaAmericanisms";
 

--- a/packages/aila/src/features/analytics/adapters/DatadogAnalyticsAdapter.ts
+++ b/packages/aila/src/features/analytics/adapters/DatadogAnalyticsAdapter.ts
@@ -1,7 +1,7 @@
 import { aiLogger } from "@oakai/logger";
 
 import { getEncoding } from "js-tiktoken";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { AnalyticsAdapter } from "./AnalyticsAdapter";
 

--- a/packages/aila/src/lib/agentic-system/agents/agenticPromptRegistry.ts
+++ b/packages/aila/src/lib/agentic-system/agents/agenticPromptRegistry.ts
@@ -5,7 +5,7 @@ import {
 import type { OakPromptDefinition } from "@oakai/core/src/prompts/types";
 import type { PrismaClientWithAccelerate } from "@oakai/db/client";
 
-import { z } from "zod";
+import { z } from "zod/v3";
 
 const VARIANT_SLUG = "main";
 

--- a/packages/aila/src/lib/agentic-system/agents/britishEnglishCorrectorAgent/createBritishEnglishCorrectorAgent.ts
+++ b/packages/aila/src/lib/agentic-system/agents/britishEnglishCorrectorAgent/createBritishEnglishCorrectorAgent.ts
@@ -1,4 +1,4 @@
-import type { z } from "zod";
+import type { z } from "zod/v3";
 
 import {
   AMERICANISM_ISSUE_KIND,

--- a/packages/aila/src/lib/agentic-system/agents/executeGenericPromptAgent.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/executeGenericPromptAgent.test.ts
@@ -1,5 +1,5 @@
 import type OpenAI from "openai";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { GenericPromptAgent } from "../schema";
 import {

--- a/packages/aila/src/lib/agentic-system/agents/executeGenericPromptAgent.ts
+++ b/packages/aila/src/lib/agentic-system/agents/executeGenericPromptAgent.ts
@@ -2,7 +2,7 @@ import { aiLogger, structuredLogger } from "@oakai/logger";
 
 import type OpenAI from "openai";
 import { zodTextFormat } from "openai/helpers/zod";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { GenericPromptAgent } from "../schema";
 import type { AgentResult } from "../types";

--- a/packages/aila/src/lib/agentic-system/agents/messageToUserAgent/messageToUserAgent.schema.ts
+++ b/packages/aila/src/lib/agentic-system/agents/messageToUserAgent/messageToUserAgent.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const messageToUserAgentSchema = z.object({
   message: z.string(),

--- a/packages/aila/src/lib/agentic-system/agents/plannerAgent/createPlannerAgent.ts
+++ b/packages/aila/src/lib/agentic-system/agents/plannerAgent/createPlannerAgent.ts
@@ -1,4 +1,4 @@
-import type { z } from "zod";
+import type { z } from "zod/v3";
 
 import { DEFAULT_AGENT_MODEL_PARAMS } from "../../constants";
 import type { GenericPromptAgent } from "../../schema";

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/additionalMaterialsAgent/index.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/additionalMaterialsAgent/index.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { DEFAULT_AGENT_MODEL_PARAMS } from "../../../constants";
 import { createSectionAgent } from "../createSectionAgent";

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/createSectionAgent.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/createSectionAgent.test.ts
@@ -1,5 +1,5 @@
 import type OpenAI from "openai";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { AilaExecutionContext } from "../../types";
 import { executeGenericPromptAgent } from "../executeGenericPromptAgent";

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/createSectionAgent.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/createSectionAgent.ts
@@ -1,7 +1,7 @@
 import * as Sentry from "@sentry/nextjs";
 import type OpenAI from "openai";
 import type { ResponseCreateParamsNonStreaming } from "openai/resources/responses/responses";
-import type { z } from "zod";
+import type { z } from "zod/v3";
 
 import type { PartialLessonPlan } from "../../../../protocol/schema";
 import { deriveSectionBuildMode } from "../../quizOperations/deriveSectionBuildMode";

--- a/packages/aila/src/lib/agentic-system/agents/sectionAgents/keyStageAgent/keyStage.schema.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionAgents/keyStageAgent/keyStage.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const keyStageSchema = z
   .union([

--- a/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.test.ts
+++ b/packages/aila/src/lib/agentic-system/agents/sectionToGenericPromptAgent.test.ts
@@ -1,5 +1,5 @@
 import type { ResponseCreateParamsNonStreaming } from "openai/resources/responses/responses";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { PartialLessonPlan } from "../../../protocol/schema";
 import type {

--- a/packages/aila/src/lib/agentic-system/execution/applyBritishEnglishCorrection.test.ts
+++ b/packages/aila/src/lib/agentic-system/execution/applyBritishEnglishCorrection.test.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { AMERICANISM_ISSUE_KIND } from "../../../features/americanisms";
 import { createEmptyCorrectorStats } from "../correctorStats";

--- a/packages/aila/src/lib/agentic-system/execution/applyBritishEnglishCorrection.ts
+++ b/packages/aila/src/lib/agentic-system/execution/applyBritishEnglishCorrection.ts
@@ -1,6 +1,6 @@
 import { aiLogger } from "@oakai/logger";
 
-import type { z } from "zod";
+import type { z } from "zod/v3";
 
 import { AMERICANISM_ISSUE_KIND } from "../../../features/americanisms";
 import { AilaAmericanisms } from "../../../features/americanisms/AilaAmericanisms";

--- a/packages/aila/src/lib/agentic-system/execution/executePlanSteps.ts
+++ b/packages/aila/src/lib/agentic-system/execution/executePlanSteps.ts
@@ -1,7 +1,7 @@
 import { aiLogger } from "@oakai/logger";
 
 import { type Draft, enablePatches, produceWithPatches } from "immer";
-import { type ZodType } from "zod";
+import { type ZodType } from "zod/v3";
 
 import type {
   Keyword,

--- a/packages/aila/src/lib/agentic-system/schema.ts
+++ b/packages/aila/src/lib/agentic-system/schema.ts
@@ -1,5 +1,5 @@
 import type { ResponseCreateParamsNonStreaming } from "openai/resources/responses/responses";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 const sectionKeysSchema = z.enum([
   "title",

--- a/packages/aila/src/lib/agentic-system/types.ts
+++ b/packages/aila/src/lib/agentic-system/types.ts
@@ -1,4 +1,4 @@
-import type { z } from "zod";
+import type { z } from "zod/v3";
 
 import type {
   AdditionalMaterialsSchema,

--- a/packages/aila/src/protocol/jsonPatchProtocol.ts
+++ b/packages/aila/src/protocol/jsonPatchProtocol.ts
@@ -6,8 +6,8 @@ import type { Operation } from "fast-json-patch";
 import { JsonPatchError, applyPatch, deepClone } from "fast-json-patch";
 import * as immer from "immer";
 import untruncateJson from "untruncate-json";
-import { z } from "zod";
 import zodToJsonSchema from "zod-to-json-schema";
+import { z } from "zod/v3";
 
 import type { PartialLessonPlan } from "./schema";
 import {

--- a/packages/aila/src/protocol/schema.ts
+++ b/packages/aila/src/protocol/schema.ts
@@ -1,6 +1,6 @@
 import { dedent } from "ts-dedent";
-import { z } from "zod";
 import { zodToJsonSchema } from "zod-to-json-schema";
+import { z } from "zod/v3";
 
 import { MessageSchema } from "../core/chat/types";
 import { minMaxText } from "./schemaHelpers";
@@ -411,6 +411,8 @@ export const LessonPlanKeySchema = z.enum([
   ...allSectionsInOrder,
 ]);
 
+// TODO: when this schema migrates to Zod 4, drop zod-to-json-schema in favour
+// of the native z.toJSONSchema().
 export const LessonPlanJsonSchema = zodToJsonSchema(
   CompletedLessonPlanSchema,
   "lessonPlanSchema",

--- a/packages/aila/src/protocol/schemas/quiz/conversion/cloudinaryImageHelper.ts
+++ b/packages/aila/src/protocol/schemas/quiz/conversion/cloudinaryImageHelper.ts
@@ -7,7 +7,10 @@ const sizeConstraints = "c_limit,h_1200,w_1200";
  * Constrains image size by adding Cloudinary transformations to limit dimensions to 1200x1200
  * Preserves version numbers and existing transformations
  */
-export function constrainImageUrl(url: string): string {
+export function constrainImageUrl(url: string | undefined): string {
+  if (!url) {
+    return "";
+  }
   if (!url.includes("cloudinary.com/image/upload")) {
     return url;
   }

--- a/packages/aila/src/protocol/schemas/quiz/index.ts
+++ b/packages/aila/src/protocol/schemas/quiz/index.ts
@@ -7,7 +7,7 @@
  * - V3: V2 + imageMetadata with dimensions (latest)
  * - Latest: Aliases pointing to current version (V3) - update these when V4 releases
  */
-import { z } from "zod";
+import { z } from "zod/v3";
 
 // Import V3 exports for aliases
 import type { QuizV3, QuizV3Optional, QuizV3Question } from "./quizV3";

--- a/packages/aila/src/protocol/schemas/quiz/quizV1.ts
+++ b/packages/aila/src/protocol/schemas/quiz/quizV1.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 // ********** QUIZ V1 (legacy with only multiple-choice) **********
 

--- a/packages/aila/src/protocol/schemas/quiz/quizV2.ts
+++ b/packages/aila/src/protocol/schemas/quiz/quizV2.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { minMaxText } from "../../schemaHelpers";
 

--- a/packages/aila/src/protocol/schemas/quiz/quizV3.ts
+++ b/packages/aila/src/protocol/schemas/quiz/quizV3.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { minMaxText } from "../../schemaHelpers";
 

--- a/packages/aila/src/protocol/schemas/quiz/rawQuiz.ts
+++ b/packages/aila/src/protocol/schemas/quiz/rawQuiz.ts
@@ -1,6 +1,6 @@
 import type {
   imageItemSchema,
-  quizQuestionSchema,
+  questionSchema,
   textItemSchema,
 } from "@oaknational/oak-curriculum-schema";
 import {
@@ -13,9 +13,9 @@ import { z } from "zod";
 
 // Direct types from Oak's schema without any conversion
 
-export type QuizQuestion = z.infer<typeof quizQuestionSchema>;
+export type QuizQuestion = z.infer<typeof questionSchema>;
 export type QuizQuestionAnswers = NonNullable<
-  z.infer<typeof quizQuestionSchema>["answers"]
+  z.infer<typeof questionSchema>["answers"]
 >;
 
 export type MCAnswer = z.infer<typeof multipleChoiceSchema>;
@@ -37,17 +37,19 @@ export type StemTextObject = z.infer<typeof stemTextObjectSchema>;
 const stemImageObjectSchema = z.object({
   image_object: z.object({
     format: z.enum(["png", "jpg", "jpeg", "webp", "gif", "svg"]).optional(),
-    secure_url: z.string().url(),
-    url: z.string().url().optional(),
+    secure_url: z.url().optional(),
+    url: z.url().optional(),
     height: z.number().optional(),
     width: z.number().optional(),
-    metadata: z.union([
-      z.array(z.unknown()),
-      z.object({
-        attribution: z.string().optional(),
-        usageRestriction: z.string().optional(),
-      }),
-    ]),
+    metadata: z
+      .union([
+        z.array(z.unknown()),
+        z.object({
+          attribution: z.string().optional(),
+          usageRestriction: z.string().optional(),
+        }),
+      ])
+      .optional(),
     context: z
       .object({
         custom: z

--- a/packages/aila/src/protocol/schemas/versioning/migrateChatData.ts
+++ b/packages/aila/src/protocol/schemas/versioning/migrateChatData.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { AilaPersistedChat } from "../../schema";
 import { PartialLessonPlanSchema, chatSchema } from "../../schema";

--- a/packages/aila/src/protocol/schemas/versioning/migrateLessonPlan.ts
+++ b/packages/aila/src/protocol/schemas/versioning/migrateLessonPlan.ts
@@ -1,6 +1,6 @@
 import { aiLogger } from "@oakai/logger";
 
-import { type ZodTypeAny, z } from "zod";
+import { type ZodTypeAny, z } from "zod/v3";
 
 import { CompletedLessonPlanSchemaWithoutLength } from "../../schema";
 import type { LatestQuiz } from "../quiz";

--- a/packages/aila/src/protocol/sectionToMarkdown.ts
+++ b/packages/aila/src/protocol/sectionToMarkdown.ts
@@ -1,7 +1,7 @@
 import { camelCaseToSentenceCase } from "@oakai/core/src/utils/camelCaseConversion";
 
 import { isArray, isNumber, isObject, isString } from "remeda";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export function sortIgnoringSpecialChars(strings: string[]): string[] {
   // Function to normalize strings by removing *, -, and spaces

--- a/packages/aila/src/utils/extractPromptTextFromMessages.ts
+++ b/packages/aila/src/utils/extractPromptTextFromMessages.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 /**
  * This function extracts the prompt text from messages.

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -38,7 +38,7 @@
     "next": "16.0.10",
     "remeda": "^1.29.0",
     "superjson": "^1.9.1",
-    "zod": "3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@oakai/eslint-config": "*",

--- a/packages/api/src/export/exportQuizDoc.ts
+++ b/packages/api/src/export/exportQuizDoc.ts
@@ -5,7 +5,7 @@ import { aiLogger } from "@oakai/logger";
 
 import type { SignedInAuthObject } from "@clerk/backend/internal";
 import * as Sentry from "@sentry/nextjs";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { OutputSchema } from "../router/exports";
 import { ailaSaveExport, reportErrorResult } from "../router/exports";

--- a/packages/api/src/router/admin.ts
+++ b/packages/api/src/router/admin.ts
@@ -8,7 +8,7 @@ import {
 import type { Moderation, SafetyViolation } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
 
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { AilaPersistedChat } from "../../../aila/src/protocol/schema";
 import { adminProcedure } from "../middleware/adminAuth";

--- a/packages/api/src/router/app.ts
+++ b/packages/api/src/router/app.ts
@@ -6,7 +6,7 @@ import { prisma } from "@oakai/db";
 import { aiLogger, structuredLogger as logger } from "@oakai/logger";
 
 import { TRPCError } from "@trpc/server";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { protectedProcedure } from "../middleware/auth";
 import { publicProcedure, router } from "../trpc";

--- a/packages/api/src/router/appSessions.ts
+++ b/packages/api/src/router/appSessions.ts
@@ -8,7 +8,7 @@ import { clerkClient } from "@clerk/nextjs/server";
 import * as Sentry from "@sentry/nextjs";
 import { TRPCError } from "@trpc/server";
 import { isTruthy } from "remeda";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { getSessionModerations } from "../../../aila/src/features/moderation/getSessionModerations";
 import { generateChatId } from "../../../aila/src/helpers/chat/generateChatId";

--- a/packages/api/src/router/auth.ts
+++ b/packages/api/src/router/auth.ts
@@ -3,7 +3,7 @@ import { posthogAiBetaServerClient } from "@oakai/core/src/analytics/posthogAiBe
 import { demoUsers } from "@oakai/core/src/models/demoUsers";
 
 import { clerkClient } from "@clerk/nextjs/server";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { protectedProcedure } from "../middleware/auth";
 import { router } from "../trpc";

--- a/packages/api/src/router/chatFeedback.ts
+++ b/packages/api/src/router/chatFeedback.ts
@@ -1,5 +1,5 @@
 import * as Sentry from "@sentry/nextjs";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { protectedProcedure } from "../middleware/auth";
 import { router } from "../trpc";

--- a/packages/api/src/router/chats.ts
+++ b/packages/api/src/router/chats.ts
@@ -3,7 +3,7 @@ import { prisma } from "@oakai/db/client";
 
 import { TRPCError } from "@trpc/server";
 import { isTruthy } from "remeda";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { protectedProcedure } from "../middleware/auth";
 import { router } from "../trpc";

--- a/packages/api/src/router/cloudinary.ts
+++ b/packages/api/src/router/cloudinary.ts
@@ -2,7 +2,7 @@ import { requestImageDescription } from "@oakai/core/src/functions/generation/im
 import { aiLogger } from "@oakai/logger";
 
 import { v2 as cloudinary } from "cloudinary";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { protectedProcedure } from "../middleware/auth";
 import { router } from "../trpc";

--- a/packages/api/src/router/exports.ts
+++ b/packages/api/src/router/exports.ts
@@ -13,7 +13,7 @@ import { clerkClient } from "@clerk/nextjs/server";
 import type { LessonExportType } from "@prisma/client";
 import * as Sentry from "@sentry/nextjs";
 import { kv } from "@vercel/kv";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { exportAdditionalMaterialsDoc } from "../export/exportAdditionalMaterialsDoc";
 import {

--- a/packages/api/src/router/lesson-summary.ts
+++ b/packages/api/src/router/lesson-summary.ts
@@ -1,6 +1,6 @@
 import { LessonSummaries } from "@oakai/core";
 
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { protectedProcedure } from "../middleware/auth";
 import { router } from "../trpc";

--- a/packages/api/src/router/lesson.ts
+++ b/packages/api/src/router/lesson.ts
@@ -2,7 +2,7 @@ import { Lessons } from "@oakai/core";
 import { LessonWithSnippets } from "@oakai/db";
 
 import { TRPCError } from "@trpc/server";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { protectedProcedure } from "../middleware/auth";
 import { router } from "../trpc";

--- a/packages/api/src/router/lessonAdapt.ts
+++ b/packages/api/src/router/lessonAdapt.ts
@@ -12,7 +12,7 @@ import { aiLogger } from "@oakai/logger";
 import { TRPCError } from "@trpc/server";
 import { kv } from "@vercel/kv";
 import { nanoid } from "nanoid";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { adminProcedure } from "../middleware/adminAuth";
 import { protectedProcedure } from "../middleware/auth";

--- a/packages/api/src/router/moderations.ts
+++ b/packages/api/src/router/moderations.ts
@@ -1,7 +1,7 @@
 import { aiLogger } from "@oakai/logger";
 
 import * as Sentry from "@sentry/node";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { protectedProcedure } from "../middleware/auth";
 import { router } from "../trpc";

--- a/packages/api/src/router/owaLesson/build.ts
+++ b/packages/api/src/router/owaLesson/build.ts
@@ -1,4 +1,4 @@
-import type { z } from "zod";
+import type { z } from "zod/v3";
 
 import type {
   UnitDataSchema,

--- a/packages/api/src/router/owaLesson/build.ts
+++ b/packages/api/src/router/owaLesson/build.ts
@@ -1,4 +1,4 @@
-import type { z } from "zod/v3";
+import type { z } from "zod";
 
 import type {
   UnitDataSchema,

--- a/packages/api/src/router/owaLesson/extractLessonData.ts
+++ b/packages/api/src/router/owaLesson/extractLessonData.ts
@@ -1,7 +1,7 @@
 import { aiLogger } from "@oakai/logger";
 
 import { TRPCError } from "@trpc/server";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { lessonAdaptApiDataSchema } from "./schemas";
 import { transformKeywords, transformMisconceptions } from "./transformer";

--- a/packages/api/src/router/owaLesson/prepare.ts
+++ b/packages/api/src/router/owaLesson/prepare.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from "@trpc/server";
-import type { z } from "zod";
+import type { z } from "zod/v3";
 
 import {
   checkForRestrictedContentGuidance,

--- a/packages/api/src/router/owaLesson/prepare.ts
+++ b/packages/api/src/router/owaLesson/prepare.ts
@@ -1,5 +1,5 @@
 import { TRPCError } from "@trpc/server";
-import type { z } from "zod/v3";
+import type { z } from "zod";
 
 import {
   checkForRestrictedContentGuidance,

--- a/packages/api/src/router/owaLesson/schemas.ts
+++ b/packages/api/src/router/owaLesson/schemas.ts
@@ -5,7 +5,10 @@ import {
   syntheticUnitvariantLessonsByKsSchema,
   syntheticUnitvariantLessonsSchema,
 } from "@oaknational/oak-curriculum-schema";
-import { z } from "zod/v3";
+// oak-curriculum-schema emits zod 4 schemas (imports bare "zod"), so this file
+// composes them with the matching bare "zod" import rather than the "zod/v3"
+// shim used elsewhere. Mixing the two produces TS2589 / ZodType mismatches.
+import { z } from "zod";
 
 const subjectSchema = z.union([
   subjects,

--- a/packages/api/src/router/owaLesson/schemas.ts
+++ b/packages/api/src/router/owaLesson/schemas.ts
@@ -5,7 +5,7 @@ import {
   syntheticUnitvariantLessonsByKsSchema,
   syntheticUnitvariantLessonsSchema,
 } from "@oaknational/oak-curriculum-schema";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 const subjectSchema = z.union([
   subjects,

--- a/packages/api/src/router/owaLesson/slideDeck.ts
+++ b/packages/api/src/router/owaLesson/slideDeck.ts
@@ -6,7 +6,7 @@ import {
 import { aiLogger } from "@oakai/logger";
 
 import { TRPCError } from "@trpc/server";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { LessonOverviewResponse } from "./types";
 

--- a/packages/api/src/router/owaLesson/transformer.ts
+++ b/packages/api/src/router/owaLesson/transformer.ts
@@ -8,7 +8,7 @@ import type { LessonPlanSchemaTeachingMaterials } from "@oakai/teaching-material
 
 import { type QuizQuestion as OwaQuizQuestion } from "@oaknational/oak-curriculum-schema/";
 import { isArray, isTruthy } from "remeda";
-import z from "zod";
+import z from "zod/v3";
 
 import type {
   LessonBrowseDataByKsSchema,

--- a/packages/api/src/router/owaLesson/transformers.test.ts
+++ b/packages/api/src/router/owaLesson/transformers.test.ts
@@ -10,6 +10,7 @@ describe("transformQuiz", () => {
         order: 1,
         question_uid: "q1",
         question_type: "multiple-choice",
+        _state: "published",
         question_stem: [{ type: "text", text: "What is 2 + 2?" }],
         answers: {
           "multiple-choice": [
@@ -51,6 +52,7 @@ describe("transformQuiz", () => {
         question_id: 1,
         question_uid: "q1",
         question_type: "multiple-choice",
+        _state: "published",
         question_stem: [
           { type: "text", text: "Look at this image: " },
           {
@@ -76,6 +78,7 @@ describe("transformQuiz", () => {
         question_id: 2,
         question_uid: "q2",
         question_type: "multiple-choice",
+        _state: "published",
         question_stem: [{ type: "text", text: "Valid question?" }],
         answers: {
           "multiple-choice": [
@@ -106,6 +109,7 @@ describe("transformQuiz", () => {
         question_id: 1,
         question_uid: "q1",
         question_type: "multiple-choice",
+        _state: "published",
         question_stem: [{ type: "text", text: "What do you see?" }],
         answers: {
           "multiple-choice": [
@@ -135,6 +139,7 @@ describe("transformQuiz", () => {
         question_id: 2,
         question_uid: "q2",
         question_type: "multiple-choice",
+        _state: "published",
         question_stem: [{ type: "text", text: "Valid question?" }],
         answers: {
           "multiple-choice": [
@@ -165,6 +170,7 @@ describe("transformQuiz", () => {
         question_id: 1,
         question_uid: "q1",
         question_type: "short-answer",
+        _state: "published",
         question_stem: [{ type: "text", text: "Describe this image:" }],
         answers: {
           "short-answer": [
@@ -172,6 +178,7 @@ describe("transformQuiz", () => {
               answer: [
                 { type: "text", text: "It shows" },
                 {
+                  // @ts-expect-error: 'image' is not assignable to short-answer answer type 'text'
                   type: "image",
                   image_object: {
                     secure_url: "https://example.com/image.png",
@@ -191,6 +198,7 @@ describe("transformQuiz", () => {
         question_id: 1,
         question_uid: "q1",
         question_type: "short-answer",
+        _state: "published",
         question_stem: [{ type: "text", text: "What is water?" }],
         answers: {
           "short-answer": [
@@ -221,6 +229,7 @@ describe("transformQuiz", () => {
         question_id: 1,
         question_uid: "q1",
         question_type: "multiple-choice",
+        _state: "published",
         question_stem: [
           { type: "text", text: "Part 1" },
           // @ts-expect-error: 'video' is not assignable to 'text' | 'image'
@@ -259,6 +268,7 @@ describe("transformQuiz", () => {
         question_uid: "q1",
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         question_type: "essay" as any,
+        _state: "published",
         question_stem: [{ type: "text", text: "Write an essay about..." }],
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         answers: {} as any,
@@ -278,6 +288,7 @@ describe("transformQuiz", () => {
         question_id: 1,
         question_uid: "q1",
         question_type: "multiple-choice",
+        _state: "published",
         question_stem: [{ type: "text", text: "What is the answer?" }],
         answers: {
           "multiple-choice": [

--- a/packages/api/src/router/quizPlayground.ts
+++ b/packages/api/src/router/quizPlayground.ts
@@ -2,7 +2,7 @@ import { ReportStorage } from "@oakai/aila/src/core/quiz/reporting";
 import { migrateChatData } from "@oakai/aila/src/protocol/schemas/versioning/migrateChatData";
 import { aiLogger } from "@oakai/logger";
 
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { adminProcedure } from "../middleware/adminAuth";
 import { router } from "../trpc";

--- a/packages/api/src/router/subjectsAndKeyStage.ts
+++ b/packages/api/src/router/subjectsAndKeyStage.ts
@@ -5,7 +5,7 @@ import {
 } from "@oakai/core";
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { protectedProcedure } from "../middleware/auth";
 import { router } from "../trpc";

--- a/packages/api/src/router/teachingMaterials/generatePartialLessonPlan.test.ts
+++ b/packages/api/src/router/teachingMaterials/generatePartialLessonPlan.test.ts
@@ -13,7 +13,7 @@ import type { PartialLessonContextSchemaType } from "@oakai/teaching-materials/s
 import { performThreatCheck } from "@oakai/teaching-materials/src/threatDetection/performThreatCheck";
 
 import type { SignedInAuthObject } from "@clerk/backend/internal";
-import type { z } from "zod";
+import type { z } from "zod/v3";
 
 import { generatePartialLessonPlan } from "./generatePartialLessonPlan";
 import { recordSafetyViolation } from "./safetyUtils";

--- a/packages/api/src/router/teachingMaterials/testFixtures.ts
+++ b/packages/api/src/router/teachingMaterials/testFixtures.ts
@@ -2,7 +2,7 @@ import type { moderationResponseSchema } from "@oakai/core/src/utils/ailaModerat
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 
 import type { SignedInAuthObject } from "@clerk/backend/internal";
-import type { z } from "zod";
+import type { z } from "zod/v3";
 
 // Shared mock data
 export const mockGlossaryResult = {

--- a/packages/api/src/router/teachingMaterialsRouter.ts
+++ b/packages/api/src/router/teachingMaterialsRouter.ts
@@ -12,7 +12,7 @@ import {
 import { clerkClient } from "@clerk/nextjs/server";
 import * as Sentry from "@sentry/nextjs";
 import { TRPCError } from "@trpc/server";
-import { ZodError, z } from "zod";
+import { ZodError, z } from "zod/v3";
 
 import { protectedProcedure } from "../middleware/auth";
 import { teachingMaterialUserBasedRateLimitProcedure } from "../middleware/rateLimiter";

--- a/packages/api/src/router/testSupport/prepareUser.ts
+++ b/packages/api/src/router/testSupport/prepareUser.ts
@@ -3,7 +3,7 @@ import { aiLogger } from "@oakai/logger";
 import { clerkClient } from "@clerk/nextjs/server";
 import { waitUntil } from "@vercel/functions";
 import os from "os";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { publicProcedure } from "../../trpc";
 import { personaNames, personas } from "./personas";

--- a/packages/api/src/trpc.ts
+++ b/packages/api/src/trpc.ts
@@ -2,7 +2,7 @@ import { aiLogger } from "@oakai/logger";
 
 import * as Sentry from "@sentry/node";
 import { initTRPC } from "@trpc/server";
-import { ZodError } from "zod";
+import { ZodError } from "zod/v3";
 
 import { transformer } from "../transformer";
 import type { Context } from "./context";

--- a/packages/api/src/types.ts
+++ b/packages/api/src/types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const rateLimitInfoSchema = z.union([
   z.object({

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -55,7 +55,7 @@
     "unique-names-generator": "^4.7.1",
     "untruncate-json": "^0.0.1",
     "webvtt-parser": "^2.2.0",
-    "zod": "3.25.76",
+    "zod": "^4.4.3",
     "zod-to-json-schema": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -64,5 +64,10 @@
     "@types/jest": "^30.0.0",
     "jest": "^30.0.0",
     "ts-jest": "^29.2.5"
+  },
+  "overrides": {
+    "@langchain/community": {
+      "zod": "3.25.67"
+    }
   }
 }

--- a/packages/core/src/backgroundTasks/index.ts
+++ b/packages/core/src/backgroundTasks/index.ts
@@ -2,7 +2,7 @@ import { aiLogger } from "@oakai/logger";
 
 import * as Sentry from "@sentry/nextjs";
 import { waitUntil } from "@vercel/functions";
-import type { z } from "zod";
+import type { z } from "zod/v3";
 
 import { notifyModeration } from "../functions/slack/notifyModeration";
 import {

--- a/packages/core/src/functions/slack/notifyModeration.schema.ts
+++ b/packages/core/src/functions/slack/notifyModeration.schema.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import z from "zod/v3";
 
 export const notifyModerationSchema = z.object({
   user: z.object({

--- a/packages/core/src/functions/slack/notifyModerationTeachingMaterials.schema.ts
+++ b/packages/core/src/functions/slack/notifyModerationTeachingMaterials.schema.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import z from "zod/v3";
 
 export const notifyModerationTeachingMaterialsSchema = z.object({
   user: z.object({

--- a/packages/core/src/functions/slack/notifyRateLimit.schema.ts
+++ b/packages/core/src/functions/slack/notifyRateLimit.schema.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import z from "zod/v3";
 
 export const notifyRateLimitSchema = z.object({
   user: z.object({

--- a/packages/core/src/functions/slack/notifyThreatDetectionAila.schema.ts
+++ b/packages/core/src/functions/slack/notifyThreatDetectionAila.schema.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import z from "zod/v3";
 
 import {
   threatDetectionMessageSchema,

--- a/packages/core/src/functions/slack/notifyThreatDetectionTeachingMaterials.schema.ts
+++ b/packages/core/src/functions/slack/notifyThreatDetectionTeachingMaterials.schema.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import z from "zod/v3";
 
 import {
   threatDetectionMessageSchema,

--- a/packages/core/src/functions/slack/notifyUserBan.schema.ts
+++ b/packages/core/src/functions/slack/notifyUserBan.schema.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import z from "zod/v3";
 
 export const notifyUserBanSchema = z.object({
   user: z.object({

--- a/packages/core/src/models/lessonPlans.ts
+++ b/packages/core/src/models/lessonPlans.ts
@@ -10,7 +10,7 @@ import type {
 import { LessonPlanPartStatus, LessonPlanStatus } from "@oakai/db";
 import { aiLogger } from "@oakai/logger";
 
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { LLMResponseJsonSchema } from "../../../aila/src/protocol/jsonPatchProtocol";
 import { LessonPlanJsonSchema } from "../../../aila/src/protocol/schema";

--- a/packages/core/src/models/lessons.ts
+++ b/packages/core/src/models/lessons.ts
@@ -14,7 +14,7 @@ import { aiLogger } from "@oakai/logger";
 import { StructuredOutputParser } from "langchain/output_parsers";
 import { PromptTemplate } from "langchain/prompts";
 import { RunnableSequence } from "langchain/schema/runnable";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { createOpenAILangchainClient } from "../llm/langchain";
 import type { SnippetWithLesson } from "./snippets";

--- a/packages/core/src/models/lessons.ts
+++ b/packages/core/src/models/lessons.ts
@@ -122,41 +122,48 @@ export class Lessons {
       ],
     });
 
-    const parser = StructuredOutputParser.fromZodSchema(
-      z.object({
-        summary: z.string().describe("An overall summary of the lesson"),
-        topics: z
-          .array(z.string())
-          .describe(
-            "An array of strings representing the main topics covered by the lesson",
-          ),
-        learningObjectives: z
-          .array(z.string())
-          .describe(
-            "An array of strings representing the learning objectives of the lesson",
-          ),
-        concepts: z
-          .array(z.string())
-          .describe(
-            "An array of strings representing the main concepts discussed within the lesson",
-          ),
+    const summarySchema = z.object({
+      summary: z.string().describe("An overall summary of the lesson"),
+      topics: z
+        .array(z.string())
+        .describe(
+          "An array of strings representing the main topics covered by the lesson",
+        ),
+      learningObjectives: z
+        .array(z.string())
+        .describe(
+          "An array of strings representing the learning objectives of the lesson",
+        ),
+      concepts: z
+        .array(z.string())
+        .describe(
+          "An array of strings representing the main concepts discussed within the lesson",
+        ),
 
-        keywords: z
-          .array(z.string())
-          .describe(
-            "A set of keywords which could be used to categorise the lesson to appear in search results",
-          ),
-      }),
+      keywords: z
+        .array(z.string())
+        .describe(
+          "A set of keywords which could be used to categorise the lesson to appear in search results",
+        ),
+    });
+    // `zod/v3` (from zod 4) and langchain's own nested zod are two distinct
+    // copies of zod's recursive types, so letting `fromZodSchema` infer the
+    // schema type triggers TS2589. Erase the generic to langchain's expected
+    // input type and recover our result type via `z.infer` below.
+    const parser = StructuredOutputParser.fromZodSchema(
+      summarySchema as unknown as Parameters<
+        typeof StructuredOutputParser.fromZodSchema
+      >[0],
     );
 
     const chain = RunnableSequence.from([prompt, model, parser]);
 
-    const response = await chain.invoke({
+    const response = (await chain.invoke({
       title: lesson.title,
       description: description,
       transcript: transcript,
       format_instructions: parser.getFormatInstructions(),
-    });
+    })) as z.infer<typeof summarySchema>;
 
     log.info(response);
 

--- a/packages/core/src/models/promptVariants.test.ts
+++ b/packages/core/src/models/promptVariants.test.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { OakPromptDefinition } from "../prompts/types";
 import { PromptVariants, promptHash } from "./promptVariants";

--- a/packages/core/src/models/transcript.ts
+++ b/packages/core/src/models/transcript.ts
@@ -6,7 +6,7 @@ import { StructuredOutputParser } from "langchain/output_parsers";
 import { PromptTemplate } from "langchain/prompts";
 import { RunnableSequence } from "langchain/schema/runnable";
 import { RecursiveCharacterTextSplitter } from "langchain/text_splitter";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { createOpenAILangchainClient } from "../llm/langchain";
 

--- a/packages/core/src/models/transcript.ts
+++ b/packages/core/src/models/transcript.ts
@@ -132,12 +132,19 @@ export class Transcripts {
 
     log.info(template);
 
+    const snippetsSchema = z.object({
+      snippets: z
+        .array(z.string())
+        .describe("snippets of the transcript to be summarised"),
+    });
+    // `zod/v3` (from zod 4) and langchain's own nested zod are two distinct
+    // copies of zod's recursive types, so letting `fromZodSchema` infer the
+    // schema type triggers TS2589. Erase the generic to langchain's expected
+    // input type and recover our result type via `z.infer` below.
     const parser = StructuredOutputParser.fromZodSchema(
-      z.object({
-        snippets: z
-          .array(z.string())
-          .describe("snippets of the transcript to be summarised"),
-      }),
+      snippetsSchema as unknown as Parameters<
+        typeof StructuredOutputParser.fromZodSchema
+      >[0],
     );
 
     const openAi = createOpenAILangchainClient({
@@ -156,10 +163,10 @@ export class Transcripts {
 
     const transcript_text = (transcript.content as unknown as TranscriptWithRaw)
       .raw;
-    const response = await chain.invoke({
+    const response = (await chain.invoke({
       transcript_text,
       format_instructions,
-    });
+    })) as z.infer<typeof snippetsSchema>;
 
     log.info("Got response", { response });
 

--- a/packages/core/src/models/types/caption.ts
+++ b/packages/core/src/models/types/caption.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import z from "zod/v3";
 
 export const CaptionSchema = z.object({
   end: z.number(),

--- a/packages/core/src/prompts/lesson-assistant/variants.ts
+++ b/packages/core/src/prompts/lesson-assistant/variants.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import z from "zod/v3";
 
 import type { TemplateProps } from ".";
 import { getPromptParts } from ".";

--- a/packages/core/src/prompts/types.ts
+++ b/packages/core/src/prompts/types.ts
@@ -1,4 +1,4 @@
-import type { z } from "zod";
+import type { z } from "zod/v3";
 
 export type OakPromptDefinition = {
   name: string;

--- a/packages/core/src/rag/categorisation.ts
+++ b/packages/core/src/rag/categorisation.ts
@@ -1,4 +1,4 @@
-import z from "zod";
+import z from "zod/v3";
 
 // Make a new Zod schema for a response from OpenAI for the categoriseKeyStageAndSubject function
 

--- a/packages/core/src/rag/types.ts
+++ b/packages/core/src/rag/types.ts
@@ -1,5 +1,5 @@
 import type { KeyStage, LessonPlan, Subject } from "@prisma/client";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export interface FilterOptions {
   key_stage_id?: object;

--- a/packages/core/src/threatDetection/lakera/schema.ts
+++ b/packages/core/src/threatDetection/lakera/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 /**
  * Schema for a message sent to Lakera Guard API

--- a/packages/core/src/threatDetection/modelArmor/modelArmorAuth.ts
+++ b/packages/core/src/threatDetection/modelArmor/modelArmorAuth.ts
@@ -1,5 +1,5 @@
 import { GoogleAuth } from "google-auth-library";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { createWorkloadIdentityAccessTokenProvider } from "./ModelArmorClient";
 

--- a/packages/core/src/threatDetection/modelArmor/schema.ts
+++ b/packages/core/src/threatDetection/modelArmor/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const modelArmorCredentialsSchema = z
   .object({

--- a/packages/core/src/threatDetection/types.ts
+++ b/packages/core/src/threatDetection/types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const threatSeveritySchema = z.enum([
   "low",

--- a/packages/core/src/types/generation-parts.ts
+++ b/packages/core/src/types/generation-parts.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const enum GenerationPartType {
   AIGenerated = "aiGenerated",

--- a/packages/core/src/utils/ailaModeration/moderationSchema.ts
+++ b/packages/core/src/utils/ailaModeration/moderationSchema.ts
@@ -1,5 +1,5 @@
 import type { JsonValue } from "@prisma/client/runtime/library";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export type ModerationBase = {
   categories: JsonValue[];

--- a/packages/core/src/utils/getCaptionsFromFile.ts
+++ b/packages/core/src/utils/getCaptionsFromFile.ts
@@ -3,7 +3,7 @@ import { aiLogger } from "@oakai/logger";
 import { Storage } from "@google-cloud/storage";
 import type { Cue } from "webvtt-parser";
 import { WebVTTParser } from "webvtt-parser";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 const log = aiLogger("transcripts");
 

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -14,9 +14,9 @@
     "db-export": "DB_ENV=dev doppler run --config dev -- bash scripts/import-export/db_export.sh",
     "db-export:prd": "DB_ENV=prd doppler run --config prd -- bash scripts/import-export/db_export.sh",
     "db-export:stg": "DB_ENV=stg doppler run --config stg -- bash scripts/import-export/db_export.sh",
-    "db-generate": "echo 'Running db-generate...' && rm -f ./prisma/zod-schemas/*.ts && pnpm with-env prisma generate --schema=./prisma/schema.prisma",
-    "db-generate:dev": "rm -f ./prisma/zod-schemas/*.ts && pnpm with-env prisma generate",
-    "db-generate:no-engine": "echo 'Running db-generate:no-engine...' && rm -f ./prisma/zod-schemas/*.ts && pnpm with-env prisma generate --no-engine --schema=./prisma/schema.prisma",
+    "db-generate": "echo 'Running db-generate...' && rm -f ./prisma/zod-schemas/*.ts && pnpm with-env prisma generate --schema=./prisma/schema.prisma && node scripts/rewrite-generated-zod-import.mjs",
+    "db-generate:dev": "rm -f ./prisma/zod-schemas/*.ts && pnpm with-env prisma generate && node scripts/rewrite-generated-zod-import.mjs",
+    "db-generate:no-engine": "echo 'Running db-generate:no-engine...' && rm -f ./prisma/zod-schemas/*.ts && pnpm with-env prisma generate --no-engine --schema=./prisma/schema.prisma && node scripts/rewrite-generated-zod-import.mjs",
     "db-migrate": "pnpm with-env prisma migrate dev",
     "db-migrate-deploy": "pnpm with-env prisma migrate deploy",
     "db-migrate-resolve-applied:prd": "doppler run --config prd -- prisma migrate resolve --applied",
@@ -82,7 +82,8 @@
     "p-queue": "^7.4.1",
     "p-queue-compat": "^1.0.225",
     "ts-node": "^10.9.2",
-    "yaml": "^2.4.1"
+    "yaml": "^2.4.1",
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@oakai/eslint-config": "*",

--- a/packages/db/schemas/caption.ts
+++ b/packages/db/schemas/caption.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const Caption = z.object({
   start: z.number(),

--- a/packages/db/schemas/download.ts
+++ b/packages/db/schemas/download.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { ZLesson } from "./lesson";
 

--- a/packages/db/schemas/lesson-with-snippets.ts
+++ b/packages/db/schemas/lesson-with-snippets.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const LessonWithSnippets = z.object({
   lesson: z.object({

--- a/packages/db/schemas/lesson.ts
+++ b/packages/db/schemas/lesson.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { Programme } from "./programme";
 import { Quiz } from "./quiz";

--- a/packages/db/schemas/programme.ts
+++ b/packages/db/schemas/programme.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const Programme = z.object({
   id: z.number(),

--- a/packages/db/schemas/question.ts
+++ b/packages/db/schemas/question.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const Question = z.object({
   order: z.number(),

--- a/packages/db/schemas/quiz.ts
+++ b/packages/db/schemas/quiz.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { Question } from "./question";
 

--- a/packages/db/schemas/unit.ts
+++ b/packages/db/schemas/unit.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { Programme } from "./programme";
 

--- a/packages/db/schemas/video.ts
+++ b/packages/db/schemas/video.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const Video = z
   .object({

--- a/packages/db/scripts/import-export/validate_data.ts
+++ b/packages/db/scripts/import-export/validate_data.ts
@@ -10,7 +10,7 @@ import csvParser from "csv-parser";
 import dotenv from "dotenv";
 import * as fs from "fs";
 import * as path from "path";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { prisma } from "../..";
 

--- a/packages/db/scripts/processing/update_clerk_users.ts
+++ b/packages/db/scripts/processing/update_clerk_users.ts
@@ -1,6 +1,6 @@
 import { aiLogger } from "@oakai/logger";
 
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { prisma } from "../../";
 

--- a/packages/db/scripts/rewrite-generated-zod-import.mjs
+++ b/packages/db/scripts/rewrite-generated-zod-import.mjs
@@ -1,0 +1,37 @@
+// zod-prisma@0.5.4 hardcodes `import * as z from "zod"` in every generated
+// schema. Since this package now depends on zod 4 (to share one physical copy
+// with the rest of the monorepo), bare "zod" resolves to the v4 API, which
+// breaks the v3-style code zod-prisma emits (e.g. single-arg `z.record`).
+// Rewriting the import to the "zod/v3" compat subpath keeps the generated
+// schemas on the v3 API while staying the same physical zod@4 copy that app
+// code consumes via `zod/v3` — so db schemas and their consumers type-check.
+//
+// This runs as the last step of every `db-generate*` script, so a fresh
+// `prisma generate` can never reintroduce the broken import.
+import { readFileSync, readdirSync, writeFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const schemasDir = join(
+  dirname(fileURLToPath(import.meta.url)),
+  "..",
+  "prisma",
+  "zod-schemas",
+);
+
+const FROM = 'import * as z from "zod"';
+const TO = 'import * as z from "zod/v3"';
+
+let changed = 0;
+for (const file of readdirSync(schemasDir)) {
+  if (!file.endsWith(".ts")) continue;
+  const path = join(schemasDir, file);
+  const contents = readFileSync(path, "utf8");
+  if (!contents.includes(FROM)) continue;
+  writeFileSync(path, contents.replace(FROM, TO));
+  changed += 1;
+}
+
+console.log(
+  `Rewrote zod import to "zod/v3" in ${changed} generated schema(s).`,
+);

--- a/packages/exports/src/schema/additionalMaterialsDoc.schema.ts
+++ b/packages/exports/src/schema/additionalMaterialsDoc.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const additionalMaterialsTemplateSchema = z.object({
   lesson_title: z.string(),

--- a/packages/exports/src/schema/input.schema.ts
+++ b/packages/exports/src/schema/input.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { DeepPartial } from "../types";
 

--- a/packages/exports/src/schema/lessonPlanDocsTemplate.schema.ts
+++ b/packages/exports/src/schema/lessonPlanDocsTemplate.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const lessonPlanDocsTemplateSchema = z.object({
   lesson_title: z.string(),

--- a/packages/exports/src/schema/lessonSlidesTemplate.schema.ts
+++ b/packages/exports/src/schema/lessonSlidesTemplate.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const lessonSlidesTemplateSchema = z.object({
   lesson_title: z.string(),

--- a/packages/exports/src/schema/quizDocsTemplate.schema.ts
+++ b/packages/exports/src/schema/quizDocsTemplate.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 const questionCount = 6;
 const answerOptions = ["a", "b", "c"] as const;

--- a/packages/exports/src/schema/teachingMaterialsBlockSchema.schema.ts
+++ b/packages/exports/src/schema/teachingMaterialsBlockSchema.schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 // Simple block types - only title and placeholders are used now
 const title = z.object({

--- a/packages/gsuite/package.json
+++ b/packages/gsuite/package.json
@@ -17,7 +17,7 @@
     "@googleapis/slides": "^1.0.5",
     "dotenv-cli": "^6.0.0",
     "google-auth-library": "^9.7.0",
-    "zod": "3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@oakai/eslint-config": "workspace:*",

--- a/packages/gsuite/src/shared/auth.ts
+++ b/packages/gsuite/src/shared/auth.ts
@@ -1,5 +1,5 @@
 import { auth, drive } from "@googleapis/drive";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 /**
  * Environment variables schema for Google Service Account

--- a/packages/lesson-adapters/package.json
+++ b/packages/lesson-adapters/package.json
@@ -26,7 +26,7 @@
     "@oakai/logger": "*",
     "ai": "npm:ai@^6.0.48",
     "openai": "^6.45.0",
-    "zod": "3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@oakai/eslint-config": "*",

--- a/packages/lesson-adapters/src/agents/analyseKlpLearningCycles.ts
+++ b/packages/lesson-adapters/src/agents/analyseKlpLearningCycles.ts
@@ -1,6 +1,6 @@
 import { openai } from "@ai-sdk/openai";
 import { Output, generateText } from "ai";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { slideTypeSchema } from "../slides/extraction/schemas";
 import type { SlideContent } from "../slides/extraction/types";

--- a/packages/lesson-adapters/src/agents/classifierAgent.ts
+++ b/packages/lesson-adapters/src/agents/classifierAgent.ts
@@ -1,6 +1,6 @@
 import { openai } from "@ai-sdk/openai";
 import { Output, generateText } from "ai";
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const intentSchema = z.object({
   intent: z.enum([

--- a/packages/lesson-adapters/src/agents/slidesAgent/schemas.ts
+++ b/packages/lesson-adapters/src/agents/slidesAgent/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import type { SlideContent } from "../../slides/extraction/types";
 import { SUPPORTED_EDIT_TYPES } from "./intents";

--- a/packages/lesson-adapters/src/schemas/execution.ts
+++ b/packages/lesson-adapters/src/schemas/execution.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 /**
  * Execution result schemas

--- a/packages/lesson-adapters/src/schemas/history.ts
+++ b/packages/lesson-adapters/src/schemas/history.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 /**
  * History tracking schemas

--- a/packages/lesson-adapters/src/schemas/input.ts
+++ b/packages/lesson-adapters/src/schemas/input.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { slideDeckContentSchema } from "../slides/extraction/schemas";
 

--- a/packages/lesson-adapters/src/schemas/lesson.ts
+++ b/packages/lesson-adapters/src/schemas/lesson.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 /**
  * Schema for a complete lesson version

--- a/packages/lesson-adapters/src/schemas/plan.ts
+++ b/packages/lesson-adapters/src/schemas/plan.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { intentSchema } from "../agents/classifierAgent";
 

--- a/packages/lesson-adapters/src/slides/extraction/schemas.ts
+++ b/packages/lesson-adapters/src/slides/extraction/schemas.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 /**
  * Zod schemas for slide content types.

--- a/packages/lesson-adapters/src/slides/extraction/types.ts
+++ b/packages/lesson-adapters/src/slides/extraction/types.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import {
   nonTextElementTypeSchema,

--- a/packages/rag/getRagLessonPlansByIds/getRagLessonPlansByIds.test.ts
+++ b/packages/rag/getRagLessonPlansByIds/getRagLessonPlansByIds.test.ts
@@ -1,6 +1,6 @@
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 
-import { generateMock } from "@anatine/zod-mock";
+import { generateMock } from "../testUtils/generateMock";
 import * as Sentry from "@sentry/nextjs";
 
 import { CompletedLessonPlanSchema } from "../../aila/src/protocol/schema";

--- a/packages/rag/getRagLessonPlansByIds/getRagLessonPlansByIds.test.ts
+++ b/packages/rag/getRagLessonPlansByIds/getRagLessonPlansByIds.test.ts
@@ -1,11 +1,11 @@
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 
-import { generateMock } from "../testUtils/generateMock";
 import * as Sentry from "@sentry/nextjs";
 
 import { CompletedLessonPlanSchema } from "../../aila/src/protocol/schema";
 import { QuizV1Schema } from "../../aila/src/protocol/schemas/quiz/quizV1";
 import { QuizV2Schema } from "../../aila/src/protocol/schemas/quiz/quizV2";
+import { generateMock } from "../testUtils/generateMock";
 import { getRagLessonPlansByIds } from "./getRagLessonPlansByIds";
 
 jest.mock("@sentry/nextjs", () => ({

--- a/packages/rag/lib/search/parseResult.ts
+++ b/packages/rag/lib/search/parseResult.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { CompletedLessonPlanSchemaWithoutLength } from "../../../aila/src/protocol/schema";
 import type { DeepPartial, RagLessonPlanResult } from "../../types";

--- a/packages/rag/lib/search/search.test.ts
+++ b/packages/rag/lib/search/search.test.ts
@@ -1,8 +1,7 @@
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 
-import { generateMock } from "../../testUtils/generateMock";
-
 import { CompletedLessonPlanSchemaWithoutLength } from "../../../aila/src/protocol/schema";
+import { generateMock } from "../../testUtils/generateMock";
 import type { RagLogger } from "../../types";
 import { executePrismaQueryRaw } from "./executePrismaQueryRaw";
 import { vectorSearch } from "./search";

--- a/packages/rag/lib/search/search.test.ts
+++ b/packages/rag/lib/search/search.test.ts
@@ -1,6 +1,6 @@
 import type { PrismaClientWithAccelerate } from "@oakai/db";
 
-import { generateMock } from "@anatine/zod-mock";
+import { generateMock } from "../../testUtils/generateMock";
 
 import { CompletedLessonPlanSchemaWithoutLength } from "../../../aila/src/protocol/schema";
 import type { RagLogger } from "../../types";

--- a/packages/rag/package.json
+++ b/packages/rag/package.json
@@ -22,7 +22,7 @@
     "@oakai/logger": "*",
     "@oakai/prettier-config": "*",
     "@sentry/nextjs": "^10.29.0",
-    "zod": "3.25.76"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@oakai/test-support": "workspace:*",

--- a/packages/rag/testUtils/generateMock.ts
+++ b/packages/rag/testUtils/generateMock.ts
@@ -1,0 +1,24 @@
+import { generateMock as baseGenerateMock } from "@anatine/zod-mock";
+import type { z } from "zod/v3";
+
+/**
+ * Thin wrapper around @anatine/zod-mock.
+ *
+ * After the Zod 4 upgrade the library's types resolve to Zod 4 (it imports the
+ * bare `zod` specifier), but our schemas are still Zod 3. The single cast here
+ * bridges that type gap; at runtime the library reads the Zod 3 schema's `_def`
+ * exactly as before. Import from here instead of `@anatine/zod-mock` directly
+ * so the cast lives in one place.
+ *
+ * Alternative considered: `zocker` (Zod-4-native, has a dedicated `zod/v3`
+ * codepath so it accepts our schemas with no cast). It was tried and does
+ * generate valid data for our schemas at runtime, but it depends on the
+ * ESM-only `@faker-js/faker@10` and ships no `exports` map, so ts-jest
+ * resolves its CJS entry and crashes require()-ing ESM faker. Adopting it
+ * would need Jest ESM config changes, so for now the cast above is simpler.
+ */
+export function generateMock<T extends z.ZodTypeAny>(schema: T): z.infer<T> {
+  return baseGenerateMock(
+    schema as unknown as Parameters<typeof baseGenerateMock>[0],
+  ) as z.infer<T>;
+}

--- a/packages/teaching-materials/package.json
+++ b/packages/teaching-materials/package.json
@@ -26,13 +26,13 @@
     "@clerk/nextjs": "6.36.1",
     "@oakai/core": "*",
     "@oakai/logger": "*",
-    "@oaknational/oak-curriculum-schema": "1.61.0",
+    "@oaknational/oak-curriculum-schema": "2.15.0",
     "@sentry/nextjs": "^10.29.0",
     "ai": "^4.1.00",
     "dotenv-cli": "^6.0.0",
     "openai": "^6.45.0",
     "serialize-error": "^12.0.0",
-    "zod": "3.25.76",
+    "zod": "^4.4.3",
     "zod-to-json-schema": "^3.23.0"
   },
   "devDependencies": {

--- a/packages/teaching-materials/src/aiProviders/getGeneration.ts
+++ b/packages/teaching-materials/src/aiProviders/getGeneration.ts
@@ -1,6 +1,6 @@
 import { aiLogger } from "@oakai/logger";
 
-import { ZodError, type ZodType } from "zod";
+import { ZodError, type ZodType } from "zod/v3";
 
 import { type ProviderKey, providers } from ".";
 

--- a/packages/teaching-materials/src/aiProviders/openaiProvider.ts
+++ b/packages/teaching-materials/src/aiProviders/openaiProvider.ts
@@ -1,6 +1,6 @@
 import { openai } from "@ai-sdk/openai";
-import { generateObject } from "ai";
-import type { ZodSchema } from "zod";
+import { type Schema, generateObject } from "ai";
+import type { ZodSchema } from "zod/v3";
 
 export const OpenAIProvider = {
   async generateObject<T>({
@@ -14,7 +14,10 @@ export const OpenAIProvider = {
   }): Promise<T> {
     const { object } = await generateObject({
       prompt,
-      schema,
+      // The AI SDK's zod overload references z.ZodTypeDef, removed in Zod 4, so
+      // it no longer matches a Zod 3 schema. Cast to the SDK's own Schema<T>
+      // union branch instead; at runtime the SDK accepts the zod schema as-is.
+      schema: schema as unknown as Schema<T>,
       model: openai("gpt-4o"),
       system: systemMessage,
       mode: "json",

--- a/packages/teaching-materials/src/documents/documentConfig.ts
+++ b/packages/teaching-materials/src/documents/documentConfig.ts
@@ -1,4 +1,4 @@
-import type { ZodSchema } from "zod";
+import type { ZodSchema } from "zod/v3";
 
 export type DocumentConfig<T> = Record<
   string,

--- a/packages/teaching-materials/src/documents/partialLessonPlan/generateLessonPlan.ts
+++ b/packages/teaching-materials/src/documents/partialLessonPlan/generateLessonPlan.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { LessonPlanSchema } from "../../../../aila/src/protocol/schema";
 import type { ProviderKey } from "../../aiProviders";

--- a/packages/teaching-materials/src/documents/partialLessonPlan/schema.ts
+++ b/packages/teaching-materials/src/documents/partialLessonPlan/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { LessonPlanSchema } from "../../../../aila/src/protocol/schema";
 

--- a/packages/teaching-materials/src/documents/schemas/oakOpenApi.ts
+++ b/packages/teaching-materials/src/documents/schemas/oakOpenApi.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const oakOpenAiLessonSummarySchema = z.object({
   lessonTitle: z.string(),

--- a/packages/teaching-materials/src/documents/teachingMaterials/comprehension/schema.ts
+++ b/packages/teaching-materials/src/documents/teachingMaterials/comprehension/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { refinementSchema } from "../refinement/schema";
 import { baseContext } from "../sharedSchema";

--- a/packages/teaching-materials/src/documents/teachingMaterials/configSchema.ts
+++ b/packages/teaching-materials/src/documents/teachingMaterials/configSchema.ts
@@ -1,4 +1,4 @@
-import { type ZodSchema, type ZodType, z } from "zod";
+import { type ZodSchema, type ZodType, z } from "zod/v3";
 
 import {
   buildComprehensionPrompt,

--- a/packages/teaching-materials/src/documents/teachingMaterials/dataHelpers/transformDataForExports.ts
+++ b/packages/teaching-materials/src/documents/teachingMaterials/dataHelpers/transformDataForExports.ts
@@ -1,6 +1,6 @@
 import { aiLogger } from "@oakai/logger";
 
-import type { z } from "zod";
+import type { z } from "zod/v3";
 
 import { comprehensionTaskSchema } from "../comprehension/schema";
 import type { TeachingMaterialType } from "../configSchema";

--- a/packages/teaching-materials/src/documents/teachingMaterials/exitQuiz/schema.ts
+++ b/packages/teaching-materials/src/documents/teachingMaterials/exitQuiz/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { refinementSchema } from "../refinement/schema";
 import { baseContext, baseQuizSchema } from "../sharedSchema";

--- a/packages/teaching-materials/src/documents/teachingMaterials/glossary/schema.ts
+++ b/packages/teaching-materials/src/documents/teachingMaterials/glossary/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { refinementSchema } from "../refinement/schema";
 import { baseContext } from "../sharedSchema";

--- a/packages/teaching-materials/src/documents/teachingMaterials/materialTypes.ts
+++ b/packages/teaching-materials/src/documents/teachingMaterials/materialTypes.ts
@@ -2,7 +2,11 @@ import type {
   subjectSlugs,
   yearSlugs,
 } from "@oaknational/oak-curriculum-schema";
-import { type ZodType, type z } from "zod";
+// `z` must use the bare "zod" specifier to match how oak-curriculum-schema
+// imports zod, so z.infer can read its schema types. `ZodType` uses "zod/v3"
+// to match the Zod 3 material schemas assigned below.
+import { type z } from "zod";
+import { type ZodType } from "zod/v3";
 
 import type { PartialLessonPlanFieldKeyArray } from "../partialLessonPlan/schema";
 import {

--- a/packages/teaching-materials/src/documents/teachingMaterials/refinement/schema.ts
+++ b/packages/teaching-materials/src/documents/teachingMaterials/refinement/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 export const refinementMap = {
   lowerReadingAge: "Lower reading age",

--- a/packages/teaching-materials/src/documents/teachingMaterials/sharedSchema.ts
+++ b/packages/teaching-materials/src/documents/teachingMaterials/sharedSchema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { LessonPlanSchema } from "../../../../aila/src/protocol/schema";
 

--- a/packages/teaching-materials/src/documents/teachingMaterials/starterQuiz/schema.ts
+++ b/packages/teaching-materials/src/documents/teachingMaterials/starterQuiz/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "zod/v3";
 
 import { refinementSchema } from "../refinement/schema";
 import { baseContext, baseQuizSchema } from "../sharedSchema";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -150,10 +150,10 @@ importers:
         version: 2.36.0(next-cloudinary@6.17.4)(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)(styled-components@5.3.11)
       '@oaknational/oak-consent-client':
         specifier: ^2.1.0
-        version: 2.1.0(react-dom@19.2.1)(react@19.2.1)(zod@3.25.76)
+        version: 2.1.0(react-dom@19.2.1)(react@19.2.1)(zod@4.4.3)
       '@oaknational/oak-curriculum-schema':
-        specifier: 1.61.0
-        version: 1.61.0(zod@3.25.76)
+        specifier: 2.15.0
+        version: 2.15.0(zod@4.4.3)
       '@portabletext/react':
         specifier: ^3.1.0
         version: 3.1.0(react@19.2.1)
@@ -219,7 +219,7 @@ importers:
         version: 3.1.0
       ai:
         specifier: 4.0.20
-        version: 4.0.20(react@19.2.1)(zod@3.25.76)
+        version: 4.0.20(react@19.2.1)(zod@4.4.3)
       american-british-english-translator:
         specifier: ^0.2.1
         version: 0.2.1
@@ -294,7 +294,7 @@ importers:
         version: 3.0.0
       openai:
         specifier: ^6.45.0
-        version: 6.45.0(zod@3.25.76)
+        version: 6.45.0(zod@4.4.3)
       p-limit:
         specifier: ^7.2.0
         version: 7.2.0
@@ -380,11 +380,11 @@ importers:
         specifier: ^2.9.1
         version: 2.9.1(react-dom@19.2.1)(react@19.2.1)
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
       zod-to-json-schema:
-        specifier: ^3.23.0
-        version: 3.23.0(zod@3.25.76)
+        specifier: ^3.25.2
+        version: 3.25.2(zod@4.4.3)
       zustand:
         specifier: ^5.0.3
         version: 5.0.3(@types/react@19.2.7)(react@19.2.1)
@@ -487,7 +487,7 @@ importers:
     dependencies:
       '@anatine/zod-mock':
         specifier: ^3.13.4
-        version: 3.13.4(@faker-js/faker@9.4.0)(zod@3.25.76)
+        version: 3.13.4(@faker-js/faker@9.4.0)(zod@4.4.3)
       '@clerk/nextjs':
         specifier: 6.36.1
         version: 6.36.1(next@16.0.10)(react-dom@19.2.1)(react@19.2.1)
@@ -520,7 +520,7 @@ importers:
         version: 3.1.0
       ai:
         specifier: 4.0.20
-        version: 4.0.20(react@19.2.1)(zod@3.25.76)
+        version: 4.0.20(react@19.2.1)(zod@4.4.3)
       american-british-english-translator:
         specifier: ^0.2.1
         version: 0.2.1
@@ -541,7 +541,7 @@ importers:
         version: 3.8.0
       openai:
         specifier: ^6.45.0
-        version: 6.45.0(zod@3.25.76)
+        version: 6.45.0(zod@4.4.3)
       openapi-fetch:
         specifier: ^0.15.0
         version: 0.15.0
@@ -558,11 +558,11 @@ importers:
         specifier: ^1.3.1
         version: 1.3.1
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
       zod-to-json-schema:
-        specifier: ^3.23.0
-        version: 3.23.0(zod@3.25.76)
+        specifier: ^3.25.2
+        version: 3.25.2(zod@4.4.3)
     devDependencies:
       '@oakai/eslint-config':
         specifier: '*'
@@ -652,8 +652,8 @@ importers:
         specifier: ^1.9.1
         version: 1.12.0
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@oakai/eslint-config':
         specifier: '*'
@@ -735,7 +735,7 @@ importers:
         version: 0.1.4
       openai:
         specifier: ^6.45.0
-        version: 6.45.0(zod@3.25.76)
+        version: 6.45.0(zod@4.4.3)
       openapi-fetch:
         specifier: ^0.15.0
         version: 0.15.0
@@ -761,11 +761,11 @@ importers:
         specifier: ^2.2.0
         version: 2.2.0
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
       zod-to-json-schema:
         specifier: ^3.23.0
-        version: 3.23.0(zod@3.25.76)
+        version: 3.23.0(zod@4.4.3)
     devDependencies:
       '@oakai/prettier-config':
         specifier: '*'
@@ -989,8 +989,8 @@ importers:
         specifier: ^9.7.0
         version: 9.7.0
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@oakai/eslint-config':
         specifier: workspace:*
@@ -1015,7 +1015,7 @@ importers:
     dependencies:
       '@ai-sdk/openai':
         specifier: npm:@ai-sdk/openai@^3.0.0
-        version: 3.0.0(zod@3.25.76)
+        version: 3.0.0(zod@4.4.3)
       '@oakai/core':
         specifier: '*'
         version: link:../core
@@ -1030,13 +1030,13 @@ importers:
         version: link:../logger
       ai:
         specifier: npm:ai@^6.0.48
-        version: 6.0.48(zod@3.25.76)
+        version: 6.0.48(zod@4.4.3)
       openai:
         specifier: ^6.45.0
-        version: 6.45.0(zod@3.25.76)
+        version: 6.45.0(zod@4.4.3)
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@oakai/eslint-config':
         specifier: '*'
@@ -1095,7 +1095,7 @@ importers:
     dependencies:
       '@anatine/zod-mock':
         specifier: ^3.13.4
-        version: 3.13.4(@faker-js/faker@9.4.0)(zod@3.25.76)
+        version: 3.13.4(@faker-js/faker@9.4.0)(zod@4.4.3)
       '@faker-js/faker':
         specifier: ^9.4.0
         version: 9.4.0
@@ -1115,8 +1115,8 @@ importers:
         specifier: ^10.29.0
         version: 10.31.0(@opentelemetry/context-async-hooks@2.2.0)(@opentelemetry/core@2.2.0)(@opentelemetry/sdk-trace-base@2.2.0)(next@16.0.10)(react@19.2.1)(webpack@5.102.1)
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@oakai/test-support':
         specifier: workspace:*
@@ -1130,6 +1130,9 @@ importers:
       ts-jest:
         specifier: ^29.2.5
         version: 29.2.5(@babel/core@7.28.5)(jest@30.2.0)(typescript@5.9.2)
+      zocker:
+        specifier: ^3.0.0
+        version: 3.0.0(zod@4.4.3)
 
   packages/teaching-materials:
     dependencies:
@@ -1143,29 +1146,29 @@ importers:
         specifier: '*'
         version: link:../logger
       '@oaknational/oak-curriculum-schema':
-        specifier: 1.61.0
-        version: 1.61.0(zod@3.25.76)
+        specifier: 2.15.0
+        version: 2.15.0(zod@4.4.3)
       '@sentry/nextjs':
         specifier: ^10.29.0
         version: 10.31.0(@opentelemetry/context-async-hooks@2.2.0)(@opentelemetry/core@2.2.0)(@opentelemetry/sdk-trace-base@2.2.0)(next@16.0.10)(react@19.2.1)(webpack@5.102.1)
       ai:
         specifier: ^4.1.00
-        version: 4.1.59(react@19.2.1)(zod@3.25.76)
+        version: 4.1.59(react@19.2.1)(zod@4.4.3)
       dotenv-cli:
         specifier: ^6.0.0
         version: 6.0.0
       openai:
         specifier: ^6.45.0
-        version: 6.45.0(zod@3.25.76)
+        version: 6.45.0(zod@4.4.3)
       serialize-error:
         specifier: ^12.0.0
         version: 12.0.0
       zod:
-        specifier: 3.25.76
-        version: 3.25.76
+        specifier: ^4.4.3
+        version: 4.4.3
       zod-to-json-schema:
         specifier: ^3.23.0
-        version: 3.23.0(zod@3.25.76)
+        version: 3.23.0(zod@4.4.3)
     devDependencies:
       '@oakai/eslint-config':
         specifier: '*'
@@ -1255,16 +1258,16 @@ packages:
   /@adobe/css-tools@4.4.0:
     resolution: {integrity: sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==}
 
-  /@ai-sdk/gateway@3.0.22(zod@3.25.76):
+  /@ai-sdk/gateway@3.0.22(zod@4.4.3):
     resolution: {integrity: sha512-NgnlY73JNuooACHqUIz5uMOEWvqR1MMVbb2soGLMozLY1fgwEIF5iJFDAGa5/YArlzw2ATVU7zQu7HkR/FUjgA==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
     dependencies:
       '@ai-sdk/provider': 3.0.5
-      '@ai-sdk/provider-utils': 4.0.9(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.9(zod@4.4.3)
       '@vercel/oidc': 3.1.0
-      zod: 3.25.76
+      zod: 4.4.3
     dev: false
 
   /@ai-sdk/openai@0.0.72(zod@3.25.76):
@@ -1278,15 +1281,15 @@ packages:
       zod: 3.25.76
     dev: true
 
-  /@ai-sdk/openai@3.0.0(zod@3.25.76):
+  /@ai-sdk/openai@3.0.0(zod@4.4.3):
     resolution: {integrity: sha512-/o2xCQlRA+O0cAXIIBOfMeT35H6Fonzilz9r/IJojPOMQnmIL+0jPQVKOUPr5bouRqCjnwKpwuKEBRqm8jUZkQ==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
     dependencies:
       '@ai-sdk/provider': 3.0.0
-      '@ai-sdk/provider-utils': 4.0.0(zod@3.25.76)
-      zod: 3.25.76
+      '@ai-sdk/provider-utils': 4.0.0(zod@4.4.3)
+      zod: 4.4.3
     dev: false
 
   /@ai-sdk/provider-utils@1.0.22(zod@3.25.76):
@@ -1305,7 +1308,7 @@ packages:
       zod: 3.25.76
     dev: true
 
-  /@ai-sdk/provider-utils@2.0.4(zod@3.25.76):
+  /@ai-sdk/provider-utils@2.0.4(zod@4.4.3):
     resolution: {integrity: sha512-GMhcQCZbwM6RoZCri0MWeEWXRt/T+uCxsmHEsTwNvEH3GDjNzchfX25C8ftry2MeEOOn6KfqCLSKomcgK6RoOg==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -1318,10 +1321,10 @@ packages:
       eventsource-parser: 3.0.6
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
-      zod: 3.25.76
+      zod: 4.4.3
     dev: false
 
-  /@ai-sdk/provider-utils@2.1.12(zod@3.25.76):
+  /@ai-sdk/provider-utils@2.1.12(zod@4.4.3):
     resolution: {integrity: sha512-NLm2Ypkv419jR5TNOvZ057ciSYFKzSDEIIwE8cRyeR1Y5RbuX+auZveqGg6GWsDzvUnn6Xra7BJmr0422v60UA==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -1334,10 +1337,10 @@ packages:
       eventsource-parser: 3.0.6
       nanoid: 3.3.11
       secure-json-parse: 2.7.0
-      zod: 3.25.76
+      zod: 4.4.3
     dev: false
 
-  /@ai-sdk/provider-utils@4.0.0(zod@3.25.76):
+  /@ai-sdk/provider-utils@4.0.0(zod@4.4.3):
     resolution: {integrity: sha512-HyCyOls9I3a3e38+gtvOJOEjuw9KRcvbBnCL5GBuSmJvS9Jh9v3fz7pRC6ha1EUo/ZH1zwvLWYXBMtic8MTguA==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -1346,10 +1349,10 @@ packages:
       '@ai-sdk/provider': 3.0.0
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 3.25.76
+      zod: 4.4.3
     dev: false
 
-  /@ai-sdk/provider-utils@4.0.9(zod@3.25.76):
+  /@ai-sdk/provider-utils@4.0.9(zod@4.4.3):
     resolution: {integrity: sha512-bB4r6nfhBOpmoS9mePxjRoCy+LnzP3AfhyMGCkGL4Mn9clVNlqEeKj26zEKEtB6yoSVcT1IQ0Zh9fytwMCDnow==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -1358,7 +1361,7 @@ packages:
       '@ai-sdk/provider': 3.0.5
       '@standard-schema/spec': 1.1.0
       eventsource-parser: 3.0.6
-      zod: 3.25.76
+      zod: 4.4.3
     dev: false
 
   /@ai-sdk/provider@0.0.26:
@@ -1396,7 +1399,7 @@ packages:
       json-schema: 0.4.0
     dev: false
 
-  /@ai-sdk/react@1.0.6(react@19.2.1)(zod@3.25.76):
+  /@ai-sdk/react@1.0.6(react@19.2.1)(zod@4.4.3):
     resolution: {integrity: sha512-8Hkserq0Ge6AEi7N4hlv2FkfglAGbkoAXEZ8YSp255c3PbnZz6+/5fppw+aROmZMOfNwallSRuy1i/iPa2rBpQ==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -1408,15 +1411,15 @@ packages:
       zod:
         optional: true
     dependencies:
-      '@ai-sdk/provider-utils': 2.0.4(zod@3.25.76)
-      '@ai-sdk/ui-utils': 1.0.5(zod@3.25.76)
+      '@ai-sdk/provider-utils': 2.0.4(zod@4.4.3)
+      '@ai-sdk/ui-utils': 1.0.5(zod@4.4.3)
       react: 19.2.1
       swr: 2.3.4(react@19.2.1)
       throttleit: 2.1.0
-      zod: 3.25.76
+      zod: 4.4.3
     dev: false
 
-  /@ai-sdk/react@1.1.22(react@19.2.1)(zod@3.25.76):
+  /@ai-sdk/react@1.1.22(react@19.2.1)(zod@4.4.3):
     resolution: {integrity: sha512-+ZlmJBu9NH59wvAtuh+xXEJ2MEfisBpVbYwN347+VlJJ3LfHVH9Rp1d58jVwBsfJvDUMn5UMuHZIXIdQhJIBTg==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -1428,15 +1431,15 @@ packages:
       zod:
         optional: true
     dependencies:
-      '@ai-sdk/provider-utils': 2.1.12(zod@3.25.76)
-      '@ai-sdk/ui-utils': 1.1.18(zod@3.25.76)
+      '@ai-sdk/provider-utils': 2.1.12(zod@4.4.3)
+      '@ai-sdk/ui-utils': 1.1.18(zod@4.4.3)
       react: 19.2.1
       swr: 2.3.4(react@19.2.1)
       throttleit: 2.1.0
-      zod: 3.25.76
+      zod: 4.4.3
     dev: false
 
-  /@ai-sdk/ui-utils@1.0.5(zod@3.25.76):
+  /@ai-sdk/ui-utils@1.0.5(zod@4.4.3):
     resolution: {integrity: sha512-DGJSbDf+vJyWmFNexSPUsS1AAy7gtsmFmoSyNbNbJjwl9hRIf2dknfA1V0ahx6pg3NNklNYFm53L8Nphjovfvg==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -1446,12 +1449,12 @@ packages:
         optional: true
     dependencies:
       '@ai-sdk/provider': 1.0.2
-      '@ai-sdk/provider-utils': 2.0.4(zod@3.25.76)
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.1(zod@3.25.76)
+      '@ai-sdk/provider-utils': 2.0.4(zod@4.4.3)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     dev: false
 
-  /@ai-sdk/ui-utils@1.1.18(zod@3.25.76):
+  /@ai-sdk/ui-utils@1.1.18(zod@4.4.3):
     resolution: {integrity: sha512-PCDXKKKHqA8Oqm5LsXl3Byxmit0r0Gg3nMPI3bdEriDIExoQikULX2T6/IS5u1qNeoC3UK5F2acpCyl5Q+aIuQ==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -1461,9 +1464,9 @@ packages:
         optional: true
     dependencies:
       '@ai-sdk/provider': 1.0.10
-      '@ai-sdk/provider-utils': 2.1.12(zod@3.25.76)
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.1(zod@3.25.76)
+      '@ai-sdk/provider-utils': 2.1.12(zod@4.4.3)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     dev: false
 
   /@alloc/quick-lru@5.2.0:
@@ -1482,7 +1485,7 @@ packages:
       '@jridgewell/trace-mapping': 0.3.31
     dev: false
 
-  /@anatine/zod-mock@3.13.4(@faker-js/faker@9.4.0)(zod@3.25.76):
+  /@anatine/zod-mock@3.13.4(@faker-js/faker@9.4.0)(zod@4.4.3):
     resolution: {integrity: sha512-yO/KeuyYsEDCTcQ+7CiRuY3dnafMHIZUMok6Ci7aERRCTQ+/XmsiPk/RnMx5wlLmWBTmX9kw+PavbMsjM+sAJA==}
     peerDependencies:
       '@faker-js/faker': ^7.0.0 || ^8.0.0
@@ -1490,7 +1493,7 @@ packages:
     dependencies:
       '@faker-js/faker': 9.4.0
       randexp: 0.5.3
-      zod: 3.25.76
+      zod: 4.4.3
     dev: false
 
   /@anthropic-ai/sdk@0.27.3:
@@ -3604,7 +3607,7 @@ packages:
       openai: 4.96.0(zod@3.25.76)
       ws: 8.18.0
       zod: 3.24.2
-      zod-to-json-schema: 3.24.1(zod@3.24.2)
+      zod-to-json-schema: 3.25.2(zod@3.24.2)
     transitivePeerDependencies:
       - bufferutil
       - encoding
@@ -4654,6 +4657,11 @@ packages:
       '@playwright/test': 1.51.1
       ansi-to-html: 0.7.2
       marked: 12.0.2
+    dev: true
+
+  /@faker-js/faker@10.5.0:
+    resolution: {integrity: sha512-bsxD8WLS5lIj7aaoCx1YJkktqYj5vlBUE6HWzu2Q51ksrGJ0H737ECCKlFU7Yf8Br45z9t99frBp/J7kzbMPAg==}
+    engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
     dev: true
 
   /@faker-js/faker@9.4.0:
@@ -5950,7 +5958,7 @@ packages:
       p-retry: 4.6.2
       uuid: 9.0.1
       zod: 3.25.76
-      zod-to-json-schema: 3.24.1(zod@3.25.76)
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     dev: false
 
   /@langchain/openai@0.0.14:
@@ -5961,7 +5969,7 @@ packages:
       js-tiktoken: 1.0.7
       openai: 4.96.0(zod@3.25.76)
       zod: 3.25.76
-      zod-to-json-schema: 3.24.1(zod@3.25.76)
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - encoding
       - ws
@@ -6034,7 +6042,7 @@ packages:
       pkce-challenge: 5.0.0
       raw-body: 3.0.2
       zod: 3.25.76
-      zod-to-json-schema: 3.24.1(zod@3.25.76)
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -6407,7 +6415,7 @@ packages:
       styled-components: 5.3.11(@babel/core@7.28.5)(react-dom@19.2.1)(react-is@18.3.1)(react@19.2.1)
     dev: false
 
-  /@oaknational/oak-consent-client@2.1.0(react-dom@19.2.1)(react@19.2.1)(zod@3.25.76):
+  /@oaknational/oak-consent-client@2.1.0(react-dom@19.2.1)(react@19.2.1)(zod@4.4.3):
     resolution: {integrity: sha512-77AyUZoDQNgUFzUx2Vz8WaoCCmwwfBAfLm1o7FH1vXtvCXuh8szNjeM8uU0CVTVAwvRzy5BFyfKV4RTp8vVFqw==}
     peerDependencies:
       react: 18.x
@@ -6418,15 +6426,16 @@ packages:
       nanoid: 5.0.7
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
-      zod: 3.25.76
+      zod: 4.4.3
     dev: false
 
-  /@oaknational/oak-curriculum-schema@1.61.0(zod@3.25.76):
-    resolution: {integrity: sha512-pmwpN/z63+eXxuv8hOe2NZ04H8LRbEBc+ScLZysutctFUNQR1+Vdi4P7QNLuMDA1jETaHHurIgvFQ287HdsMGQ==}
+  /@oaknational/oak-curriculum-schema@2.15.0(zod@4.4.3):
+    resolution: {integrity: sha512-2vMCLjgcPNUCvpnUq08FdnmywjJUHhCRLLx0a4mdHECSYXX1+e98RjgaROO6P0M5GxaaqVY4OJkFajjA4dV4sw==}
     peerDependencies:
-      zod: ^3.22.4
+      zod: ^4.0.0
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
+      zod-to-camel-case: 0.5.0(zod@4.4.3)
     dev: false
 
   /@octokit/auth-token@4.0.0:
@@ -7407,12 +7416,12 @@ packages:
     resolution: {integrity: sha512-JTF99U/6XIjCBo0wqkU5sK10glYe27MRRsfwoiq5zzOEZLHU3A3KCMa5X/azekYRCJ0HlwI0crAXS/5dEHTzDg==}
     dev: false
 
-  /@radix-ui/primitive@1.1.4:
-    resolution: {integrity: sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==}
+  /@radix-ui/primitive@1.1.6:
+    resolution: {integrity: sha512-w9hl+724uYEgCGR3bhuRepjBtrNB/6gkhCnAf58Ke+SLbHPPQqVZZB59z60roB+5H+nh3nWTcdJhQdFMEydWmw==}
     dev: false
 
-  /@radix-ui/react-accessible-icon@1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-TraSwZUqTcVbiDV2/RXzAXC7aeVVXchq0daPFZE7zAxYFaMzjOUggLOfQH9KFLgRizuwVKZO/crveV1eeO3/ZQ==}
+  /@radix-ui/react-accessible-icon@1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-Y0zhCQ/XUdTom5hAxvE8RlXqR4hZmKGK6g2//LfgHmb88PJFOpXSh9B/7FlfYXezVY5FKGjRYWCYz5FXxZ9WZQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7424,7 +7433,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-visually-hidden': 1.2.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.1
@@ -7459,8 +7468,8 @@ packages:
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-alert-dialog@1.1.17(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-563ygGeyWPrxyVCNp7OV4rE2aIXhFPknpFyo4wbDlcyMMPZ6ySh+zC5WTvY0ZFLgPTg/QB6tA8PyDQyJ2b4cPg==}
+  /@radix-ui/react-alert-dialog@1.1.20(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-Ft1W+jPqSh5BKfSTe4dpq6UYQKKQJ5Tvq3wfux+WVlg7nPwFK/3pIlHTb3Rbe+b/tNurx8YGXD9em91ujmgwuQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7472,19 +7481,19 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.6
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-dialog': 1.1.17(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-dialog': 1.1.20(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-arrow@1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-j2VTDz1vgCsmuG0k5lBfOcM8n5JPFqZBcMryasFjHYMhwxYL5SRUV5lMSUpRdNtw3D/Sv8pzJtrlAgkssYSsQQ==}
+  /@radix-ui/react-arrow@1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-ltXCE0glRomMZ9+u10d9o1Go+edqa1aLxufH59JRNNM3Yz1uvaeNWSaS1HeVh1X64agtdBG5JA1W1I6ySqWiwA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7496,7 +7505,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.1
@@ -7523,8 +7532,8 @@ packages:
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-aspect-ratio@1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-kbI7NrqhDeuytYrq7JjAsoXczvL8wgj2tc1MyaYWm+50bMKHCHQtVWCryslx4cCpmCTTkBcwQckE4CmmGV2haQ==}
+  /@radix-ui/react-aspect-ratio@1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-Sok2IBJxA1XO4pU3ldzZMwUBMumIt64EY8zOUlVq5CdS+i0FrEbajVslfDB+YGWLMsrjY2kZQB0DgkrZXLZvcg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7536,15 +7545,15 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-avatar@1.2.0(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-am/CwltXtmtdtP+5FbYblYDnMa/zuKcMJP1i3/SJMDXXfj2mG+BTqLH2wucqeyyiQMursUtg/5cK+Nh2pCaSOA==}
+  /@radix-ui/react-avatar@1.2.3(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-peavtnApRB1tABx42tHw+rPU83GSg5tXicMYO/Xi1/lqNcRsF6jkr6L7Njo7gj4q/xtDRDKBkqJvbMtoOMYWtA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7556,8 +7565,9 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.7)(react@19.2.1)
@@ -7567,8 +7577,8 @@ packages:
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-checkbox@1.3.5(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-pREzrmNnVwGvYaBoM64huTRK7B3lrTRuwj8A9nwhPiEtMb+yudiWh6zWAqEtP0Dzd5+iBa1Ki7V1pCxV8ExMdA==}
+  /@radix-ui/react-checkbox@1.3.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-wfN60IGuxynWK7rP4Ks2p7u9G7gqirzkAiFptuzVbsR1ot2/K+PavNUAtxiKxyRfLOvSbVfvvm9m3rFqLEXz7A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7580,13 +7590,12 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.6
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -7621,8 +7630,8 @@ packages:
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-collection@1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-IVVz4EvBcKjrzKgof714qDnz/SzQAkLA2Emh5edlHbgcE6fNd3Un6CJLlaYcnm8N4JmAtzQgse4dOKxcD2yc9g==}
+  /@radix-ui/react-collection@1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-nb67INpE0IahJKN7EYPp9m9YGwYeKlnzxT3MwXVkgCskaSJia97kG4T0ywpjNUSSnoJk/uvk12V8vbrEHEj+/Q==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7635,8 +7644,8 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -7693,8 +7702,8 @@ packages:
       react: 19.2.1
     dev: false
 
-  /@radix-ui/react-context-menu@2.3.1(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-XbrxS68W5dyiE4fAb96yvJwSVU5x66B20A99sD5Mk3xSWK/LqeOnx6TZnim1KieMjXS/CTFq8reOAjWxas2G8Q==}
+  /@radix-ui/react-context-menu@2.3.4(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-eO9tkvHvo4dNwb+lytEcKWjy8c8To+ttLwNt0f9XzzsVFIaspqt3i1/c0JaaksxBB5G//zPo9CCgn39huWQyBA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7706,11 +7715,11 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-menu': 2.1.18(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-menu': 2.1.21(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.1
@@ -7730,8 +7739,8 @@ packages:
       react: 19.2.1
     dev: false
 
-  /@radix-ui/react-context@1.1.4(@types/react@19.2.7)(react@19.2.1):
-    resolution: {integrity: sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==}
+  /@radix-ui/react-context@1.2.0(@types/react@19.2.7)(react@19.2.1):
+    resolution: {integrity: sha512-fOE+JtN9rygNZkCnHRBEP0TAvLldlhyOxMsbwFvTP4nAs+nBmfnna+o/Zski2wkmY1YMrFC0aSzsHoLY47iLrg==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -7743,8 +7752,8 @@ packages:
       react: 19.2.1
     dev: false
 
-  /@radix-ui/react-dialog@1.1.17(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-TDTYmpdq8dI2+Xgvgj9AJ8Ghqq+Eph/TRVEdaFQPDItIY+6QSkU7MJMeevw1568Yw/2Ijz8BTphPSP2XejKphw==}
+  /@radix-ui/react-dialog@1.1.20(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-cngVJcvK0yMvR7wICJpv+1uW3Qw4T7QM5sdbb+oE/lxOdTdvF00oaRpWUjVgmjyXe3J+xh7eZyXZlVF3g2g59g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7756,18 +7765,19 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.6
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-focus-scope': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       aria-hidden: 1.2.6
@@ -7826,8 +7836,8 @@ packages:
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-dismissable-layer@1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-2v+zNAWWe0ySxgC0D0yeXMPQ23xZVgXZTerTz+JKlmdRj6gfTqmCcR29jb6d290DezXPGgruHWDX/vYUebtErg==}
+  /@radix-ui/react-dismissable-layer@1.1.16(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-t45h68IjFx0ccBnPJqk0X6ecv69LkCFWd6DNCFQX56mUnVEXZbNOLCH/u9fHlAjFZ1RrFdl8/m4zev7B7NyhXQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7839,19 +7849,19 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.6
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-use-escape-keydown': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-dropdown-menu@2.1.18(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-PZGV82gFk0WltDRI//SsG28ZIjlo9ANTmoNYg0jLNzXXiDsAy5PkOOYQaVD1pPxY6t7gxffb1QMD6qaUvsBZdw==}
+  /@radix-ui/react-dropdown-menu@2.1.21(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-gavFM1iWLmWdxWNdGJHVeWeSQul5WE/0pxfvWWt1QnD71hyyujyMCDVacqBomaSOjdxwDzYB+Ng4+MxOvrFB1A==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7863,13 +7873,13 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.6
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-menu': 2.1.18(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-menu': 2.1.21(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.1
@@ -7889,8 +7899,8 @@ packages:
       react: 19.2.1
     dev: false
 
-  /@radix-ui/react-focus-scope@1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-Fas/lXQqhVvqwAb64s5RFeHiHYElZ6SUQbZaNd6EkfhP/Al7wTIQ9WIR4QVX475tlu5yFCEdDcJH6/UwsZjMWw==}
+  /@radix-ui/react-focus-scope@1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-dE04aPEuP9rvKKT0d0KjSOtTEYNg6bmCYFsoSJpfC+y91Hic28ZfDCGgv6aJ+2Kw/LBXYipMZpyqVj/OD3Z8Gg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7903,7 +7913,7 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -7911,8 +7921,8 @@ packages:
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-form@0.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-1NfuvctVtX4sU3Mmq/IdrR8UunxiCMiVg3A5UENKhFzxUBeOyaQQ+lmaQaV7Tc8cqvBKsJL3/KGBsixK0D8WFg==}
+  /@radix-ui/react-form@0.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-PopvWqiutoZh5TJXk9EV9Wh+khbp+LQ+A0H4uHocIjVcKIi6gMlBy4sAaW15thwUSc6PrR8J62nB2uM+htqrcg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7924,20 +7934,20 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.6
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-label': 2.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-label': 2.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-hover-card@1.1.17(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-GjZQIEANVkuuWeztlKz6QEHe31ZX2iDfHzcTMCQVZXC0JyQrgfKWSC+LOOEw6aVV64zyjzobIzSA4AU4eKWrHA==}
+  /@radix-ui/react-hover-card@1.1.20(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-UPmdiR8NsngWjG/y9mClzFg+Rbbpy8u0p0SKM+t7mfH4V07TiLsuylqR0RhJiRibopsawoTtMQudm/TxwHWa9w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -7949,15 +7959,15 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.6
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-popper': 1.3.4(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.1
@@ -8000,8 +8010,8 @@ packages:
       react: 19.2.1
     dev: false
 
-  /@radix-ui/react-label@2.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-ib0zvq2ZsAqKm5tRnqGJn3vOxSgIts5ToxsXT0q1S/GfLD1Zj7UOEnkw8u2w6sRmn47djpQWuSU1DCL1R29/yw==}
+  /@radix-ui/react-label@2.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-dxioNQ7VOrYKKWJIxMRmJPDSWQN0gNCUy3zaqUSBwsuFAiFzI0yLGJr2q3ml07k/HlOk55N8KEfwa1ZgfprJ3w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8013,15 +8023,15 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-menu@2.1.18(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-lj8Rxjtn6zJq1oSbE/uDtAwCbB9BnxgHD+8MwJMuTh6u1dPamYhW9iuELr/Z8d0D/UysFblYYHeBPwi7T4k0YQ==}
+  /@radix-ui/react-menu@2.1.21(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-2BHtaJHvvoWTECyrja1mOjN6z2dWdpeHL6b8PxqZYgex8J8xakT2KAchpZIaMwNPauIRHH/VlPJYhSSKe8lz2g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8033,20 +8043,20 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-focus-scope': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-popper': 1.3.4(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-roving-focus': 1.1.16(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
@@ -8057,8 +8067,8 @@ packages:
       react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-popover@1.1.17(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-/YSAOdJ7YJvdn7bn5sdSx2egW+SKY+u7O5RyAVs94Ymrg2fg5QTSFPMRkzvhGyFuE4/qsmPBdrwYoZMZh/4f+g==}
+  /@radix-ui/react-popover@1.1.20(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-/PYqbsyuDkNj+IxMcRx71qNt6GelnuNulMwdCV7AtFEhUyK6XkbwreEN6CCLydMeTiDozBV4uv5aF5d12dDH7w==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8070,19 +8080,19 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.6
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-focus-scope': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-popper': 1.3.4(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       aria-hidden: 1.2.6
@@ -8120,8 +8130,8 @@ packages:
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-popper@1.3.1(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-bhnq/0DEPTi2lsOD3J5rTL65qUKHbKbhqHsmN9TMiclSXpipi651ooUKPPp6G5lF/WiHBdn1s0Wuqsn+myVAvw==}
+  /@radix-ui/react-popper@1.3.4(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-PXnCa3XgTQk0FegMctxgqJXtFLZe4IFJdbUkB7jKSCKEpb6utEO4S9Vog/pkyCfEPdzM331gvE4xpztmBAfMng==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8134,10 +8144,10 @@ packages:
         optional: true
     dependencies:
       '@floating-ui/react-dom': 2.1.6(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-arrow': 1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-arrow': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-rect': 1.1.2(@types/react@19.2.7)(react@19.2.1)
@@ -8149,8 +8159,8 @@ packages:
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-portal@1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-m309havGzsjLHHaIX50G5PlvRs3xkgPCsGk/5PTvYm8D5q33yG0J7w/712PTOhid7NTaFETtnSXjngHQavvhVw==}
+  /@radix-ui/react-portal@1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-REwjAGPMa3J9oyDE4cuWkZbwnCbbyky66NurquQklXMSDn67cl6oGFx2gO7KZhPtFNbNw9xTWNrti3VIhgluYw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8162,7 +8172,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -8212,8 +8222,8 @@ packages:
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-presence@1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==}
+  /@radix-ui/react-presence@1.1.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-0hhyrQdXMaATgq4ammLG9+iPqsXxzZkgTSIxdrJHdfLnXO4Uo5L7BoO3/Xf0AEaettadGZWGGJMw6ujzQvIpGA==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8252,8 +8262,8 @@ packages:
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-primitive@2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-wetd0QI77DbvrPpTAvH1SqOxsYF2wZe5TNxqwOd5Ty4XDpV3dpV0s8K/1MGMJBeY5o7lg8ub5VIt1Ub+yVen6g==}
+  /@radix-ui/react-primitive@2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-bC3NiwsprbxKjuon9l7X6BUTw7FPVzEYaL92MPEY5SCd/9hUTPXVFtVwRix7778wtRsVao+zE062gL79FZleeQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8272,8 +8282,8 @@ packages:
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-radio-group@1.4.1(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-/SSxZdKEo2Eo29FFRKd06EfFDYp8HryKg0WYg7QLXaydPzl52YfSvCH2a3QDBRdtcuwACroJT8UVjQVgOJ7P9A==}
+  /@radix-ui/react-radio-group@1.4.4(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-OpbUmp/korY+tjEQmHwGyQ+QQ3LBlCPC70z03Q/NSqGaHf2EijuwpjQPnswrH6cZLWyT2J6FmB+kzRoMUtPBig==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8285,15 +8295,14 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.6
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-roving-focus': 1.1.16(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -8301,8 +8310,8 @@ packages:
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-roving-focus@1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-9gkwneI0guf8JDmrFxPjJF6Ozzgioyw+/lonYNCwefS9ZHA05er0BVHiXr+LbWGHxUfczvMY6G1oiZZi1VzjRw==}
+  /@radix-ui/react-roving-focus@1.1.16(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-w7lLsTSd3940vFYEshKkHw+NGf7H0QDJPHYsy8NRjDCVbO6ZdKW1X/xoJSYHZtttnrdZiYqbN2O/2uHGB0zasw==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8314,23 +8323,25 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-is-hydrated': 0.1.1(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-scroll-area@1.2.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-xuafVzQiTCLsyEjakowTdG3OgTXsmO7IdCiO77otIa+z44xoLNs9Do5eg7POFumIOCjtG6djfm6RKUKpUa/csA==}
+  /@radix-ui/react-scroll-area@1.2.15(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-JVBHNfTBbGd9hhq/xZZOgmVnBCXhLs8PJJ8vMzgwI0pLZNsKckW9pkoqHyxokUCt1hoxbwDNvF9DItEeZsG68g==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8343,12 +8354,12 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/number': 1.1.2
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.6
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
@@ -8357,8 +8368,8 @@ packages:
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-select@2.3.1(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-w6eDvY78LE9ZUiNnXCA1QVK8RYN7k9galFv09kjVydJqBAgHd7Y9A6h0UJ/6DCZNGZMZrB2ohcSW1Bo9d8+wWA==}
+  /@radix-ui/react-select@2.3.4(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-E2JxqAvaTUEhWtBptWo02g8FnLYPymv9ahEvW/cZQPPV4ySeyo0M8n3sXccsLUAIfMbexnfXt91qF7UjTbTMMg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8371,25 +8382,25 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/number': 1.1.2
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-focus-guards': 1.1.4(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-focus-scope': 1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-focus-scope': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-popper': 1.3.4(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-visually-hidden': 1.2.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       aria-hidden: 1.2.6
@@ -8398,8 +8409,8 @@ packages:
       react-remove-scroll: 2.7.2(@types/react@19.2.7)(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-separator@1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-Y6K6jLQCVfCnTL2MEtGxDLffkhNfEfHsEg3Wa8JU+IWdn3EWbLXd3OuOfQRN7p/W/cUce1WyTk3QeuAoDBzN9g==}
+  /@radix-ui/react-separator@1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-2hezgFBBR5jU3S9L9bIZ9Uag6LnvxuFBNsLCfTR8qx+NshuvFmpL4C72+5zMS3Z6UgHNSU1thOw2UaBBPEDpsQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8411,15 +8422,15 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-slider@1.4.1(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-r91WSpQucNGFKAIxT8FT0H0zyjd5tJlqObLp7LOMV4z49KoDCwjy01w3vDOU4e1wxhF9IgjYco7SB6byOW7Buw==}
+  /@radix-ui/react-slider@1.4.4(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-8dUytW34KoJaB22ctfP7hqUCuyYa8xn2w7H8kCneeOtS5oM7UBivcnZtR8P4kPYMgdoAZlkMhE9/qkYZ5MlRzQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8432,13 +8443,13 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/number': 1.1.2
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-collection': 1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-collection': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.7)(react@19.2.1)
@@ -8476,8 +8487,8 @@ packages:
       react: 19.2.1
     dev: false
 
-  /@radix-ui/react-switch@1.3.1(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-55bQtCnOB0BohomSHi6qvQXpJEEqUGDm6hRrM0Bph5OXwhSegqkd8IqgBAQkM1IlgUlWZIxpxRcpOEfRIgimyw==}
+  /@radix-ui/react-switch@1.3.4(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-7iGMj1SfZBAc6xRiy0Y3Wr/v52viQeDhOmaM3fNRyNf2nbYooZA3kKoEDGLPtrDv8JitpzcueqdZLusVMojLdQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8489,12 +8500,11 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.6
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-use-previous': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-size': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -8502,8 +8512,8 @@ packages:
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-tabs@1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-kxc9gI6/HfcU4nfMMVS3AmQK414kbU1IE6UCJmMmxjhO3cRPXOyYnmvyKD+ODt7q56nRq9l7Wovi6uaGwKgMlg==}
+  /@radix-ui/react-tabs@1.1.18(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-1zq2XkQkK/KfbZn84edytYpOLquhNalra5LXc3NAMKhNRSGtyXqjMv6OyC9jlSuNKpqvQtsb57WKoICNk1v/sQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8515,22 +8525,22 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-roving-focus': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-roving-focus': 1.1.16(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.1
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-tooltip@1.2.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-NlNe8D0dWEpVfXFli90IO6X07Josx/b1iu98tDnx9Xv0HT4wLIL+m2VOheMHhK7qbp2HoTBqALEFzGyZs/levw==}
+  /@radix-ui/react-tooltip@1.2.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-56XPNYGMnGBcPyiBTaEXB7IGPybbsdNkFgSv90SCrHkXnu2Av1HhsyZMegzXlTu/QHA3V6/l22GZCv9iEoiqmQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8542,18 +8552,19 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/primitive': 1.1.4
+      '@radix-ui/primitive': 1.1.6
       '@radix-ui/react-compose-refs': 1.1.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-context': 1.1.4(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-dismissable-layer': 1.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-context': 1.2.0(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-dismissable-layer': 1.1.16(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-id': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-popper': 1.3.1(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-presence': 1.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-popper': 1.3.4(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-presence': 1.1.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-use-controllable-state': 1.2.3(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-use-controllable-state': 1.2.4(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.7)(react@19.2.1)
+      '@radix-ui/react-visually-hidden': 1.2.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.1
@@ -8632,8 +8643,8 @@ packages:
       react: 19.2.1
     dev: false
 
-  /@radix-ui/react-use-controllable-state@1.2.3(@types/react@19.2.7)(react@19.2.1):
-    resolution: {integrity: sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==}
+  /@radix-ui/react-use-controllable-state@1.2.4(@types/react@19.2.7)(react@19.2.1):
+    resolution: {integrity: sha512-cx2DixxmSfjCcEoRvDvy1NLd6SWK94XFcEEOZUcharUlXbmahFQGKCfwdKZL2ub34iIwOPOEFVF80xb+yfLYiA==}
     peerDependencies:
       '@types/react': '*'
       react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
@@ -8641,6 +8652,7 @@ packages:
       '@types/react':
         optional: true
     dependencies:
+      '@radix-ui/primitive': 1.1.6
       '@radix-ui/react-use-effect-event': 0.0.3(@types/react@19.2.7)(react@19.2.1)
       '@radix-ui/react-use-layout-effect': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
@@ -8685,20 +8697,6 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.7)(react@19.2.1)
-      '@types/react': 19.2.7
-      react: 19.2.1
-    dev: false
-
-  /@radix-ui/react-use-escape-keydown@1.1.2(@types/react@19.2.7)(react@19.2.1):
-    resolution: {integrity: sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==}
-    peerDependencies:
-      '@types/react': '*'
-      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@radix-ui/react-use-callback-ref': 1.1.2(@types/react@19.2.7)(react@19.2.1)
       '@types/react': 19.2.7
       react: 19.2.1
     dev: false
@@ -8831,8 +8829,8 @@ packages:
       react-dom: 19.2.1(react@19.2.1)
     dev: false
 
-  /@radix-ui/react-visually-hidden@1.2.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
-    resolution: {integrity: sha512-jCE0WljWifTI4niIMCll06kGpsJTAPiZVU9H4WR1N6qW7At9ystHbN7dDB+we2xH535roFHj7qKS+RGj0FMDWQ==}
+  /@radix-ui/react-visually-hidden@1.2.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1):
+    resolution: {integrity: sha512-FjsQEpkNBJJYiPSat6jh2LGKLPX2jAoDVS3AZSBNX3cOUoEGhw/f+z2FCY8Cf1NkoYIbytJ1f4mlWPQpR+MjVg==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -8844,7 +8842,7 @@ packages:
       '@types/react-dom':
         optional: true
     dependencies:
-      '@radix-ui/react-primitive': 2.1.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-primitive': 2.1.7(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       react: 19.2.1
@@ -8873,30 +8871,30 @@ packages:
         optional: true
     dependencies:
       '@radix-ui/colors': 2.0.1
-      '@radix-ui/primitive': 1.1.4
-      '@radix-ui/react-accessible-icon': 1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-alert-dialog': 1.1.17(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-aspect-ratio': 1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-avatar': 1.2.0(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-checkbox': 1.3.5(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-context-menu': 2.3.1(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-dialog': 1.1.17(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/primitive': 1.1.6
+      '@radix-ui/react-accessible-icon': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-alert-dialog': 1.1.20(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-aspect-ratio': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-avatar': 1.2.3(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-checkbox': 1.3.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-context-menu': 2.3.4(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-dialog': 1.1.20(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-direction': 1.1.2(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-dropdown-menu': 2.1.18(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-form': 0.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-hover-card': 1.1.17(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-popover': 1.1.17(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-portal': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-radio-group': 1.4.1(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-scroll-area': 1.2.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-select': 2.3.1(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-separator': 1.1.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-slider': 1.4.1(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-dropdown-menu': 2.1.21(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-form': 0.1.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-hover-card': 1.1.20(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-popover': 1.1.20(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-portal': 1.1.14(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-radio-group': 1.4.4(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-scroll-area': 1.2.15(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-select': 2.3.4(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-separator': 1.1.12(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-slider': 1.4.4(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@radix-ui/react-slot': 1.3.0(@types/react@19.2.7)(react@19.2.1)
-      '@radix-ui/react-switch': 1.3.1(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-tabs': 1.1.15(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-tooltip': 1.2.10(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
-      '@radix-ui/react-visually-hidden': 1.2.6(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-switch': 1.3.4(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-tabs': 1.1.18(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-tooltip': 1.2.13(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
+      '@radix-ui/react-visually-hidden': 1.2.8(@types/react-dom@19.2.3)(@types/react@19.2.7)(react-dom@19.2.1)(react@19.2.1)
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
       classnames: 2.3.2
@@ -9641,7 +9639,7 @@ packages:
       '@sentry/react': 10.31.0(react@19.2.1)
       '@sentry/vercel-edge': 10.31.0
       '@sentry/webpack-plugin': 4.6.1(webpack@5.102.1)
-      next: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.1)(react@19.2.1)
+      next: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.1)(react@19.2.1)
       resolve: 1.22.8
       rollup: 4.53.5
       stacktrace-parser: 0.1.10
@@ -12107,7 +12105,7 @@ packages:
       indent-string: 5.0.0
     dev: true
 
-  /ai@4.0.20(react@19.2.1)(zod@3.25.76):
+  /ai@4.0.20(react@19.2.1)(zod@4.4.3):
     resolution: {integrity: sha512-dYevYKtREcjSVopBDFWVNca7WJEI1p9Vr9eo7V7fZHzi2vXGDyEa2WYatjFbpR6z6gpVAxKHsof8EoN+B1IAsA==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -12120,17 +12118,17 @@ packages:
         optional: true
     dependencies:
       '@ai-sdk/provider': 1.0.2
-      '@ai-sdk/provider-utils': 2.0.4(zod@3.25.76)
-      '@ai-sdk/react': 1.0.6(react@19.2.1)(zod@3.25.76)
-      '@ai-sdk/ui-utils': 1.0.5(zod@3.25.76)
+      '@ai-sdk/provider-utils': 2.0.4(zod@4.4.3)
+      '@ai-sdk/react': 1.0.6(react@19.2.1)(zod@4.4.3)
+      '@ai-sdk/ui-utils': 1.0.5(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
       jsondiffpatch: 0.6.0
       react: 19.2.1
-      zod: 3.25.76
-      zod-to-json-schema: 3.24.1(zod@3.25.76)
+      zod: 4.4.3
+      zod-to-json-schema: 3.25.2(zod@4.4.3)
     dev: false
 
-  /ai@4.1.59(react@19.2.1)(zod@3.25.76):
+  /ai@4.1.59(react@19.2.1)(zod@4.4.3):
     resolution: {integrity: sha512-8lpm3YS/f9yWsHcEDeJqVZd7Ds5t22dbWecSQ3+TyHCutpUSAEykN+B0NZFjOoR7xXWxrmNPl1v8GBKmKNAePg==}
     engines: {node: '>=18'}
     peerDependencies:
@@ -12143,27 +12141,27 @@ packages:
         optional: true
     dependencies:
       '@ai-sdk/provider': 1.0.10
-      '@ai-sdk/provider-utils': 2.1.12(zod@3.25.76)
-      '@ai-sdk/react': 1.1.22(react@19.2.1)(zod@3.25.76)
-      '@ai-sdk/ui-utils': 1.1.18(zod@3.25.76)
+      '@ai-sdk/provider-utils': 2.1.12(zod@4.4.3)
+      '@ai-sdk/react': 1.1.22(react@19.2.1)(zod@4.4.3)
+      '@ai-sdk/ui-utils': 1.1.18(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
       eventsource-parser: 3.0.6
       jsondiffpatch: 0.6.0
       react: 19.2.1
-      zod: 3.25.76
+      zod: 4.4.3
     dev: false
 
-  /ai@6.0.48(zod@3.25.76):
+  /ai@6.0.48(zod@4.4.3):
     resolution: {integrity: sha512-nON0rHNTEQgzT1HahGl7AeszJh7es5ibZ6LWqm3IiN+bUAQtXkdArXD9vDlVAPBiCd7ERclZ6lUpOE6ltgJb3w==}
     engines: {node: '>=18'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
     dependencies:
-      '@ai-sdk/gateway': 3.0.22(zod@3.25.76)
+      '@ai-sdk/gateway': 3.0.22(zod@4.4.3)
       '@ai-sdk/provider': 3.0.5
-      '@ai-sdk/provider-utils': 4.0.9(zod@3.25.76)
+      '@ai-sdk/provider-utils': 4.0.9(zod@4.4.3)
       '@opentelemetry/api': 1.9.0
-      zod: 3.25.76
+      zod: 4.4.3
     dev: false
 
   /ajv-formats@2.1.1(ajv@8.17.1):
@@ -15018,7 +15016,6 @@ packages:
   /drange@1.1.1:
     resolution: {integrity: sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==}
     engines: {node: '>=4'}
-    dev: false
 
   /dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -15863,8 +15860,8 @@ packages:
       '@babel/parser': 7.28.5
       eslint: 9.36.0
       hermes-parser: 0.25.1
-      zod: 3.25.76
-      zod-validation-error: 4.0.2(zod@3.25.76)
+      zod: 4.4.3
+      zod-validation-error: 4.0.2(zod@4.4.3)
     transitivePeerDependencies:
       - supports-color
     dev: true
@@ -20325,7 +20322,7 @@ packages:
       uuid: 9.0.1
       yaml: 2.4.1
       zod: 3.25.76
-      zod-to-json-schema: 3.24.1(zod@3.25.76)
+      zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
       - encoding
     dev: false
@@ -22139,6 +22136,29 @@ packages:
       zod: 3.25.76
     dev: false
 
+  /openai@6.45.0(zod@4.4.3):
+    resolution: {integrity: sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==}
+    peerDependencies:
+      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
+      '@smithy/hash-node': '>=4.3.0 <5'
+      '@smithy/signature-v4': '>=5.4.0 <6'
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      '@aws-sdk/credential-provider-node':
+        optional: true
+      '@smithy/hash-node':
+        optional: true
+      '@smithy/signature-v4':
+        optional: true
+      ws:
+        optional: true
+      zod:
+        optional: true
+    dependencies:
+      zod: 4.4.3
+    dev: false
+
   /openapi-fetch@0.15.0:
     resolution: {integrity: sha512-OjQUdi61WO4HYhr9+byCPMj0+bgste/LtSBEcV6FzDdONTs7x0fWn8/ndoYwzqCsKWIxEZwo4FN/TG1c1rI8IQ==}
     dependencies:
@@ -23432,7 +23452,6 @@ packages:
     dependencies:
       drange: 1.1.1
       ret: 0.2.2
-    dev: false
 
   /randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -24190,7 +24209,6 @@ packages:
   /ret@0.2.2:
     resolution: {integrity: sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==}
     engines: {node: '>=4'}
-    dev: false
 
   /retry-request@7.0.2:
     resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
@@ -27482,6 +27500,16 @@ packages:
       readable-stream: 4.4.2
     dev: false
 
+  /zocker@3.0.0(zod@4.4.3):
+    resolution: {integrity: sha512-xSJz2M9AELZKzgpuuZPbTQdMv9263p/zSHDIj81B58X3334Xl6iJ/C3u6OQiOlsrWAoJSJsveBcIdz1eEPL0EA==}
+    peerDependencies:
+      zod: ^3.25.0 || ^4.0.0
+    dependencies:
+      '@faker-js/faker': 10.5.0
+      randexp: 0.5.3
+      zod: 4.4.3
+    dev: true
+
   /zod-prisma@0.5.4(prisma@6.3.1)(zod@3.25.76):
     resolution: {integrity: sha512-5Ca4Qd1a1jy1T/NqCEpbr0c+EsbjJfJ/7euEHob3zDvtUK2rTuD1Rc/vfzH8q8PtaR2TZbysD88NHmrLwpv3Xg==}
     engines: {node: '>=14'}
@@ -27501,36 +27529,53 @@ packages:
       zod: 3.25.76
     dev: true
 
-  /zod-to-json-schema@3.23.0(zod@3.25.76):
+  /zod-to-camel-case@0.5.0(zod@4.4.3):
+    resolution: {integrity: sha512-IaVeFsfly59+8mgu5uh+J/0AeKXboZau3IKfojF5lYE/IpevpJOSX3q/XX2P7jXHmP1Fg/VrSg+7Wv3UbjOgmg==}
+    engines: {node: '>=20.x'}
+    peerDependencies:
+      zod: ^4.3.6
+    dependencies:
+      zod: 4.4.3
+    dev: false
+
+  /zod-to-json-schema@3.23.0(zod@4.4.3):
     resolution: {integrity: sha512-az0uJ243PxsRIa2x1WmNE/pnuA05gUq/JB8Lwe1EDCCL/Fz9MgjYQ0fPlyc2Tcv6aF2ZA7WM5TWaRZVEFaAIag==}
     peerDependencies:
       zod: ^3.23.3
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
     dev: false
 
-  /zod-to-json-schema@3.24.1(zod@3.24.2):
-    resolution: {integrity: sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==}
+  /zod-to-json-schema@3.25.2(zod@3.24.2):
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
-      zod: ^3.24.1
+      zod: ^3.25.28 || ^4
     dependencies:
       zod: 3.24.2
     dev: true
 
-  /zod-to-json-schema@3.24.1(zod@3.25.76):
-    resolution: {integrity: sha512-3h08nf3Vw3Wl3PK+q3ow/lIil81IT2Oa7YpQyUUDsEWbXveMesdfK1xBd2RhCkynwZndAxixji/7SYJJowr62w==}
+  /zod-to-json-schema@3.25.2(zod@3.25.76):
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
     peerDependencies:
-      zod: ^3.24.1
+      zod: ^3.25.28 || ^4
     dependencies:
       zod: 3.25.76
 
-  /zod-validation-error@4.0.2(zod@3.25.76):
+  /zod-to-json-schema@3.25.2(zod@4.4.3):
+    resolution: {integrity: sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==}
+    peerDependencies:
+      zod: ^3.25.28 || ^4
+    dependencies:
+      zod: 4.4.3
+    dev: false
+
+  /zod-validation-error@4.0.2(zod@4.4.3):
     resolution: {integrity: sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ==}
     engines: {node: '>=18.0.0'}
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
     dependencies:
-      zod: 3.25.76
+      zod: 4.4.3
     dev: true
 
   /zod@3.24.2:
@@ -27539,6 +27584,9 @@ packages:
 
   /zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  /zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
   /zustand@5.0.3(@types/react@19.2.7)(react@19.2.1):
     resolution: {integrity: sha512-14fwWQtU3pH4dE0dOpdMiWjddcH+QzKIgk1cl8epwSE7yag43k/AD/m4L6+K7DytAOr9gGBe3/EXj9g7cdostg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1130,9 +1130,6 @@ importers:
       ts-jest:
         specifier: ^29.2.5
         version: 29.2.5(@babel/core@7.28.5)(jest@30.2.0)(typescript@5.9.2)
-      zocker:
-        specifier: ^3.0.0
-        version: 3.0.0(zod@4.4.3)
 
   packages/teaching-materials:
     dependencies:
@@ -4657,11 +4654,6 @@ packages:
       '@playwright/test': 1.51.1
       ansi-to-html: 0.7.2
       marked: 12.0.2
-    dev: true
-
-  /@faker-js/faker@10.5.0:
-    resolution: {integrity: sha512-bsxD8WLS5lIj7aaoCx1YJkktqYj5vlBUE6HWzu2Q51ksrGJ0H737ECCKlFU7Yf8Br45z9t99frBp/J7kzbMPAg==}
-    engines: {node: ^20.19.0 || ^22.13.0 || ^23.5.0 || >=24.0.0, npm: '>=10'}
     dev: true
 
   /@faker-js/faker@9.4.0:
@@ -9639,7 +9631,7 @@ packages:
       '@sentry/react': 10.31.0(react@19.2.1)
       '@sentry/vercel-edge': 10.31.0
       '@sentry/webpack-plugin': 4.6.1(webpack@5.102.1)
-      next: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.56.1)(react-dom@19.2.1)(react@19.2.1)
+      next: 16.0.10(@babel/core@7.28.5)(@opentelemetry/api@1.9.0)(@playwright/test@1.51.1)(react-dom@19.2.1)(react@19.2.1)
       resolve: 1.22.8
       rollup: 4.53.5
       stacktrace-parser: 0.1.10
@@ -15016,6 +15008,7 @@ packages:
   /drange@1.1.1:
     resolution: {integrity: sha512-pYxfDYpued//QpnLIm4Avk7rsNtAtQkUES2cwAYSvD/wd2pKD71gN2Ebj3e7klzXwjocvE8c5vx/1fxwpqmSxA==}
     engines: {node: '>=4'}
+    dev: false
 
   /dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
@@ -23452,6 +23445,7 @@ packages:
     dependencies:
       drange: 1.1.1
       ret: 0.2.2
+    dev: false
 
   /randombytes@2.1.0:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
@@ -24209,6 +24203,7 @@ packages:
   /ret@0.2.2:
     resolution: {integrity: sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==}
     engines: {node: '>=4'}
+    dev: false
 
   /retry-request@7.0.2:
     resolution: {integrity: sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==}
@@ -27499,16 +27494,6 @@ packages:
       compress-commons: 6.0.2
       readable-stream: 4.4.2
     dev: false
-
-  /zocker@3.0.0(zod@4.4.3):
-    resolution: {integrity: sha512-xSJz2M9AELZKzgpuuZPbTQdMv9263p/zSHDIj81B58X3334Xl6iJ/C3u6OQiOlsrWAoJSJsveBcIdz1eEPL0EA==}
-    peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
-    dependencies:
-      '@faker-js/faker': 10.5.0
-      randexp: 0.5.3
-      zod: 4.4.3
-    dev: true
 
   /zod-prisma@0.5.4(prisma@6.3.1)(zod@3.25.76):
     resolution: {integrity: sha512-5Ca4Qd1a1jy1T/NqCEpbr0c+EsbjJfJ/7euEHob3zDvtUK2rTuD1Rc/vfzH8q8PtaR2TZbysD88NHmrLwpv3Xg==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -811,7 +811,7 @@ importers:
         version: 6.1.0(graphql@16.12.0)
       openai:
         specifier: ^6.45.0
-        version: 6.45.0(zod@3.25.76)
+        version: 6.45.0(zod@4.4.3)
       p-queue:
         specifier: ^7.4.1
         version: 7.4.1
@@ -824,6 +824,9 @@ importers:
       yaml:
         specifier: ^2.4.1
         version: 2.4.1
+      zod:
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@oakai/eslint-config':
         specifier: '*'
@@ -842,7 +845,7 @@ importers:
         version: 5.9.2
       zod-prisma:
         specifier: ^0.5.4
-        version: 0.5.4(prisma@6.3.1)(zod@3.25.76)
+        version: 0.5.4(prisma@6.3.1)(zod@4.4.3)
 
   packages/eslint-config:
     devDependencies:
@@ -1496,7 +1499,7 @@ packages:
   /@anthropic-ai/sdk@0.27.3:
     resolution: {integrity: sha512-IjLt0gd3L4jlOfilxVXTifn42FnVffMgDC04RJK1KDZpmkBWLv0XC92MVVmkxrFZNS/7l3xWgP/I3nqtX1sQHw==}
     dependencies:
-      '@types/node': 18.19.75
+      '@types/node': 18.19.80
       '@types/node-fetch': 2.6.4
       abort-controller: 3.0.0
       agentkeepalive: 4.5.0
@@ -1510,7 +1513,7 @@ packages:
   /@anthropic-ai/sdk@0.39.0:
     resolution: {integrity: sha512-eMyDIPRZbt1CCLErRCi3exlAvNkBtRe+kW5vvJyef93PmNr/clstYgHhtvmkxN82nlKgzyGPCyGxrm0JQ1ZIdg==}
     dependencies:
-      '@types/node': 18.19.75
+      '@types/node': 18.19.80
       '@types/node-fetch': 2.6.4
       abort-controller: 3.0.0
       agentkeepalive: 4.5.0
@@ -1524,7 +1527,7 @@ packages:
   /@anthropic-ai/sdk@0.6.8:
     resolution: {integrity: sha512-z4gDFrBf+W2wOVvwA3CA+5bfKOxQhPeXQo7+ITWj3r3XPulIMEasVT0KrD41G+anr5Yc3d2PKvXKB6b1LSon5w==}
     dependencies:
-      '@types/node': 18.19.75
+      '@types/node': 18.19.80
       '@types/node-fetch': 2.6.4
       abort-controller: 3.0.0
       agentkeepalive: 4.5.0
@@ -3576,7 +3579,7 @@ packages:
   /@browserbasehq/sdk@2.4.0:
     resolution: {integrity: sha512-o1+6C4MQCpZ9+8je1IUF9UvWLuSzLcBjE1kPfu2sw7MgRFNFJS1NcWCiEmjZe71ke4CNojZWaU7XTNxh8z2PUw==}
     dependencies:
-      '@types/node': 18.19.75
+      '@types/node': 18.19.80
       '@types/node-fetch': 2.6.4
       abort-controller: 3.0.0
       agentkeepalive: 4.5.0
@@ -5943,7 +5946,7 @@ packages:
       ansi-styles: 5.2.0
       camelcase: 6.3.0
       decamelize: 1.2.0
-      js-tiktoken: 1.0.10
+      js-tiktoken: 1.0.14
       langsmith: 0.1.3
       ml-distance: 4.0.1
       p-queue: 6.6.2
@@ -5958,7 +5961,7 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       '@langchain/core': 0.1.30
-      js-tiktoken: 1.0.7
+      js-tiktoken: 1.0.14
       openai: 4.96.0(zod@3.25.76)
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
@@ -11051,8 +11054,8 @@ packages:
     resolution: {integrity: sha512-4slmbtwV59ZxitY4ixUZdy1uRLf9eSIvBWPQxNjhHYWEtn0FryfKpyS2cvADYXTayWdKEIsJengncrVvkI4I6A==}
     dev: false
 
-  /@types/node@18.19.75:
-    resolution: {integrity: sha512-UIksWtThob6ZVSyxcOqCLOUNg/dyO1Qvx4McgeuhrEtHTLFTf7BBhEazaE4K806FGTPtzd/2sE90qn4fVr7cyw==}
+  /@types/node@18.19.80:
+    resolution: {integrity: sha512-kEWeMwMeIvxYkeg1gTc01awpwLbfMRZXdIhwRcakd/KlK53jmRC26LqcbIt7fnAQTu5GzlnWmzA3H6+l1u6xxQ==}
     dependencies:
       undici-types: 5.26.5
 
@@ -12667,7 +12670,7 @@ packages:
     resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
     dependencies:
       follow-redirects: 1.15.9
-      form-data: 4.0.4
+      form-data: 4.0.6
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
       - debug
@@ -12947,11 +12950,6 @@ packages:
 
   /bignumber.js@9.1.2:
     resolution: {integrity: sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==}
-
-  /binary-extensions@2.2.0:
-    resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
-    engines: {node: '>=8'}
-    dev: false
 
   /binary-extensions@2.3.0:
     resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
@@ -14179,7 +14177,7 @@ packages:
     dependencies:
       '@cspell/cspell-types': 8.17.5
       comment-json: 4.2.5
-      yaml: 2.7.0
+      yaml: 2.8.1
     dev: true
 
   /cspell-dictionary@8.17.5:
@@ -15202,7 +15200,7 @@ packages:
       has-property-descriptors: 1.0.2
       has-proto: 1.0.1
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       internal-slot: 1.0.7
       is-array-buffer: 3.0.4
       is-callable: 1.2.7
@@ -15253,7 +15251,7 @@ packages:
       has-property-descriptors: 1.0.2
       has-proto: 1.0.3
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       internal-slot: 1.0.7
       is-array-buffer: 3.0.4
       is-callable: 1.2.7
@@ -15307,7 +15305,7 @@ packages:
       has-property-descriptors: 1.0.2
       has-proto: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       internal-slot: 1.1.0
       is-array-buffer: 3.0.5
       is-callable: 1.2.7
@@ -15399,19 +15397,19 @@ packages:
       es-errors: 1.3.0
       get-intrinsic: 1.3.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
 
   /es-shim-unscopables@1.0.2:
     resolution: {integrity: sha512-J3yBRXCzDu4ULnQwxyToo/OjdMx6akgVC7K6few0a7F/0wLtmKKN7I73AH5T2836UuXRqN7Qg+IIUw/+YJksRw==}
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
     dev: true
 
   /es-shim-unscopables@1.1.0:
     resolution: {integrity: sha512-d9T8ucsEhh8Bi1woXCf+TIKDIROLG5WCkxg8geBCbvk22kzwC5G2OnXVMO6FUsvQlgUUXQ2itephWDLqDzbeCw==}
     engines: {node: '>= 0.4'}
     dependencies:
-      hasown: 2.0.2
+      hasown: 2.0.4
     dev: true
 
   /es-to-primitive@1.2.1:
@@ -16084,6 +16082,11 @@ packages:
 
   /eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
+    dev: false
+
+  /eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
+    dev: true
 
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
@@ -16744,6 +16747,17 @@ packages:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
+    dev: false
+
+  /form-data@4.0.6:
+    resolution: {integrity: sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.4
+      mime-types: 2.1.35
 
   /format@0.2.2:
     resolution: {integrity: sha512-wzsgA6WOq+09wrU1tsJ09udeR/YZRaeArL9e1wPbFg3GG2yDnC2ldKpxs4xunpFF9DgqCqOIra3bc1HWrJ37Ww==}
@@ -16891,7 +16905,7 @@ packages:
       call-bound: 1.0.4
       define-properties: 1.2.1
       functions-have-names: 1.2.3
-      hasown: 2.0.2
+      hasown: 2.0.4
       is-callable: 1.2.7
     dev: true
 
@@ -16997,7 +17011,7 @@ packages:
       get-proto: 1.0.1
       gopd: 1.2.0
       has-symbols: 1.1.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       math-intrinsics: 1.1.0
 
   /get-it@8.6.5:
@@ -17308,7 +17322,7 @@ packages:
       gcp-metadata: 7.0.1
       google-logging-utils: 1.1.1
       gtoken: 8.0.0
-      jws: 4.0.0
+      jws: 4.0.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -17460,7 +17474,7 @@ packages:
     engines: {node: '>=18'}
     dependencies:
       gaxios: 7.1.1
-      jws: 4.0.0
+      jws: 4.0.1
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -17555,6 +17569,12 @@ packages:
 
   /hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
+    engines: {node: '>= 0.4'}
+    dependencies:
+      function-bind: 1.1.2
+
+  /hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
     engines: {node: '>= 0.4'}
     dependencies:
       function-bind: 1.1.2
@@ -18110,7 +18130,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       side-channel: 1.1.0
 
   /internal-slot@1.1.0:
@@ -18118,7 +18138,7 @@ packages:
     engines: {node: '>= 0.4'}
     dependencies:
       es-errors: 1.3.0
-      hasown: 2.0.2
+      hasown: 2.0.4
       side-channel: 1.1.0
     dev: true
 
@@ -18482,7 +18502,7 @@ packages:
       call-bound: 1.0.4
       gopd: 1.2.0
       has-tostringtag: 1.0.2
-      hasown: 2.0.2
+      hasown: 2.0.4
     dev: true
 
   /is-retry-allowed@2.2.0:
@@ -19731,20 +19751,8 @@ packages:
     engines: {node: '>=14'}
     dev: false
 
-  /js-tiktoken@1.0.10:
-    resolution: {integrity: sha512-ZoSxbGjvGyMT13x6ACo9ebhDha/0FHdKA+OsQcMOWcm1Zs7r90Rhk5lhERLzji+3rA7EKpXCgwXcM5fF3DMpdA==}
-    dependencies:
-      base64-js: 1.5.1
-    dev: false
-
   /js-tiktoken@1.0.14:
     resolution: {integrity: sha512-Pk3l3WOgM9joguZY2k52+jH82RtABRgB5RdGFZNUGbOKGMVlNmafcPA3b0ITcCZPu1L9UclP1tne6aw7ZI4Myg==}
-    dependencies:
-      base64-js: 1.5.1
-    dev: false
-
-  /js-tiktoken@1.0.7:
-    resolution: {integrity: sha512-biba8u/clw7iesNEWLOLwrNGoBP2lA+hTaBLs/D45pJdUPFXyxD6nhcDVtADChghv4GgyAiMKYMiRx7x6h7Biw==}
     dependencies:
       base64-js: 1.5.1
     dev: false
@@ -19789,7 +19797,7 @@ packages:
       decimal.js: 10.4.3
       domexception: 4.0.0
       escodegen: 2.1.0
-      form-data: 4.0.4
+      form-data: 4.0.6
       html-encoding-sniffer: 3.0.0
       http-proxy-agent: 5.0.0
       https-proxy-agent: 5.0.1
@@ -19960,6 +19968,14 @@ packages:
       ecdsa-sig-formatter: 1.0.11
       safe-buffer: 5.2.1
 
+  /jwa@2.0.1:
+    resolution: {integrity: sha512-hRF04fqJIP8Abbkq5NKGN0Bbr3JxlQ+qhZufXVr0DvujKy93ZCbXZMHDL4EOtodSbCWxOqR8MS1tXA5hwqCXDg==}
+    dependencies:
+      buffer-equal-constant-time: 1.0.1
+      ecdsa-sig-formatter: 1.0.11
+      safe-buffer: 5.2.1
+    dev: false
+
   /jws@3.2.2:
     resolution: {integrity: sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==}
     dependencies:
@@ -19972,6 +19988,13 @@ packages:
     dependencies:
       jwa: 2.0.0
       safe-buffer: 5.2.1
+
+  /jws@4.0.1:
+    resolution: {integrity: sha512-EKI/M/yqPncGUUh44xz0PxSidXFr/+r0pA70+gIYhjv+et7yxM+s29Y+VGDkovRofQem0fs7Uvf4+YmAdyRduA==}
+    dependencies:
+      jwa: 2.0.1
+      safe-buffer: 5.2.1
+    dev: false
 
   /keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
@@ -20295,7 +20318,7 @@ packages:
       '@google-cloud/storage': 7.7.0
       '@upstash/redis': 1.22.0
       ansi-styles: 5.2.0
-      binary-extensions: 2.2.0
+      binary-extensions: 2.3.0
       camelcase: 6.3.0
       decamelize: 1.2.0
       expr-eval: 2.0.2
@@ -20313,7 +20336,7 @@ packages:
       p-queue: 6.6.2
       p-retry: 4.6.2
       uuid: 9.0.1
-      yaml: 2.4.1
+      yaml: 2.8.1
       zod: 3.25.76
       zod-to-json-schema: 3.25.2(zod@3.25.76)
     transitivePeerDependencies:
@@ -20326,6 +20349,7 @@ packages:
 
   /langsmith@0.0.48:
     resolution: {integrity: sha512-s0hW8iZ90Q9XLTnDK0Pgee245URV3b1cXQjPDj5OKm1+KN7iSK1pKx+4CO7RcFLz58Ixe7Mt+mVcomYqUuryxQ==}
+    hasBin: true
     dependencies:
       '@types/uuid': 9.0.3
       commander: 10.0.1
@@ -20425,7 +20449,7 @@ packages:
     dependencies:
       cli-truncate: 5.1.0
       colorette: 2.0.20
-      eventemitter3: 5.0.1
+      eventemitter3: 5.0.4
       log-update: 6.1.0
       rfdc: 1.4.1
       wrap-ansi: 9.0.0
@@ -22095,7 +22119,7 @@ packages:
       zod:
         optional: true
     dependencies:
-      '@types/node': 18.19.75
+      '@types/node': 18.19.80
       '@types/node-fetch': 2.6.4
       abort-controller: 3.0.0
       agentkeepalive: 4.5.0
@@ -22105,29 +22129,6 @@ packages:
       zod: 3.25.76
     transitivePeerDependencies:
       - encoding
-
-  /openai@6.45.0(zod@3.25.76):
-    resolution: {integrity: sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==}
-    peerDependencies:
-      '@aws-sdk/credential-provider-node': '>=3.972.0 <4'
-      '@smithy/hash-node': '>=4.3.0 <5'
-      '@smithy/signature-v4': '>=5.4.0 <6'
-      ws: ^8.18.0
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      '@aws-sdk/credential-provider-node':
-        optional: true
-      '@smithy/hash-node':
-        optional: true
-      '@smithy/signature-v4':
-        optional: true
-      ws:
-        optional: true
-      zod:
-        optional: true
-    dependencies:
-      zod: 3.25.76
-    dev: false
 
   /openai@6.45.0(zod@4.4.3):
     resolution: {integrity: sha512-5DQVNErssk0afNpTTHUm/qZPU4iKR9OYdNid8Ib4puq4gHNNvGWZht2zY4h9a8JMF949Ik6m8gQutllVPbjdnw==}
@@ -22363,7 +22364,7 @@ packages:
     resolution: {integrity: sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==}
     engines: {node: '>=18'}
     dependencies:
-      eventemitter3: 5.0.1
+      eventemitter3: 5.0.4
       p-timeout: 6.1.4
     dev: true
 
@@ -27417,17 +27418,10 @@ packages:
     hasBin: true
     dev: false
 
-  /yaml@2.7.0:
-    resolution: {integrity: sha512-+hSoy/QHluxmC9kCIJyL/uyFmLmc+e5CFR5Wa+bpIhIj85LVb9ZH2nVnqrHoSvKogwODv0ClqZkmiSSaIH5LTA==}
-    engines: {node: '>= 14'}
-    hasBin: true
-    dev: true
-
   /yaml@2.8.1:
     resolution: {integrity: sha512-lcYcMxX2PO9XMGvAJkJ3OsNMw+/7FKes7/hgerGUYWIoWu5j/+YQqcZr5JnPZWzOsEBgMbSbiSTn/dv/69Mkpw==}
     engines: {node: '>= 14.6'}
     hasBin: true
-    dev: true
 
   /yargs-parser@20.2.9:
     resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
@@ -27495,7 +27489,7 @@ packages:
       readable-stream: 4.4.2
     dev: false
 
-  /zod-prisma@0.5.4(prisma@6.3.1)(zod@3.25.76):
+  /zod-prisma@0.5.4(prisma@6.3.1)(zod@4.4.3):
     resolution: {integrity: sha512-5Ca4Qd1a1jy1T/NqCEpbr0c+EsbjJfJ/7euEHob3zDvtUK2rTuD1Rc/vfzH8q8PtaR2TZbysD88NHmrLwpv3Xg==}
     engines: {node: '>=14'}
     hasBin: true
@@ -27511,7 +27505,7 @@ packages:
       parenthesis: 3.1.8
       prisma: 6.3.1(typescript@5.9.2)
       ts-morph: 13.0.3
-      zod: 3.25.76
+      zod: 4.4.3
     dev: true
 
   /zod-to-camel-case@0.5.0(zod@4.4.3):


### PR DESCRIPTION
This pull request updates the `zod` validation library to version 4 and standardizes all imports to use the `zod/v3` entry point throughout the `apps/nextjs` codebase. Additionally, it updates related dependencies and schemas to ensure compatibility with the new version.

**Dependency updates:**

* Updated `zod` to version `^4.4.3` and `zod-to-json-schema` to `^3.25.2` in `package.json`.
* Updated `@oaknational/oak-curriculum-schema` to `2.15.0` in `package.json`.

**Codebase-wide import changes:**

* Replaced all imports of `zod` with imports from `zod/v3` in all TypeScript and JavaScript files, including type imports such as `ZodError`, `ZodIssue`, and `ZodSchema`. [[1]](diffhunk://#diff-83a05a6630eabbf78337b504c0f07a6fd886d949ca890c78b2ab5e812c00a57dL4-R4) [[2]](diffhunk://#diff-c8b029261a1c0e5579985f1bf2a9112987d419ae531bdd00a8e3e3b369ac6091L7-R7) [[3]](diffhunk://#diff-a8e5f5984c0a65567a52a9971433636a012868576b16c6cdb1eb24d062e2d77dL32-R32) [[4]](diffhunk://#diff-b03464b0df43217180051f12232a9c124efff0482e4dc656ca47d94e34526b37L7-R7) [[5]](diffhunk://#diff-0560f499d18557a90d888e5eef0a8036a8fb0603e25d1dd1d48fa6d982ab117fL9-R9) [[6]](diffhunk://#diff-89268108a6b72c99b795477de7f0b54694b9c929bef3850e0943f9ef251dd218L10-R10) [[7]](diffhunk://#diff-0e0092df176a93dcc96a2bff0245b9d81b64add8984e114ab4d0b30b4dabbeceL8-R8) [[8]](diffhunk://#diff-d1d2a25e1820f2afe219133822d9ecbb854a0cd0c02d8bbc21a27dd4bdba7365L10-R10) [[9]](diffhunk://#diff-a3c9997491b855dc0e66a4c70cbae0297bffec0fa591f6d854b825262564c66dL8-R8) [[10]](diffhunk://#diff-8cb2da8e91582a93dd711d5d55817a541a48da6aca545b56e120eb45343d9a52L8-R8) [[11]](diffhunk://#diff-dd370f144dc356ca68c7c8da9af90650d11fcfa8ab9a9c0e80071d6d37806141L11-R11) [[12]](diffhunk://#diff-5005cb0054666dcdcb03cf5c652f6e09d95ac9dbcb4fa6630c3e203178802352L8-R8) [[13]](diffhunk://#diff-f9af0df61ed17b9719323675fde2428270dcb82b9c09844562f8125fb7341b88L2-R2) [[14]](diffhunk://#diff-66b8e10e578721a76a6262323c6086414ca723c64af94d059b44dcbe2b64acffL1-R1) [[15]](diffhunk://#diff-518c47ca416fc49940f71ad179cdb734529f5c8455a4e9ebfcfc10456a56aba5L4-R4) [[16]](diffhunk://#diff-c272b53f81edad32a74abb48ee1e6d544b6ca21ef58de7e085d1139d404a3df9L5-R5) [[17]](diffhunk://#diff-75bc7e4a85a4c6d533fdd75e03942e2b0b30233ed8e3a4704697dc5d15a2dd97L9-R9) [[18]](diffhunk://#diff-68d6fe86d5fe9042635799b93b384a347a8cd207fc0e77218cca79239bb995f1L6-R6) [[19]](diffhunk://#diff-e56ea67c2c99142c59353cf5350e5d1e2dc733d9af968073467db7f07e5c9843L1-R1)

These changes ensure consistency and compatibility with the latest version of `zod` across the project.## Description



## How to test

1. Go to <!-- vercel-preview -->https://oak-ai-lesson-assistant-website-qwi59jdla.vercel.thenational.academy<!-- /vercel-preview -->

Full app test 


## Checklist

- [ ] Manually tested across browsers / devices
- [ ] Considered impact on accessibility
- [ ] Does this PR update a package with a breaking change
