### PR TITLE
fix: prevent automatic preload on homepage videos

### DIFF
--- a/apps/nextjs/src/app/home-page.tsx
+++ b/apps/nextjs/src/app/home-page.tsx
@@ -34,10 +34,7 @@ import type { HomePageQueryResult } from "@/cms/types/aiHomePageType";
 import HeroContainer from "@/components/HeroContainer";
 import { HomePageCTA } from "@/components/Home/HomePageCTA";
 import Layout from "@/components/Layout";
-import {
-  OakBoxCustomMaxWidth,
-  OakFlexCustomMaxWidth,
-} from "@/components/OakBoxCustomMaxWidth";
+import { OakFlexCustomMaxWidth } from "@/components/OakBoxCustomMaxWidth";
 import useAnalytics from "@/lib/analytics/useAnalytics";
 import { getAilaUrl } from "@/utils/getAilaUrl";
 
@@ -147,7 +144,10 @@ function truncateLabel(label: string, maxLength = 15): string {
   return label.length > maxLength ? `${label.slice(0, maxLength)}…` : label;
 }
 
-const StyledMuxPlayer = styled(MuxPlayer)`
+// preload="none" keeps the player from fetching the manifest or any segments
+// until a visitor presses play. This also prevents reporting aborted preload
+// fetches to Mux as fatal MEDIA_ERR_NETWORK on every page load.
+const StyledMuxPlayer = styled(MuxPlayer).attrs({ preload: "none" })`
   aspect-ratio: 16/9;
   width: 100%;
 `;
@@ -317,38 +317,26 @@ function HomePageHero({ pageData }: HomePageProps) {
             Create tailored lessons and resources with AI
           </OakHeading>
 
-          <OakFlex $flexDirection={"column-reverse"}>
-            <OakBoxCustomMaxWidth
-              $display={["flex", "none"]}
-              $borderColor="border-primary"
-              $borderStyle={"solid"}
-              $ba={"border-solid-xl"}
-              customMaxWidth={629}
-              $height="fit-content"
+          <OakBox $mb={["spacing-12", "spacing-0"]}>
+            <OakP
+              $mb={["spacing-0", "spacing-48"]}
+              $textAlign="left"
+              $font="body-1"
             >
-              <StyledMuxPlayer
-                playbackId={pageData?.heroVideo.video.asset.playbackId}
-                thumbnailTime={pageData?.heroVideo.video.asset.thumbTime}
-              />
-            </OakBoxCustomMaxWidth>
-            <OakBox $mb={["spacing-32", "spacing-0"]}>
-              <OakP
-                $mb={["spacing-0", "spacing-48"]}
-                $textAlign="left"
-                $font="body-1"
-              >
-                Try Aila, Oak&apos;s AI lesson assistant, built for teachers.
-                Create and adapt lessons and resources that draw on Oak&apos;s
-                national curriculum-aligned content, with you in control every
-                step of the way.
-              </OakP>
-              <HomePageCTA />
-            </OakBox>
-          </OakFlex>
+              Try Aila, Oak&apos;s AI lesson assistant, built for teachers.
+              Create and adapt lessons and resources that draw on Oak&apos;s
+              national curriculum-aligned content, with you in control every
+              step of the way.
+            </OakP>
+            <HomePageCTA />
+          </OakBox>
         </OakFlexCustomMaxWidthWithHalfWidth>
 
+        {/* One player at every width. The parent flex switches from column to
+            row at the first breakpoint, which puts the video below the copy on
+            mobile and beside it on desktop. Rendering a second copy behind
+            `display: none` would still mount and start downloading. */}
         <OakFlexCustomMaxWidthWithHalfWidth
-          $display={["none", "flex"]}
           $borderColor="border-primary"
           $borderStyle={"solid"}
           $ba={"border-solid-xl"}


### PR DESCRIPTION
## Description

- Set `preload="none"` on all Mux players (via `.attrs` on the shared `StyledMuxPlayer`, so it applies to all three and any future ones)
- Render the hero player once instead of one copy per breakpoint: the mobile copy sat behind `display: none`, which still mounts and still downloads

Together these stop video being fetched for visitors and bots who never press play. Expect Mux views to roughly halve and the fatal error rate to drop from ~14.5% toward ~1%: both intended, not a regression.

## Issue(s)

Fixes #ADAPT-60

## How to test

1. Go to <!-- vercel-preview -->https://oak-ai-lesson-assistant-website-1c6uoe01c.vercel.thenational.academy<!-- /vercel-preview -->
2. Open Network tab, filter for `stream.mux`
3. You should see no activity until pressing play